### PR TITLE
fix(agent): make compaction runtime updates coherent

### DIFF
--- a/agent_docs/architecture.md
+++ b/agent_docs/architecture.md
@@ -553,3 +553,16 @@ turn goroutine starts. An overlapping submission receives an
 `ErrorEvent{Kind: "agent_busy"}` and does not append input, invoke a provider,
 or replace steering/cancellation state. Callers needing parallel turns must use
 separate `Agent` instances.
+
+## Runtime Compaction Configuration Updates
+
+`UpdateCompactionConfig` is non-blocking. If the current compaction runtime is in
+use, updates are coalesced and the latest replacement becomes a generation
+barrier: later top-level turns, manual/preflight compactions, and exported
+checkpoint commits wait rather than joining the superseded generation. Child
+work already launched by an active operation (notably asynchronous compaction)
+retains that operation's old generation and completes coherently. When the last
+old-generation use exits, the latest replacement is installed atomically,
+stale pending compaction output and old retry/cooldown state are discarded, and
+all waiters resume on the new runtime. A disabled replacement also clears the
+pending todo checkpoint signal.

--- a/sdk/agent/agent.go
+++ b/sdk/agent/agent.go
@@ -164,6 +164,15 @@ type Agent struct {
 
 	compactor *compaction.Service
 
+	// compactionRuntimeMu protects installation of compactor/hasCompactor.
+	// Complete operations hold a lifecycle use; a queued replacement is a
+	// barrier for later top-level operations while retained child work may
+	// finish against its parent's coherent generation.
+	compactionRuntimeMu      sync.Mutex
+	compactionRuntimeUses    int
+	pendingCompactionRuntime *compactionRuntimeUpdate
+	compactionRuntimeWaitCh  chan struct{}
+
 	todoCompactionPending  atomic.Bool
 	compactionRetryPending atomic.Bool
 	compactionInFlight     atomic.Bool
@@ -443,8 +452,11 @@ func (a *Agent) warnf(format string, args ...any) {
 	log.Printf(format, args...)
 }
 
-// UpdateCompactionConfig replaces the compaction service used for subsequent turns.
-// Callers should prefer updating compaction between turns when the agent is idle.
+// UpdateCompactionConfig replaces the compaction service used by future
+// operations. The call itself never blocks: while an old generation is in
+// use, updates are coalesced (latest wins). Later top-level operations wait
+// for that generation to drain, while child work already launched by an
+// active operation finishes against the same coherent service/configuration.
 func (a *Agent) UpdateCompactionConfig(cfg *compaction.Config) {
 	if a == nil {
 		return
@@ -454,14 +466,8 @@ func (a *Agent) UpdateCompactionConfig(cfg *compaction.Config) {
 	hasCompactor := compSvc != nil && compSvc.Config.Enabled
 	if !hasCompactor {
 		compSvc = nil
-		a.todoCompactionPending.Store(false)
-		a.compactionRetryPending.Store(false)
-		a.pendingCompactionMu.Lock()
-		a.pendingCompaction = nil
-		a.pendingCompactionMu.Unlock()
 	}
-	a.compactor = compSvc
-	a.hasCompactor = hasCompactor
+	a.installOrQueueCompactionRuntime(&compactionRuntimeUpdate{service: compSvc, enabled: hasCompactor})
 }
 
 func (a *Agent) Messages() []llm.Message {
@@ -534,13 +540,27 @@ func (a *Agent) QueryStreamWithSteering(ctx context.Context, input llm.Content, 
 		close(out)
 		return out
 	}
+	// Reserve synchronously when possible so an update made after this call
+	// cannot overtake an already admitted turn. A pending replacement is
+	// waited inside the goroutine so QueryStream remains non-blocking.
+	runtimeRelease, runtimeAcquired := a.tryBeginCompactionRuntimeUse()
 	unregisterTurn := a.registerTurnCancellation(out, ctx)
-	go func() {
-		// Later defers execute first. By the time admission is released, all turn
-		// cleanup and cancellation bookkeeping have completed.
+	go func(releaseCompactionRuntime func(), acquired bool) {
+		// Later defers execute first. Runtime release happens before admission
+		// is reopened and before channel close, so the next accepted operation
+		// observes any queued replacement.
 		defer close(out)
 		defer a.turnActive.Store(false)
 		defer unregisterTurn()
+		if !acquired {
+			var err error
+			releaseCompactionRuntime, err = a.beginCompactionRuntimeUse(ctx)
+			if err != nil {
+				a.emitEvent(out, a.errEvent(err))
+				return
+			}
+		}
+		defer releaseCompactionRuntime()
 		a.cleanupToolResultDumps(toolResultDumpNow(), false)
 
 		if a.compactionInFlight.Load() {
@@ -1370,7 +1390,7 @@ func (a *Agent) QueryStreamWithSteering(ctx context.Context, input llm.Content, 
 		msg := fmt.Sprintf("Max iterations reached (%d)", a.maxIterations)
 		emitErr(ErrorEvent{Provider: a.llm.Provider(), Message: msg, Kind: "max_iterations"})
 		emitFinal(fmt.Sprintf("[Max iterations reached] %d", a.maxIterations), lastResponseID)
-	}()
+	}(runtimeRelease, runtimeAcquired)
 	return out
 }
 
@@ -2963,7 +2983,13 @@ func (a *Agent) checkAndCompactWithGrowth(ctx context.Context, last *llm.Complet
 	a.mu.Unlock()
 	snapshotLen := len(messages)
 	triggerUsage := cloneUsage(last.Usage)
-	go a.runCompactionAsync(ctx, messages, snapshotLen, decisionUsage, triggerUsage, trigger, watermark)
+	// Retain synchronously before launch; otherwise the parent could release
+	// and install a queued replacement before the child reads the service.
+	releaseCompactionRuntime := a.retainCompactionRuntimeUse()
+	go func() {
+		defer releaseCompactionRuntime()
+		a.runCompactionAsync(ctx, messages, snapshotLen, decisionUsage, triggerUsage, trigger, watermark)
+	}()
 	return nil
 }
 
@@ -3868,6 +3894,11 @@ func (a *Agent) CompactNow(ctx context.Context) (compaction.Result, error) {
 // Hosts use this for preflight so they do not duplicate local-versus-summary
 // decisions outside the SDK.
 func (a *Agent) CompactPipelineNow(ctx context.Context, req compaction.PipelineRequest) (compaction.Result, error) {
+	releaseCompactionRuntime, err := a.beginCompactionRuntimeUse(ctx)
+	if err != nil {
+		return compaction.Result{Compacted: false}, err
+	}
+	defer releaseCompactionRuntime()
 	if !a.hasCompactor || a.compactor == nil {
 		return compaction.Result{Compacted: false}, nil
 	}
@@ -3891,7 +3922,7 @@ func (a *Agent) CompactPipelineNow(ctx context.Context, req compaction.PipelineR
 	newMsgs = a.withPreservedSystem(orig, newMsgs)
 	if res.Compacted {
 		res = a.reconcileCompactionTelemetry(res, orig, newMsgs, req.AdditionalTokens)
-		res, err = a.CommitCompactionCheckpoint(ctx, newMsgs, res)
+		res, err = a.commitCompactionCheckpoint(ctx, newMsgs, res)
 		if err != nil {
 			return res, err
 		}
@@ -3964,6 +3995,15 @@ func (a *Agent) persistCompactionCheckpoint(ctx context.Context, messages []llm.
 // callers replace in-memory history. A persistence failure is fail-closed: the
 // returned result is not reported as compacted and the caller keeps old state.
 func (a *Agent) CommitCompactionCheckpoint(ctx context.Context, messages []llm.Message, res compaction.Result) (compaction.Result, error) {
+	releaseCompactionRuntime, err := a.beginCompactionRuntimeUse(ctx)
+	if err != nil {
+		return res, err
+	}
+	defer releaseCompactionRuntime()
+	return a.commitCompactionCheckpoint(ctx, messages, res)
+}
+
+func (a *Agent) commitCompactionCheckpoint(ctx context.Context, messages []llm.Message, res compaction.Result) (compaction.Result, error) {
 	commit, err := a.persistCompactionCheckpoint(ctx, messages, res)
 	if err != nil {
 		return commit.result, err

--- a/sdk/agent/agent_compaction_update_race_test.go
+++ b/sdk/agent/agent_compaction_update_race_test.go
@@ -1,0 +1,356 @@
+package agent
+
+import (
+	"context"
+	"errors"
+	"runtime"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/timwhitez/agent-sdk-golang/sdk/agent/compaction"
+	"github.com/timwhitez/agent-sdk-golang/sdk/llm"
+)
+
+type blockingCompactionUpdateModel struct {
+	started chan struct{}
+	release chan struct{}
+	once    sync.Once
+	calls   atomic.Int32
+}
+
+func (m *blockingCompactionUpdateModel) Provider() string { return "stub" }
+func (m *blockingCompactionUpdateModel) Model() string    { return "stub" }
+func (m *blockingCompactionUpdateModel) Invoke(ctx context.Context, _ llm.InvokeRequest) (*llm.Completion, error) {
+	m.calls.Add(1)
+	m.once.Do(func() { close(m.started) })
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	case <-m.release:
+		return &llm.Completion{Content: llm.TextContent("ok")}, nil
+	}
+}
+
+func drainCompactionUpdateTurn(t *testing.T, events <-chan Event) {
+	t.Helper()
+	timeout := time.NewTimer(10 * time.Second)
+	defer timeout.Stop()
+	for {
+		select {
+		case _, ok := <-events:
+			if !ok {
+				return
+			}
+		case <-timeout.C:
+			t.Fatal("timed out waiting for turn to finish")
+		}
+	}
+}
+
+func newCompactionUpdateAgent(t *testing.T, model llm.ChatModel, window int) *Agent {
+	t.Helper()
+	ag, err := New(Config{
+		LLM: model,
+		Compaction: &compaction.Config{
+			Enabled:       true,
+			ContextWindow: window,
+		},
+	})
+	if err != nil {
+		t.Fatalf("new agent: %v", err)
+	}
+	return ag
+}
+
+func compactionRuntimeWindow(a *Agent) int {
+	if a == nil || !a.hasCompactor || a.compactor == nil {
+		return 0
+	}
+	return a.compactor.ContextWindow
+}
+
+func TestUpdateCompactionConfigDefersAlternatingUpdatesUntilActiveTurnCompletes(t *testing.T) {
+	model := &blockingCompactionUpdateModel{
+		started: make(chan struct{}),
+		release: make(chan struct{}),
+	}
+	ag := newCompactionUpdateAgent(t, model, 1000)
+
+	events := ag.QueryStream(context.Background(), llm.TextContent("hold"))
+	select {
+	case <-model.started:
+	case <-time.After(10 * time.Second):
+		t.Fatal("provider invocation did not start")
+	}
+
+	const updates = 500
+	const finalWindow = 2000 + updates - 1
+	firstDisableQueued := make(chan struct{})
+	continueUpdates := make(chan struct{})
+	updatesDone := make(chan struct{})
+	go func() {
+		defer close(updatesDone)
+		ag.UpdateCompactionConfig(&compaction.Config{Enabled: false})
+		close(firstDisableQueued)
+		<-continueUpdates
+		for i := 0; i < updates; i++ {
+			ag.UpdateCompactionConfig(&compaction.Config{Enabled: false})
+			ag.UpdateCompactionConfig(&compaction.Config{
+				Enabled:       true,
+				ContextWindow: 2000 + i,
+			})
+			runtime.Gosched()
+		}
+	}()
+
+	<-firstDisableQueued
+	activeRuntimeStable := true
+	observedEnabled := ag.hasCompactor
+	observedService := ag.compactor
+	observedWindow := compactionRuntimeWindow(ag)
+	if !observedEnabled || observedService == nil || observedWindow != 1000 {
+		activeRuntimeStable = false
+	}
+
+	close(continueUpdates)
+	for activeRuntimeStable {
+		select {
+		case <-updatesDone:
+			goto updatesFinished
+		default:
+			observedEnabled = ag.hasCompactor
+			observedService = ag.compactor
+			observedWindow = compactionRuntimeWindow(ag)
+			if !observedEnabled || observedService == nil || observedWindow != 1000 {
+				activeRuntimeStable = false
+				break
+			}
+			runtime.Gosched()
+		}
+	}
+	<-updatesDone
+
+updatesFinished:
+	close(model.release)
+	drainCompactionUpdateTurn(t, events)
+
+	if !activeRuntimeStable {
+		t.Fatalf("active turn observed replacement runtime: enabled=%v service=%#v window=%d", observedEnabled, observedService, observedWindow)
+	}
+	if got := compactionRuntimeWindow(ag); got != finalWindow {
+		t.Fatalf("installed context window = %d, want %d", got, finalWindow)
+	}
+	if got := model.calls.Load(); got != 1 {
+		t.Fatalf("provider calls = %d, want 1", got)
+	}
+}
+
+func TestCompactionRuntimeUpdateBlocksLaterTopLevelUse(t *testing.T) {
+	ag := newCompactionUpdateAgent(t, noopCompactionUpdateModel{}, 1000)
+	releaseOld, acquired := ag.tryBeginCompactionRuntimeUse()
+	if !acquired {
+		t.Fatal("initial runtime acquisition unexpectedly blocked")
+	}
+	ag.UpdateCompactionConfig(&compaction.Config{Enabled: true, ContextWindow: 2000})
+
+	type result struct {
+		release func()
+		window  int
+		err     error
+	}
+	resultCh := make(chan result, 1)
+	go func() {
+		release, err := ag.beginCompactionRuntimeUse(context.Background())
+		if err != nil {
+			resultCh <- result{err: err}
+			return
+		}
+		resultCh <- result{release: release, window: compactionRuntimeWindow(ag)}
+	}()
+
+	select {
+	case got := <-resultCh:
+		if got.release != nil {
+			got.release()
+		}
+		t.Fatalf("later operation joined superseded runtime: window=%d err=%v", got.window, got.err)
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	releaseOld()
+	select {
+	case got := <-resultCh:
+		if got.err != nil {
+			t.Fatalf("later operation failed: %v", got.err)
+		}
+		defer got.release()
+		if got.window != 2000 {
+			t.Fatalf("later operation observed window %d, want 2000", got.window)
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("later operation did not resume after replacement")
+	}
+}
+
+func TestRetainedChildKeepsParentGenerationWhileLaterOperationWaits(t *testing.T) {
+	ag := newCompactionUpdateAgent(t, noopCompactionUpdateModel{}, 1000)
+	releaseParent, acquired := ag.tryBeginCompactionRuntimeUse()
+	if !acquired {
+		t.Fatal("initial runtime acquisition unexpectedly blocked")
+	}
+	releaseChild := ag.retainCompactionRuntimeUse()
+	ag.UpdateCompactionConfig(&compaction.Config{Enabled: true, ContextWindow: 2000})
+	releaseParent()
+
+	if got := compactionRuntimeWindow(ag); got != 1000 {
+		t.Fatalf("retained child observed window %d, want old window 1000", got)
+	}
+
+	resumed := make(chan int, 1)
+	go func() {
+		release, err := ag.beginCompactionRuntimeUse(context.Background())
+		if err != nil {
+			resumed <- -1
+			return
+		}
+		defer release()
+		resumed <- compactionRuntimeWindow(ag)
+	}()
+	select {
+	case got := <-resumed:
+		t.Fatalf("later operation resumed before retained child ended: window=%d", got)
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	releaseChild()
+	select {
+	case got := <-resumed:
+		if got != 2000 {
+			t.Fatalf("later operation observed window %d, want 2000", got)
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("later operation did not resume after retained child ended")
+	}
+}
+
+func TestCompactionRuntimeWaitHonorsContextCancellationWithoutLeakingUse(t *testing.T) {
+	ag := newCompactionUpdateAgent(t, noopCompactionUpdateModel{}, 1000)
+	releaseOld, acquired := ag.tryBeginCompactionRuntimeUse()
+	if !acquired {
+		t.Fatal("initial runtime acquisition unexpectedly blocked")
+	}
+	ag.UpdateCompactionConfig(&compaction.Config{Enabled: true, ContextWindow: 2000})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if release, err := ag.beginCompactionRuntimeUse(ctx); !errors.Is(err, context.Canceled) {
+		if release != nil {
+			release()
+		}
+		t.Fatalf("wait error = %v, want context.Canceled", err)
+	}
+	releaseOld()
+
+	releaseNew, err := ag.beginCompactionRuntimeUse(context.Background())
+	if err != nil {
+		t.Fatalf("acquire after canceled waiter: %v", err)
+	}
+	defer releaseNew()
+	if got := compactionRuntimeWindow(ag); got != 2000 {
+		t.Fatalf("runtime after canceled waiter = %d, want 2000", got)
+	}
+}
+
+func TestCompactionRuntimeQueuedUpdatesAreLatestWins(t *testing.T) {
+	ag := newCompactionUpdateAgent(t, noopCompactionUpdateModel{}, 1000)
+	releaseOld, acquired := ag.tryBeginCompactionRuntimeUse()
+	if !acquired {
+		t.Fatal("initial runtime acquisition unexpectedly blocked")
+	}
+	ag.UpdateCompactionConfig(&compaction.Config{Enabled: true, ContextWindow: 2000})
+	ag.UpdateCompactionConfig(&compaction.Config{Enabled: false})
+	ag.UpdateCompactionConfig(&compaction.Config{Enabled: true, ContextWindow: 3000})
+	releaseOld()
+
+	releaseNew, err := ag.beginCompactionRuntimeUse(context.Background())
+	if err != nil {
+		t.Fatalf("acquire latest runtime: %v", err)
+	}
+	defer releaseNew()
+	if got := compactionRuntimeWindow(ag); got != 3000 {
+		t.Fatalf("latest queued runtime window = %d, want 3000", got)
+	}
+}
+
+func TestBusyTurnRejectionDoesNotAcquireCompactionRuntime(t *testing.T) {
+	model := &blockingCompactionUpdateModel{
+		started: make(chan struct{}),
+		release: make(chan struct{}),
+	}
+	ag := newCompactionUpdateAgent(t, model, 1000)
+	first := ag.QueryStream(context.Background(), llm.TextContent("first"))
+	select {
+	case <-model.started:
+	case <-time.After(10 * time.Second):
+		t.Fatal("first provider invocation did not start")
+	}
+
+	ag.compactionRuntimeMu.Lock()
+	usesBefore := ag.compactionRuntimeUses
+	ag.compactionRuntimeMu.Unlock()
+	second := ag.QueryStream(context.Background(), llm.TextContent("second"))
+	drainCompactionUpdateTurn(t, second)
+	ag.compactionRuntimeMu.Lock()
+	usesAfter := ag.compactionRuntimeUses
+	ag.compactionRuntimeMu.Unlock()
+	if usesAfter != usesBefore {
+		t.Fatalf("busy rejection changed runtime uses from %d to %d", usesBefore, usesAfter)
+	}
+
+	close(model.release)
+	drainCompactionUpdateTurn(t, first)
+	if got := model.calls.Load(); got != 1 {
+		t.Fatalf("provider calls = %d, want 1", got)
+	}
+}
+
+func TestRuntimeReplacementInvalidatesSupersededState(t *testing.T) {
+	ag := newCompactionUpdateAgent(t, noopCompactionUpdateModel{}, 1000)
+	ag.todoCompactionPending.Store(true)
+	ag.compactionRetryPending.Store(true)
+	ag.compactionFailureStreak.Store(3)
+	ag.compactionCooldownUntil.Store(time.Now().Add(time.Hour).UnixNano())
+	ag.pendingCompactionMu.Lock()
+	ag.pendingCompaction = &pendingCompaction{}
+	ag.pendingCompactionMu.Unlock()
+
+	ag.UpdateCompactionConfig(&compaction.Config{Enabled: true, ContextWindow: 2000})
+	if ag.compactionRetryPending.Load() {
+		t.Fatal("replacement inherited retry state from superseded compactor")
+	}
+	if got := ag.compactionFailureStreak.Load(); got != 0 {
+		t.Fatalf("replacement inherited failure streak %d", got)
+	}
+	if got := ag.compactionCooldownUntil.Load(); got != 0 {
+		t.Fatalf("replacement inherited cooldown %d", got)
+	}
+	if !ag.todoCompactionPending.Load() {
+		t.Fatal("enabled replacement unexpectedly discarded independent todo checkpoint signal")
+	}
+	ag.pendingCompactionMu.Lock()
+	pending := ag.pendingCompaction
+	ag.pendingCompactionMu.Unlock()
+	if pending != nil {
+		t.Fatal("replacement retained a result produced by the superseded compactor")
+	}
+
+	ag.UpdateCompactionConfig(&compaction.Config{Enabled: false})
+	if ag.todoCompactionPending.Load() {
+		t.Fatal("disabled replacement retained todo checkpoint signal")
+	}
+	if ag.hasCompactor || ag.compactor != nil {
+		t.Fatalf("disabled replacement not installed: enabled=%v service=%#v", ag.hasCompactor, ag.compactor)
+	}
+}

--- a/sdk/agent/compaction_runtime.go
+++ b/sdk/agent/compaction_runtime.go
@@ -1,0 +1,185 @@
+package agent
+
+import (
+	"context"
+	"sync"
+
+	"github.com/timwhitez/agent-sdk-golang/sdk/agent/compaction"
+)
+
+type compactionRuntimeUpdate struct {
+	service *compaction.Service
+	enabled bool
+}
+
+// tryBeginCompactionRuntimeUse synchronously reserves the currently installed
+// runtime when no replacement barrier is pending. QueryStream uses this before
+// returning so an update made after query submission cannot overtake an already
+// admitted turn. A false result means the caller must wait asynchronously with
+// beginCompactionRuntimeUse instead of joining the superseded generation.
+func (a *Agent) tryBeginCompactionRuntimeUse() (func(), bool) {
+	if a == nil {
+		return func() {}, true
+	}
+	a.compactionRuntimeMu.Lock()
+	acquired := a.beginCompactionRuntimeUseLocked(false)
+	a.compactionRuntimeMu.Unlock()
+	if !acquired {
+		return nil, false
+	}
+	return a.newCompactionRuntimeRelease(), true
+}
+
+// beginCompactionRuntimeUse starts a top-level operation. Once an update is
+// queued, new top-level operations wait for the old generation to drain and
+// then observe the latest replacement. This prevents a continuous stream of
+// later operations from extending the superseded generation indefinitely.
+func (a *Agent) beginCompactionRuntimeUse(ctx context.Context) (func(), error) {
+	if a == nil {
+		return func() {}, nil
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	for {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+
+		a.compactionRuntimeMu.Lock()
+		if a.beginCompactionRuntimeUseLocked(false) {
+			a.compactionRuntimeMu.Unlock()
+			return a.newCompactionRuntimeRelease(), nil
+		}
+		wait := a.compactionRuntimeWaitCh
+		if wait == nil {
+			wait = make(chan struct{})
+			a.compactionRuntimeWaitCh = wait
+		}
+		a.compactionRuntimeMu.Unlock()
+
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-wait:
+		}
+	}
+}
+
+// retainCompactionRuntimeUse extends the generation already owned by a parent
+// operation. It is intentionally allowed to join a superseded generation: an
+// asynchronously launched compaction is part of the turn that created it and
+// must finish against the same service/configuration. Call this synchronously
+// before launching the child goroutine.
+func (a *Agent) retainCompactionRuntimeUse() func() {
+	if a == nil {
+		return func() {}
+	}
+	a.compactionRuntimeMu.Lock()
+	_ = a.beginCompactionRuntimeUseLocked(true)
+	a.compactionRuntimeMu.Unlock()
+	return a.newCompactionRuntimeRelease()
+}
+
+// beginCompactionRuntimeUseLocked acquires one lifecycle use. Top-level callers
+// pass joinSuperseded=false and stop at a queued-update barrier. Retained child
+// work passes true so it can extend its parent's coherent generation.
+func (a *Agent) beginCompactionRuntimeUseLocked(joinSuperseded bool) bool {
+	if a.compactionRuntimeUses == 0 && a.pendingCompactionRuntime != nil {
+		update := a.pendingCompactionRuntime
+		a.pendingCompactionRuntime = nil
+		a.applyCompactionRuntimeUpdateLocked(update)
+		a.signalCompactionRuntimeWaitersLocked()
+	}
+	if !joinSuperseded && a.pendingCompactionRuntime != nil {
+		return false
+	}
+	a.compactionRuntimeUses++
+	return true
+}
+
+func (a *Agent) newCompactionRuntimeRelease() func() {
+	var once sync.Once
+	return func() {
+		once.Do(a.finishCompactionRuntimeUse)
+	}
+}
+
+func (a *Agent) finishCompactionRuntimeUse() {
+	if a == nil {
+		return
+	}
+	a.compactionRuntimeMu.Lock()
+	if a.compactionRuntimeUses <= 0 {
+		a.compactionRuntimeMu.Unlock()
+		a.warnf("warning: compaction runtime use released without a matching acquisition")
+		return
+	}
+	a.compactionRuntimeUses--
+	if a.compactionRuntimeUses == 0 && a.pendingCompactionRuntime != nil {
+		update := a.pendingCompactionRuntime
+		a.pendingCompactionRuntime = nil
+		a.applyCompactionRuntimeUpdateLocked(update)
+		a.signalCompactionRuntimeWaitersLocked()
+	}
+	a.compactionRuntimeMu.Unlock()
+}
+
+// installOrQueueCompactionRuntime never blocks the caller. In particular, an
+// UpdateCompactionConfig call made from a warning, estimator, checkpoint, or
+// other host callback cannot deadlock the operation that invoked that callback.
+// While the old generation is active, updates are coalesced and latest wins.
+func (a *Agent) installOrQueueCompactionRuntime(update *compactionRuntimeUpdate) {
+	if a == nil {
+		return
+	}
+	a.compactionRuntimeMu.Lock()
+	if a.compactionRuntimeUses > 0 {
+		a.pendingCompactionRuntime = update
+		if a.compactionRuntimeWaitCh == nil {
+			a.compactionRuntimeWaitCh = make(chan struct{})
+		}
+		a.compactionRuntimeMu.Unlock()
+		return
+	}
+	a.pendingCompactionRuntime = nil
+	a.applyCompactionRuntimeUpdateLocked(update)
+	a.signalCompactionRuntimeWaitersLocked()
+	a.compactionRuntimeMu.Unlock()
+}
+
+// applyCompactionRuntimeUpdateLocked publishes one coherent service/enabled
+// pair. The caller holds compactionRuntimeMu and there are no active lifecycle
+// users, so every direct compactor/hasCompactor read remains race-free. State
+// produced by the superseded service is invalidated rather than crossing the
+// generation boundary.
+func (a *Agent) applyCompactionRuntimeUpdateLocked(update *compactionRuntimeUpdate) {
+	a.pendingCompactionMu.Lock()
+	a.pendingCompaction = nil
+	a.pendingCompactionMu.Unlock()
+
+	if update == nil || !update.enabled || update.service == nil {
+		a.compactor = nil
+		a.hasCompactor = false
+	} else {
+		a.compactor = update.service
+		a.hasCompactor = true
+	}
+
+	// Retry/cooldown state describes failures of the superseded service. Carrying
+	// it into a replacement can incorrectly suppress the new configuration.
+	a.compactionRetryPending.Store(false)
+	a.compactionFailureStreak.Store(0)
+	a.compactionCooldownUntil.Store(0)
+	if !a.hasCompactor {
+		a.todoCompactionPending.Store(false)
+	}
+}
+
+func (a *Agent) signalCompactionRuntimeWaitersLocked() {
+	wait := a.compactionRuntimeWaitCh
+	a.compactionRuntimeWaitCh = nil
+	if wait != nil {
+		close(wait)
+	}
+}


### PR DESCRIPTION
## Summary

- replace independently mutable compaction fields with a generation-aware runtime lifecycle
- make queued updates a barrier for later top-level operations so they cannot join a superseded generation
- preserve coherent old-generation execution for child asynchronous compaction already launched by an active operation
- keep `UpdateCompactionConfig` non-blocking and coalesce queued replacements with latest-wins semantics
- integrate safely with single-turn admission and checkpoint persistence outside the history lock
- clear stale pending output, retry state, failure streak, and cooldown when a replacement becomes active
- add deterministic and race-focused regressions for generation barriers, cancellation, latest-wins, child retention, and busy rejection

## Rebuild and validation

The PR was rebuilt as one commit directly on current audited `main`:

- base: `c693605ac4b789a7f39502fff84f98943f37e50a`
- head: `4cb1d96bf8407bfc9e5ecae7f36234f6df83bebb`
- comparison: 1 commit ahead, 0 behind
- changed files: the two runtime source files, one focused regression file, and architecture documentation only

Validated with Go 1.24.5:

- [x] `gofmt` clean
- [x] `git diff --check`
- [x] `go mod verify`
- [x] `go vet ./...`
- [x] focused Agent tests repeated 20 times
- [x] focused Agent race tests repeated 10 times
- [x] `go test -count=1 ./...`
- [x] `go test -race -count=1 ./...`
- [x] `go build ./...`

Independent final review found no blocking correctness, race, lifecycle, or lock-order issues. No unresolved review threads remain.

Fixes #21