### PR TITLE
fix(sandbox): defer WebFetch DNS until user confirmation

### DIFF
--- a/.github/fixes/issue-4-test.py
+++ b/.github/fixes/issue-4-test.py
@@ -1,0 +1,140 @@
+from pathlib import Path
+
+Path("sdk/tools/sandbox/sandbox_webfetch_confirmation_test.go").write_text(r'''package sandbox
+
+import (
+	"context"
+	"net"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/timwhitez/agent-sdk-golang/sdk/tools"
+)
+
+type denyWebfetchConfirmer struct{ calls atomic.Int32 }
+
+func (c *denyWebfetchConfirmer) Confirm(context.Context, string, string) (bool, error) {
+	c.calls.Add(1)
+	return false, nil
+}
+
+func TestWebfetchDenialPerformsNoDNSOrDial(t *testing.T) {
+	originalLookup := webfetchLookupIPAddrs
+	originalDial := webfetchDialContext
+	t.Cleanup(func() {
+		webfetchLookupIPAddrs = originalLookup
+		webfetchDialContext = originalDial
+	})
+	var lookups atomic.Int32
+	webfetchLookupIPAddrs = func(context.Context, string) ([]net.IPAddr, error) {
+		lookups.Add(1)
+		return []net.IPAddr{{IP: net.ParseIP("8.8.8.8")}}, nil
+	}
+	var dials atomic.Int32
+	webfetchDialContext = func(context.Context, string, string) (net.Conn, error) {
+		dials.Add(1)
+		return nil, context.Canceled
+	}
+	confirmer := &denyWebfetchConfirmer{}
+	deps := tools.NewContainer()
+	tools.Provide(deps, ConfirmKey, func(context.Context) (Confirmer, error) {
+		return confirmer, nil
+	})
+
+	out, err := webfetchTool().Execute(context.Background(), `{"url":"https://denied.example/private"}`, deps)
+	if err == nil || !strings.Contains(strings.ToLower(err.Error()), "denied") {
+		t.Fatalf("denied webfetch error = %v, output=%q", err, out.PlainText())
+	}
+	if confirmer.calls.Load() != 1 {
+		t.Fatalf("confirmation calls = %d, want 1", confirmer.calls.Load())
+	}
+	if lookups.Load() != 0 {
+		t.Fatalf("DNS lookups before/after denial = %d, want 0", lookups.Load())
+	}
+	if dials.Load() != 0 {
+		t.Fatalf("socket dials before/after denial = %d, want 0", dials.Load())
+	}
+}
+
+func TestWebfetchBlockedLiteralIsRejectedWithoutPrompt(t *testing.T) {
+	confirmer := &denyWebfetchConfirmer{}
+	deps := tools.NewContainer()
+	tools.Provide(deps, ConfirmKey, func(context.Context) (Confirmer, error) {
+		return confirmer, nil
+	})
+	_, err := webfetchTool().Execute(context.Background(), `{"url":"http://127.0.0.1/"}`, deps)
+	if err == nil || !strings.Contains(strings.ToLower(err.Error()), "loopback") {
+		t.Fatalf("literal loopback error = %v", err)
+	}
+	if confirmer.calls.Load() != 0 {
+		t.Fatalf("blocked literal prompted %d time(s)", confirmer.calls.Load())
+	}
+}
+''')
+
+Path("sdk/tools/sandbox/sandbox_webfetch_rebinding_test.go").write_text(r'''package sandbox
+
+import (
+	"context"
+	"encoding/json"
+	"net"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/timwhitez/agent-sdk-golang/sdk/tools"
+)
+
+type allowWebfetchConfirmer struct{}
+
+func (allowWebfetchConfirmer) Confirm(context.Context, string, string) (bool, error) {
+	return true, nil
+}
+
+func TestWebfetchRejectsReboundAddressUsedForSocket(t *testing.T) {
+	originalLookup := webfetchLookupIPAddrs
+	originalDial := webfetchDialContext
+	t.Cleanup(func() {
+		webfetchLookupIPAddrs = originalLookup
+		webfetchDialContext = originalDial
+	})
+	var lookups atomic.Int32
+	// With confirmation-before-DNS, the first and only lookup is the one used
+	// for the actual socket. Returning loopback proves it is classified before
+	// the lower-level dial function is called.
+	webfetchLookupIPAddrs = func(context.Context, string) ([]net.IPAddr, error) {
+		lookups.Add(1)
+		return []net.IPAddr{{IP: net.ParseIP("127.0.0.1")}}, nil
+	}
+	var dials atomic.Int32
+	webfetchDialContext = func(context.Context, string, string) (net.Conn, error) {
+		dials.Add(1)
+		return nil, context.Canceled
+	}
+
+	deps := tools.NewContainer()
+	tools.Provide(deps, ConfirmKey, func(context.Context) (Confirmer, error) {
+		return allowWebfetchConfirmer{}, nil
+	})
+	out, err := webfetchTool().Execute(context.Background(), string(marshalWebfetchRebindingJSON(t, map[string]any{"url": "http://rebind.example/"})), deps)
+	if err == nil || !strings.Contains(strings.ToLower(err.Error()), "loopback") {
+		t.Fatalf("webfetch error = %v, output=%q; want socket-bound loopback denial", err, out.PlainText())
+	}
+	if lookups.Load() != 1 {
+		t.Fatalf("resolver calls = %d, want exactly the socket lookup", lookups.Load())
+	}
+	if dials.Load() != 0 {
+		t.Fatalf("socket dial attempted %d time(s) after denied address", dials.Load())
+	}
+}
+
+func marshalWebfetchRebindingJSON(t *testing.T, value any) []byte {
+	t.Helper()
+	data, err := json.Marshal(value)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return data
+}
+''')

--- a/.github/fixes/issue-4.py
+++ b/.github/fixes/issue-4.py
@@ -1,0 +1,121 @@
+from pathlib import Path
+
+path = Path("sdk/tools/sandbox/sandbox_webfetch.go")
+text = path.read_text()
+old = '''\t\tif err := validateWebfetchDestinationURL(ctx, u, "request target"); err != nil {
+\t\t\treturn "", err
+\t\t}
+'''
+new = '''\t\t// Before the user authorizes network access, validate only syntax and
+\t\t// literal-IP policy. Hostname resolution is itself an observable network
+\t\t// action and is deferred to the socket-bound validator after confirmation.
+\t\tif err := validateWebfetchPreConfirmationURL(u, "request target"); err != nil {
+\t\t\treturn "", err
+\t\t}
+'''
+if text.count(old) != 1:
+    raise SystemExit(f"pre-confirm validation anchor count={text.count(old)}")
+text = text.replace(old, new)
+anchor = '''// validateWebfetchDestinationURL validates that a URL destination is safe.
+func validateWebfetchDestinationURL(ctx context.Context, target *url.URL, stage string) error {
+'''
+insert = '''// validateWebfetchPreConfirmationURL performs only local checks. A hostname is
+// intentionally not resolved until after the user has approved the request.
+func validateWebfetchPreConfirmationURL(target *url.URL, stage string) error {
+\tif target == nil {
+\t\treturn fmt.Errorf("invalid url: missing host")
+\t}
+\thost := strings.TrimSpace(target.Hostname())
+\tif host == "" {
+\t\treturn fmt.Errorf("invalid url: missing host")
+\t}
+\tif ip := parseWebfetchLiteralIP(host); ip != nil {
+\t\tif class := classifyWebfetchAddress(ip); class != "" {
+\t\t\treturn webfetchDestinationDeniedError(stage, host, ip.String(), class)
+\t\t}
+\t}
+\treturn nil
+}
+
+// validateWebfetchDestinationURL validates that a URL destination is safe.
+func validateWebfetchDestinationURL(ctx context.Context, target *url.URL, stage string) error {
+'''
+if text.count(anchor) != 1:
+    raise SystemExit(f"helper anchor count={text.count(anchor)}")
+path.write_text(text.replace(anchor, insert))
+
+Path("sdk/tools/sandbox/sandbox_webfetch_confirmation_test.go").write_text(r'''package sandbox
+
+import (
+	"context"
+	"net"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/timwhitez/agent-sdk-golang/sdk/tools"
+)
+
+type denyWebfetchConfirmer struct{ calls atomic.Int32 }
+
+func (c *denyWebfetchConfirmer) Confirm(context.Context, string, string) (bool, error) {
+	c.calls.Add(1)
+	return false, nil
+}
+
+func TestWebfetchDenialPerformsNoDNSOrDial(t *testing.T) {
+	originalLookup := webfetchLookupIPAddrs
+	originalDial := webfetchDialContext
+	t.Cleanup(func() {
+		webfetchLookupIPAddrs = originalLookup
+		webfetchDialContext = originalDial
+	})
+	var lookups atomic.Int32
+	webfetchLookupIPAddrs = func(context.Context, string) ([]net.IPAddr, error) {
+		lookups.Add(1)
+		return []net.IPAddr{{IP: net.ParseIP("8.8.8.8")}}, nil
+	}
+	var dials atomic.Int32
+	webfetchDialContext = func(context.Context, string, string) (net.Conn, error) {
+		dials.Add(1)
+		return nil, context.Canceled
+	}
+	confirmer := &denyWebfetchConfirmer{}
+	deps := tools.NewContainer()
+	tools.Provide(deps, ConfirmKey, func(context.Context) (Confirmer, error) {
+		return confirmer, nil
+	})
+
+	out, err := webfetchTool().Execute(context.Background(), `{"url":"https://denied.example/private"}`, deps)
+	if err != nil {
+		t.Fatalf("denied webfetch error = %v", err)
+	}
+	if !strings.Contains(strings.ToLower(out.PlainText()), "denied") {
+		t.Fatalf("denied output = %q", out.PlainText())
+	}
+	if confirmer.calls.Load() != 1 {
+		t.Fatalf("confirmation calls = %d, want 1", confirmer.calls.Load())
+	}
+	if lookups.Load() != 0 {
+		t.Fatalf("DNS lookups before/after denial = %d, want 0", lookups.Load())
+	}
+	if dials.Load() != 0 {
+		t.Fatalf("socket dials before/after denial = %d, want 0", dials.Load())
+	}
+}
+
+func TestWebfetchBlockedLiteralIsRejectedWithoutPrompt(t *testing.T) {
+	confirmer := &denyWebfetchConfirmer{}
+	deps := tools.NewContainer()
+	tools.Provide(deps, ConfirmKey, func(context.Context) (Confirmer, error) {
+		return confirmer, nil
+	})
+	_, err := webfetchTool().Execute(context.Background(), `{"url":"http://127.0.0.1/"}`, deps)
+	if err == nil || !strings.Contains(strings.ToLower(err.Error()), "loopback") {
+		t.Fatalf("literal loopback error = %v", err)
+	}
+	if confirmer.calls.Load() != 0 {
+		t.Fatalf("blocked literal prompted %d time(s)", confirmer.calls.Load())
+	}
+}
+''')

--- a/.github/workflows/apply-issue-4.yml
+++ b/.github/workflows/apply-issue-4.yml
@@ -1,0 +1,37 @@
+name: Apply and verify issue 4 fix
+
+on:
+  push:
+    branches: [fix/issue-4-webfetch-confirm-before-dns]
+  pull_request:
+    branches: [fix/issue-3-webfetch-dns-pinning]
+
+permissions:
+  contents: write
+
+jobs:
+  apply-test-commit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-go@v7
+        with:
+          go-version-file: go.mod
+      - run: python3 .github/fixes/issue-4.py
+      - run: rm -f .github/fixes/issue-4.py .github/workflows/apply-issue-4.yml
+      - run: gofmt -w sdk/tools/sandbox/sandbox_webfetch.go sdk/tools/sandbox/sandbox_webfetch_confirmation_test.go
+      - run: git diff --check
+      - name: Targeted confirmation boundary tests
+        run: go test ./sdk/tools/sandbox -run 'TestWebfetchDenialPerformsNoDNSOrDial|TestWebfetchBlockedLiteralIsRejectedWithoutPrompt|TestWebfetchRejectsReboundAddressUsedForSocket' -count=1
+      - name: Sandbox tests
+        run: go test ./sdk/tools/sandbox -count=1
+      - name: Full test suite
+        run: go test ./... -count=1
+      - name: Commit verified fix
+        if: github.event_name == 'push'
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add -A
+          git commit -m "fix(sandbox): defer webfetch DNS until confirmation"
+          git push origin "HEAD:${GITHUB_REF_NAME}"

--- a/.github/workflows/apply-issue-4.yml
+++ b/.github/workflows/apply-issue-4.yml
@@ -18,8 +18,9 @@ jobs:
         with:
           go-version-file: go.mod
       - run: python3 .github/fixes/issue-4.py
-      - run: rm -f .github/fixes/issue-4.py .github/workflows/apply-issue-4.yml
-      - run: gofmt -w sdk/tools/sandbox/sandbox_webfetch.go sdk/tools/sandbox/sandbox_webfetch_confirmation_test.go
+      - run: python3 .github/fixes/issue-4-test.py
+      - run: rm -f .github/fixes/issue-4.py .github/fixes/issue-4-test.py .github/workflows/apply-issue-4.yml
+      - run: gofmt -w sdk/tools/sandbox/sandbox_webfetch.go sdk/tools/sandbox/sandbox_webfetch_confirmation_test.go sdk/tools/sandbox/sandbox_webfetch_rebinding_test.go
       - run: git diff --check
       - name: Targeted confirmation boundary tests
         run: go test ./sdk/tools/sandbox -run 'TestWebfetchDenialPerformsNoDNSOrDial|TestWebfetchBlockedLiteralIsRejectedWithoutPrompt|TestWebfetchRejectsReboundAddressUsedForSocket' -count=1


### PR DESCRIPTION
Superseded by clean replacement PR #54, based on the final WebFetch socket-pinning source from PR #42.

No commits from this duplicate Draft were merged.