### PR TITLE
fix(openai): correlate Responses tool outputs by call_id

### DIFF
--- a/sdk/llm/openai/responses.go
+++ b/sdk/llm/openai/responses.go
@@ -694,6 +694,18 @@ func (c *ResponsesClient) InvokeStream(ctx context.Context, req llm.InvokeReques
 				emitToolIdentity(idx, itemID, "")
 				return nil
 			}
+			recordStreamItemID := func(idx int, itemID string) error {
+				itemID = strings.TrimSpace(itemID)
+				if itemID == "" {
+					return nil
+				}
+				st := ensureToolState(idx)
+				if st.itemID != "" && st.itemID != itemID {
+					return fmt.Errorf("openai responses stream: tool index %d changed item_id from %q to %q", idx, st.itemID, itemID)
+				}
+				st.itemID = itemID
+				return nil
+			}
 
 			stopReason := ""
 			sawCompleted := false
@@ -881,6 +893,9 @@ func (c *ResponsesClient) InvokeStream(ctx context.Context, req llm.InvokeReques
 						if indexErr != nil {
 							return indexErr
 						}
+						if itemErr := recordStreamItemID(idx, itemID); itemErr != nil {
+							return itemErr
+						}
 						st := ensureToolState(idx)
 						if promoteErr := promoteCompatibilityItemID(idx, itemID); promoteErr != nil {
 							return promoteErr
@@ -909,6 +924,9 @@ func (c *ResponsesClient) InvokeStream(ctx context.Context, req llm.InvokeReques
 						idx, indexErr := bindToolIndex(itemID, "", autoKey, idxHint, hasIdxHint)
 						if indexErr != nil {
 							return indexErr
+						}
+						if itemErr := recordStreamItemID(idx, itemID); itemErr != nil {
+							return itemErr
 						}
 						if promoteErr := promoteCompatibilityItemID(idx, itemID); promoteErr != nil {
 							return promoteErr

--- a/sdk/llm/openai/responses.go
+++ b/sdk/llm/openai/responses.go
@@ -497,7 +497,8 @@ func (c *ResponsesClient) InvokeStream(ctx context.Context, req llm.InvokeReques
 				return
 			}
 
-			idToIndex := map[string]int{}
+			itemIDToIndex := map[string]int{}
+			callIDToIndex := map[string]int{}
 			autoToIndex := map[string]int{}
 			usedIndices := map[int]struct{}{}
 			nextIndex := 0
@@ -551,82 +552,64 @@ func (c *ResponsesClient) InvokeStream(ctx context.Context, req llm.InvokeReques
 				}
 			}
 
-			getIndex := func(id, autoKey string, preferred int, hasPreferred bool) int {
-				id = strings.TrimSpace(id)
+			bindToolIndex := func(itemID, callID, autoKey string, preferred int, hasPreferred bool) (int, error) {
+				itemID = strings.TrimSpace(itemID)
+				callID = strings.TrimSpace(callID)
 				autoKey = strings.TrimSpace(autoKey)
-				if id != "" {
-					if idx, ok := idToIndex[id]; ok {
-						if autoKey != "" {
-							autoToIndex[autoKey] = idx
+				idx := -1
+				bindCandidate := func(kind, id string, candidate int) error {
+					if idx < 0 {
+						idx = candidate
+						return nil
+					}
+					if idx != candidate {
+						return fmt.Errorf("openai responses stream: conflicting %s %q maps to tool indexes %d and %d", kind, id, idx, candidate)
+					}
+					return nil
+				}
+				if itemID != "" {
+					if existing, ok := itemIDToIndex[itemID]; ok {
+						if err := bindCandidate("item_id", itemID, existing); err != nil {
+							return 0, err
 						}
-						return idx
 					}
-					if autoKey != "" {
-						if idx, ok := autoToIndex[autoKey]; ok {
-							idToIndex[id] = idx
-							return idx
+				}
+				if callID != "" {
+					if existing, ok := callIDToIndex[callID]; ok {
+						if err := bindCandidate("call_id", callID, existing); err != nil {
+							return 0, err
 						}
 					}
-					idx := allocateIndex(preferred, hasPreferred)
-					idToIndex[id] = idx
-					if autoKey != "" {
-						autoToIndex[autoKey] = idx
-					}
-					return idx
 				}
 				if autoKey != "" {
-					if idx, ok := autoToIndex[autoKey]; ok {
-						return idx
-					}
-					idx := allocateIndex(preferred, hasPreferred)
-					autoToIndex[autoKey] = idx
-					return idx
-				}
-				return allocateIndex(-1, false)
-			}
-			getIndexForIDs := func(ids []string, autoKey string, preferred int, hasPreferred bool) int {
-				cleanIDs := make([]string, 0, len(ids))
-				for _, id := range ids {
-					id = strings.TrimSpace(id)
-					if id == "" {
-						continue
-					}
-					duplicate := false
-					for _, existing := range cleanIDs {
-						if existing == id {
-							duplicate = true
-							break
+					if existing, ok := autoToIndex[autoKey]; ok {
+						if err := bindCandidate("output index", autoKey, existing); err != nil {
+							return 0, err
 						}
-					}
-					if !duplicate {
-						cleanIDs = append(cleanIDs, id)
-					}
-				}
-
-				idx := -1
-				for _, id := range cleanIDs {
-					if existing, ok := idToIndex[id]; ok {
-						idx = existing
-						break
 					}
 				}
 				if idx < 0 {
-					idx = getIndex("", autoKey, preferred, hasPreferred)
+					idx = allocateIndex(preferred, hasPreferred)
 				}
-				for _, id := range cleanIDs {
-					idToIndex[id] = idx
+				if itemID != "" {
+					itemIDToIndex[itemID] = idx
 				}
-				if autoKey = strings.TrimSpace(autoKey); autoKey != "" {
+				if callID != "" {
+					callIDToIndex[callID] = idx
+				}
+				if autoKey != "" {
 					autoToIndex[autoKey] = idx
 				}
-				return idx
+				return idx, nil
 			}
 
 			type streamedToolState struct {
-				hasName bool
-				hasID   bool
-				hasArgs bool
-				callID  string
+				hasName     bool
+				hasID       bool
+				hasArgs     bool
+				itemID      string
+				callID      string
+				pendingArgs strings.Builder
 			}
 			toolState := map[int]*streamedToolState{}
 			ensureToolState := func(idx int) *streamedToolState {
@@ -660,6 +643,56 @@ func (c *ResponsesClient) InvokeStream(ctx context.Context, req llm.InvokeReques
 					st.hasID = true
 				}
 				st.hasArgs = true
+			}
+			applyToolIdentity := func(idx int, itemID, callID, name, args string) error {
+				st := ensureToolState(idx)
+				itemID = strings.TrimSpace(itemID)
+				callID = strings.TrimSpace(callID)
+				if st.itemID != "" && itemID != "" && st.itemID != itemID {
+					return fmt.Errorf("openai responses stream: tool index %d changed item_id from %q to %q", idx, st.itemID, itemID)
+				}
+				if st.callID != "" && callID != "" && st.callID != callID {
+					return fmt.Errorf("openai responses stream: tool index %d changed call_id from %q to %q", idx, st.callID, callID)
+				}
+				if itemID != "" {
+					st.itemID = itemID
+				}
+				if callID != "" {
+					st.callID = callID
+				}
+				needIdentity := (strings.TrimSpace(name) != "" && !st.hasName) || (st.callID != "" && !st.hasID)
+				if needIdentity {
+					emitToolIdentity(idx, st.callID, name)
+				}
+				if st.hasArgs {
+					return nil
+				}
+				if strings.TrimSpace(args) != "" {
+					st.pendingArgs.Reset()
+					emitToolArgs(idx, st.callID, args)
+					return nil
+				}
+				if st.callID != "" && st.pendingArgs.Len() > 0 {
+					pending := st.pendingArgs.String()
+					st.pendingArgs.Reset()
+					emitToolArgs(idx, st.callID, pending)
+				}
+				return nil
+			}
+			promoteCompatibilityItemID := func(idx int, itemID string) error {
+				st := ensureToolState(idx)
+				itemID = strings.TrimSpace(itemID)
+				if st.callID != "" || !st.hasName || itemID == "" {
+					return nil
+				}
+				if existing, ok := callIDToIndex[itemID]; ok && existing != idx {
+					return fmt.Errorf("openai responses stream: compatibility call_id %q maps to tool indexes %d and %d", itemID, existing, idx)
+				}
+				st.itemID = itemID
+				st.callID = itemID
+				callIDToIndex[itemID] = idx
+				emitToolIdentity(idx, itemID, "")
+				return nil
 			}
 
 			stopReason := ""
@@ -761,11 +794,12 @@ func (c *ResponsesClient) InvokeStream(ctx context.Context, req llm.InvokeReques
 						if hasIdxHint {
 							autoKey = fmt.Sprintf("output:%d", idxHint)
 						}
-						idx := getIndexForIDs([]string{callID, itemID}, autoKey, idxHint, hasIdxHint)
-						ensureToolState(idx).callID = callID
-						emitToolIdentity(idx, callID, name)
-						if args, ok := item["arguments"].(string); ok && strings.TrimSpace(args) != "" {
-							emitToolArgs(idx, callID, args)
+						idx, indexErr := bindToolIndex(itemID, callID, autoKey, idxHint, hasIdxHint)
+						if indexErr != nil {
+							return indexErr
+						}
+						if identityErr := applyToolIdentity(idx, itemID, callID, name, responsesToolArguments(item["arguments"])); identityErr != nil {
+							return identityErr
 						}
 					}
 				case "response.output_item.done":
@@ -825,15 +859,12 @@ func (c *ResponsesClient) InvokeStream(ctx context.Context, req llm.InvokeReques
 					if hasIdxHint {
 						autoKey = fmt.Sprintf("output:%d", idxHint)
 					}
-					idx := getIndexForIDs([]string{callID, itemID}, autoKey, idxHint, hasIdxHint)
-					st := ensureToolState(idx)
-					st.callID = callID
-					needIdentity := (strings.TrimSpace(name) != "" && !st.hasName) || (strings.TrimSpace(callID) != "" && !st.hasID)
-					if needIdentity {
-						emitToolIdentity(idx, callID, name)
+					idx, indexErr := bindToolIndex(itemID, callID, autoKey, idxHint, hasIdxHint)
+					if indexErr != nil {
+						return indexErr
 					}
-					if args := responsesToolArguments(item["arguments"]); strings.TrimSpace(args) != "" && !st.hasArgs {
-						emitToolArgs(idx, callID, args)
+					if identityErr := applyToolIdentity(idx, itemID, callID, name, responsesToolArguments(item["arguments"])); identityErr != nil {
+						return identityErr
 					}
 				case "response.function_call_arguments.delta":
 					itemID, _ := root["item_id"].(string)
@@ -846,12 +877,19 @@ func (c *ResponsesClient) InvokeStream(ctx context.Context, req llm.InvokeReques
 						if hasIdxHint {
 							autoKey = fmt.Sprintf("output:%d", idxHint)
 						}
-						idx := getIndexForIDs([]string{itemID}, autoKey, idxHint, hasIdxHint)
-						toolCallID := ensureToolState(idx).callID
-						if toolCallID == "" {
-							toolCallID = itemID
+						idx, indexErr := bindToolIndex(itemID, "", autoKey, idxHint, hasIdxHint)
+						if indexErr != nil {
+							return indexErr
 						}
-						emitToolArgs(idx, toolCallID, d)
+						st := ensureToolState(idx)
+						if promoteErr := promoteCompatibilityItemID(idx, itemID); promoteErr != nil {
+							return promoteErr
+						}
+						if st.callID == "" {
+							st.pendingArgs.WriteString(d)
+						} else {
+							emitToolArgs(idx, st.callID, d)
+						}
 					}
 				case "response.function_call_arguments.done":
 					itemID, _ := root["item_id"].(string)
@@ -868,13 +906,20 @@ func (c *ResponsesClient) InvokeStream(ctx context.Context, req llm.InvokeReques
 						if hasIdxHint {
 							autoKey = fmt.Sprintf("output:%d", idxHint)
 						}
-						idx := getIndexForIDs([]string{itemID}, autoKey, idxHint, hasIdxHint)
+						idx, indexErr := bindToolIndex(itemID, "", autoKey, idxHint, hasIdxHint)
+						if indexErr != nil {
+							return indexErr
+						}
+						if promoteErr := promoteCompatibilityItemID(idx, itemID); promoteErr != nil {
+							return promoteErr
+						}
 						if st := ensureToolState(idx); !st.hasArgs {
-							toolCallID := st.callID
-							if toolCallID == "" {
-								toolCallID = itemID
+							if st.callID == "" {
+								st.pendingArgs.Reset()
+								st.pendingArgs.WriteString(args)
+							} else {
+								emitToolArgs(idx, st.callID, args)
 							}
-							emitToolArgs(idx, toolCallID, args)
 						}
 					}
 				case "response.completed":

--- a/sdk/llm/openai/responses.go
+++ b/sdk/llm/openai/responses.go
@@ -584,11 +584,49 @@ func (c *ResponsesClient) InvokeStream(ctx context.Context, req llm.InvokeReques
 				}
 				return allocateIndex(-1, false)
 			}
+			getIndexForIDs := func(ids []string, autoKey string, preferred int, hasPreferred bool) int {
+				cleanIDs := make([]string, 0, len(ids))
+				for _, id := range ids {
+					id = strings.TrimSpace(id)
+					if id == "" {
+						continue
+					}
+					duplicate := false
+					for _, existing := range cleanIDs {
+						if existing == id {
+							duplicate = true
+							break
+						}
+					}
+					if !duplicate {
+						cleanIDs = append(cleanIDs, id)
+					}
+				}
+
+				idx := -1
+				for _, id := range cleanIDs {
+					if existing, ok := idToIndex[id]; ok {
+						idx = existing
+						break
+					}
+				}
+				if idx < 0 {
+					idx = getIndex("", autoKey, preferred, hasPreferred)
+				}
+				for _, id := range cleanIDs {
+					idToIndex[id] = idx
+				}
+				if autoKey = strings.TrimSpace(autoKey); autoKey != "" {
+					autoToIndex[autoKey] = idx
+				}
+				return idx
+			}
 
 			type streamedToolState struct {
 				hasName bool
 				hasID   bool
 				hasArgs bool
+				callID  string
 			}
 			toolState := map[int]*streamedToolState{}
 			ensureToolState := func(idx int) *streamedToolState {
@@ -716,20 +754,18 @@ func (c *ResponsesClient) InvokeStream(ctx context.Context, req llm.InvokeReques
 						}
 					}
 					if itType == "function_call" || itType == "tool_call" {
-						id, _ := item["id"].(string)
-						if id == "" {
-							id, _ = item["call_id"].(string)
-						}
+						itemID, callID := responsesToolCallIdentifiers(item)
 						name, _ := item["name"].(string)
 						idxHint, hasIdxHint := firstIndexHint(root["output_index"], root["item_index"], item["output_index"], item["index"])
 						autoKey := ""
 						if hasIdxHint {
 							autoKey = fmt.Sprintf("output:%d", idxHint)
 						}
-						idx := getIndex(id, autoKey, idxHint, hasIdxHint)
-						emitToolIdentity(idx, id, name)
+						idx := getIndexForIDs([]string{callID, itemID}, autoKey, idxHint, hasIdxHint)
+						ensureToolState(idx).callID = callID
+						emitToolIdentity(idx, callID, name)
 						if args, ok := item["arguments"].(string); ok && strings.TrimSpace(args) != "" {
-							emitToolArgs(idx, id, args)
+							emitToolArgs(idx, callID, args)
 						}
 					}
 				case "response.output_item.done":
@@ -782,24 +818,22 @@ func (c *ResponsesClient) InvokeStream(ctx context.Context, req llm.InvokeReques
 					if itType != "function_call" && itType != "tool_call" {
 						return nil
 					}
-					id, _ := item["id"].(string)
-					if id == "" {
-						id, _ = item["call_id"].(string)
-					}
+					itemID, callID := responsesToolCallIdentifiers(item)
 					name, _ := item["name"].(string)
 					idxHint, hasIdxHint := firstIndexHint(root["output_index"], root["item_index"], item["output_index"], item["index"])
 					autoKey := ""
 					if hasIdxHint {
 						autoKey = fmt.Sprintf("output:%d", idxHint)
 					}
-					idx := getIndex(id, autoKey, idxHint, hasIdxHint)
+					idx := getIndexForIDs([]string{callID, itemID}, autoKey, idxHint, hasIdxHint)
 					st := ensureToolState(idx)
-					needIdentity := (strings.TrimSpace(name) != "" && !st.hasName) || (strings.TrimSpace(id) != "" && !st.hasID)
+					st.callID = callID
+					needIdentity := (strings.TrimSpace(name) != "" && !st.hasName) || (strings.TrimSpace(callID) != "" && !st.hasID)
 					if needIdentity {
-						emitToolIdentity(idx, id, name)
+						emitToolIdentity(idx, callID, name)
 					}
 					if args := responsesToolArguments(item["arguments"]); strings.TrimSpace(args) != "" && !st.hasArgs {
-						emitToolArgs(idx, id, args)
+						emitToolArgs(idx, callID, args)
 					}
 				case "response.function_call_arguments.delta":
 					itemID, _ := root["item_id"].(string)
@@ -812,8 +846,12 @@ func (c *ResponsesClient) InvokeStream(ctx context.Context, req llm.InvokeReques
 						if hasIdxHint {
 							autoKey = fmt.Sprintf("output:%d", idxHint)
 						}
-						idx := getIndex(itemID, autoKey, idxHint, hasIdxHint)
-						emitToolArgs(idx, itemID, d)
+						idx := getIndexForIDs([]string{itemID}, autoKey, idxHint, hasIdxHint)
+						toolCallID := ensureToolState(idx).callID
+						if toolCallID == "" {
+							toolCallID = itemID
+						}
+						emitToolArgs(idx, toolCallID, d)
 					}
 				case "response.function_call_arguments.done":
 					itemID, _ := root["item_id"].(string)
@@ -830,9 +868,13 @@ func (c *ResponsesClient) InvokeStream(ctx context.Context, req llm.InvokeReques
 						if hasIdxHint {
 							autoKey = fmt.Sprintf("output:%d", idxHint)
 						}
-						idx := getIndex(itemID, autoKey, idxHint, hasIdxHint)
+						idx := getIndexForIDs([]string{itemID}, autoKey, idxHint, hasIdxHint)
 						if st := ensureToolState(idx); !st.hasArgs {
-							emitToolArgs(idx, itemID, args)
+							toolCallID := st.callID
+							if toolCallID == "" {
+								toolCallID = itemID
+							}
+							emitToolArgs(idx, toolCallID, args)
 						}
 					}
 				case "response.completed":
@@ -1686,10 +1728,7 @@ func parseResponses(data []byte) (*llm.Completion, error) {
 					}
 				}
 			case "function_call", "tool_call":
-				id, _ := item["id"].(string)
-				if id == "" {
-					id, _ = item["call_id"].(string)
-				}
+				_, id := responsesToolCallIdentifiers(item)
 				name, _ := item["name"].(string)
 				args := "{}"
 				if s, ok := item["arguments"].(string); ok && strings.TrimSpace(s) != "" {
@@ -1744,4 +1783,20 @@ func parseResponses(data []byte) (*llm.Completion, error) {
 		}
 	}
 	return &llm.Completion{Content: llm.Content{Blocks: blocks}, Thinking: thinking, ToolCalls: toolCalls, Usage: usage, StopReason: stopReason, ResponseID: responseID, Raw: append([]byte(nil), data...)}, nil
+}
+
+func responsesToolCallIdentifiers(item map[string]any) (itemID, callID string) {
+	if item == nil {
+		return "", ""
+	}
+	itemID, _ = item["id"].(string)
+	callID, _ = item["call_id"].(string)
+	itemID = strings.TrimSpace(itemID)
+	callID = strings.TrimSpace(callID)
+	if callID == "" {
+		// Compatibility gateways sometimes expose only one identifier and use
+		// it for both stream-item events and function output correlation.
+		callID = itemID
+	}
+	return itemID, callID
 }

--- a/sdk/llm/openai/responses_call_id_test.go
+++ b/sdk/llm/openai/responses_call_id_test.go
@@ -74,3 +74,77 @@ func TestResponsesFunctionCallRoundTripUsesCallID(t *testing.T) {
 		t.Fatalf("follow-up omitted function_call_output: %#v", input)
 	}
 }
+
+func TestResponsesStreamRoundTripUsesLateCallID(t *testing.T) {
+	t.Parallel()
+	requestCount := 0
+	var followup map[string]any
+	httpClient := &http.Client{Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+		requestCount++
+		if requestCount == 1 {
+			body := strings.Join([]string{
+				`data: {"type":"response.function_call_arguments.delta","output_index":0,"item_id":"fc_stream_roundtrip","delta":"{\"query\":\"go\"}"}`,
+				"",
+				`data: {"type":"response.output_item.done","output_index":0,"item":{"id":"fc_stream_roundtrip","call_id":"call_stream_roundtrip","type":"function_call","name":"lookup","arguments":"{\"query\":\"go\"}"}}`,
+				"",
+				"data: [DONE]",
+				"",
+			}, "\n")
+			return &http.Response{StatusCode: http.StatusOK, Status: "200 OK", Header: make(http.Header), Body: io.NopCloser(strings.NewReader(body)), Request: r}, nil
+		}
+		if err := json.NewDecoder(r.Body).Decode(&followup); err != nil {
+			t.Fatalf("decode follow-up request: %v", err)
+		}
+		body := `{"id":"resp_second","status":"completed","output":[{"type":"message","role":"assistant","content":[{"type":"output_text","text":"done"}]}]}`
+		return &http.Response{StatusCode: http.StatusOK, Status: "200 OK", Header: make(http.Header), Body: io.NopCloser(strings.NewReader(body)), Request: r}, nil
+	})}
+	client := &ResponsesClient{HTTPClient: httpClient, BaseURL: "https://example.com", ModelName: "test-model", MaxRetries: 1}
+
+	stream, err := client.InvokeStream(context.Background(), llm.InvokeRequest{Messages: []llm.Message{{Role: llm.RoleUser, Content: llm.TextContent("look it up")}}})
+	if err != nil {
+		t.Fatalf("first stream: %v", err)
+	}
+	call := llm.ToolCall{Type: "function"}
+	for ev := range stream {
+		switch e := ev.(type) {
+		case llm.StreamToolCallDeltaEvent:
+			if e.ID != "" && call.ID == "" {
+				call.ID = e.ID
+			}
+			call.Function.Name += e.NameDelta
+			call.Function.Arguments += e.ArgumentsDelta
+		case llm.StreamErrorEvent:
+			t.Fatalf("unexpected first-stream error: %v", e.AsError())
+		}
+	}
+	if call.ID != "call_stream_roundtrip" || call.Function.Name != "lookup" || call.Function.Arguments != `{"query":"go"}` {
+		t.Fatalf("streamed tool call = %#v", call)
+	}
+
+	_, err = client.Invoke(context.Background(), llm.InvokeRequest{Messages: []llm.Message{
+		{Role: llm.RoleUser, Content: llm.TextContent("look it up")},
+		{Role: llm.RoleAssistant, ToolCalls: []llm.ToolCall{call}},
+		{Role: llm.RoleTool, ToolCallID: call.ID, Content: llm.TextContent(`{"result":"ok"}`)},
+	}})
+	if err != nil {
+		t.Fatalf("follow-up response: %v", err)
+	}
+
+	input, ok := followup["input"].([]any)
+	if !ok {
+		t.Fatalf("follow-up input = %#v", followup["input"])
+	}
+	found := false
+	for _, raw := range input {
+		item, _ := raw.(map[string]any)
+		if item["type"] == "function_call_output" {
+			found = true
+			if got := item["call_id"]; got != "call_stream_roundtrip" {
+				t.Fatalf("stream follow-up call_id = %#v", got)
+			}
+		}
+	}
+	if !found {
+		t.Fatalf("stream follow-up omitted function_call_output: %#v", input)
+	}
+}

--- a/sdk/llm/openai/responses_call_id_test.go
+++ b/sdk/llm/openai/responses_call_id_test.go
@@ -1,0 +1,76 @@
+package openai
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/timwhitez/agent-sdk-golang/sdk/llm"
+)
+
+func TestResponsesFunctionCallRoundTripUsesCallID(t *testing.T) {
+	t.Parallel()
+	requestCount := 0
+	var followup map[string]any
+	httpClient := &http.Client{Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+		requestCount++
+		if requestCount == 2 {
+			if err := json.NewDecoder(r.Body).Decode(&followup); err != nil {
+				t.Fatalf("decode follow-up request: %v", err)
+			}
+		}
+		responseBody := `{"id":"resp_first","status":"completed","output":[{"id":"fc_roundtrip","call_id":"call_roundtrip","type":"function_call","name":"lookup","arguments":"{\"query\":\"go\"}"}]}`
+		if requestCount > 1 {
+			responseBody = `{"id":"resp_second","status":"completed","output":[{"type":"message","role":"assistant","content":[{"type":"output_text","text":"done"}]}]}`
+		}
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Status:     "200 OK",
+			Header:     make(http.Header),
+			Body:       io.NopCloser(strings.NewReader(responseBody)),
+			Request:    r,
+		}, nil
+	})}
+	client := &ResponsesClient{HTTPClient: httpClient, BaseURL: "https://example.com", ModelName: "test-model", MaxRetries: 1}
+
+	first, err := client.Invoke(context.Background(), llm.InvokeRequest{
+		Messages: []llm.Message{{Role: llm.RoleUser, Content: llm.TextContent("look it up")}},
+	})
+	if err != nil {
+		t.Fatalf("first response: %v", err)
+	}
+	if len(first.ToolCalls) != 1 || first.ToolCalls[0].ID != "call_roundtrip" {
+		t.Fatalf("first tool calls = %#v", first.ToolCalls)
+	}
+
+	_, err = client.Invoke(context.Background(), llm.InvokeRequest{Messages: []llm.Message{
+		{Role: llm.RoleUser, Content: llm.TextContent("look it up")},
+		{Role: llm.RoleAssistant, ToolCalls: first.ToolCalls},
+		{Role: llm.RoleTool, ToolCallID: first.ToolCalls[0].ID, Content: llm.TextContent(`{"result":"ok"}`)},
+	}})
+	if err != nil {
+		t.Fatalf("follow-up response: %v", err)
+	}
+
+	input, ok := followup["input"].([]any)
+	if !ok {
+		t.Fatalf("follow-up input = %#v", followup["input"])
+	}
+	foundOutput := false
+	for _, raw := range input {
+		item, _ := raw.(map[string]any)
+		if item["type"] != "function_call_output" {
+			continue
+		}
+		foundOutput = true
+		if got := item["call_id"]; got != "call_roundtrip" {
+			t.Fatalf("function_call_output.call_id = %#v, want call_roundtrip", got)
+		}
+	}
+	if !foundOutput {
+		t.Fatalf("follow-up omitted function_call_output: %#v", input)
+	}
+}

--- a/sdk/llm/openai/responses_parse_test.go
+++ b/sdk/llm/openai/responses_parse_test.go
@@ -73,3 +73,16 @@ func TestUsageFromResponsesKeepsCachedAndImageTokensAsBreakdown(t *testing.T) {
 		t.Fatalf("unexpected normalized usage quality: %#v", usage)
 	}
 }
+
+func TestParseResponsesUsesFunctionCallIDForToolOutputCorrelation(t *testing.T) {
+	comp, err := parseResponses([]byte(`{"id":"resp_tool","status":"completed","output":[{"id":"fc_123","call_id":"call_123","type":"function_call","name":"lookup","arguments":"{\"query\":\"go\"}"}]}`))
+	if err != nil {
+		t.Fatalf("parseResponses: %v", err)
+	}
+	if len(comp.ToolCalls) != 1 {
+		t.Fatalf("tool calls = %#v, want one", comp.ToolCalls)
+	}
+	if got := comp.ToolCalls[0].ID; got != "call_123" {
+		t.Fatalf("tool call ID = %q, want provider call_id %q", got, "call_123")
+	}
+}

--- a/sdk/llm/openai/responses_stream_test.go
+++ b/sdk/llm/openai/responses_stream_test.go
@@ -427,3 +427,91 @@ func TestResponsesStreamSeparatesItemIDFromFunctionCallID(t *testing.T) {
 		t.Fatalf("tool args = %q, want complete arguments", args)
 	}
 }
+
+func TestResponsesStreamBuffersArgumentsUntilLateCallID(t *testing.T) {
+	t.Parallel()
+	body := strings.Join([]string{
+		`data: {"type":"response.function_call_arguments.delta","output_index":0,"item_id":"fc_late","delta":"{\"path\":\"notes.txt\"}"}`,
+		"",
+		`data: {"type":"response.output_item.added","output_index":0,"item":{"id":"fc_late","call_id":"call_late","type":"function_call","name":"read","arguments":""}}`,
+		"",
+		`data: {"type":"response.output_item.done","output_index":0,"item":{"id":"fc_late","call_id":"call_late","type":"function_call","name":"read","arguments":"{\"path\":\"notes.txt\"}"}}`,
+		"",
+		"data: [DONE]",
+		"",
+	}, "\n")
+
+	httpClient := &http.Client{Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+		return &http.Response{StatusCode: http.StatusOK, Status: "200 OK", Header: make(http.Header), Body: io.NopCloser(strings.NewReader(body)), Request: r}, nil
+	})}
+	client := &ResponsesClient{HTTPClient: httpClient, BaseURL: "https://example.com", ModelName: "test-model", MaxRetries: 1}
+	ch, err := client.InvokeStream(context.Background(), llm.InvokeRequest{Messages: []llm.Message{{Role: llm.RoleUser, Content: llm.TextContent("hi")}}})
+	if err != nil {
+		t.Fatalf("invoke stream: %v", err)
+	}
+
+	name := ""
+	args := ""
+	for ev := range ch {
+		switch e := ev.(type) {
+		case llm.StreamToolCallDeltaEvent:
+			if e.ID != "" && e.ID != "call_late" {
+				t.Fatalf("late identity exposed wrong tool-call ID: %#v", e)
+			}
+			name += e.NameDelta
+			args += e.ArgumentsDelta
+		case llm.StreamErrorEvent:
+			t.Fatalf("unexpected stream error: %v", e.AsError())
+		}
+	}
+	if name != "read" || args != `{"path":"notes.txt"}` {
+		t.Fatalf("streamed tool = name %q args %q", name, args)
+	}
+}
+
+func TestResponsesStreamKeepsItemAndCallIDNamespacesSeparate(t *testing.T) {
+	t.Parallel()
+	body := strings.Join([]string{
+		`data: {"type":"response.output_item.added","output_index":0,"item":{"id":"fc_a","call_id":"shared_identifier","type":"function_call","name":"first","arguments":""}}`,
+		"",
+		`data: {"type":"response.output_item.added","output_index":1,"item":{"id":"shared_identifier","call_id":"call_b","type":"function_call","name":"second","arguments":""}}`,
+		"",
+		`data: {"type":"response.function_call_arguments.delta","output_index":0,"item_id":"fc_a","delta":"{\"value\":1}"}`,
+		"",
+		`data: {"type":"response.function_call_arguments.delta","output_index":1,"item_id":"shared_identifier","delta":"{\"value\":2}"}`,
+		"",
+		"data: [DONE]",
+		"",
+	}, "\n")
+
+	httpClient := &http.Client{Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+		return &http.Response{StatusCode: http.StatusOK, Status: "200 OK", Header: make(http.Header), Body: io.NopCloser(strings.NewReader(body)), Request: r}, nil
+	})}
+	client := &ResponsesClient{HTTPClient: httpClient, BaseURL: "https://example.com", ModelName: "test-model", MaxRetries: 1}
+	ch, err := client.InvokeStream(context.Background(), llm.InvokeRequest{Messages: []llm.Message{{Role: llm.RoleUser, Content: llm.TextContent("hi")}}})
+	if err != nil {
+		t.Fatalf("invoke stream: %v", err)
+	}
+
+	names := map[int]string{}
+	args := map[int]string{}
+	ids := map[int]string{}
+	for ev := range ch {
+		switch e := ev.(type) {
+		case llm.StreamToolCallDeltaEvent:
+			names[e.Index] += e.NameDelta
+			args[e.Index] += e.ArgumentsDelta
+			if e.ID != "" {
+				ids[e.Index] = e.ID
+			}
+		case llm.StreamErrorEvent:
+			t.Fatalf("unexpected stream error: %v", e.AsError())
+		}
+	}
+	if names[0] != "first" || args[0] != `{"value":1}` || ids[0] != "shared_identifier" {
+		t.Fatalf("first tool identity collapsed: names=%#v args=%#v ids=%#v", names, args, ids)
+	}
+	if names[1] != "second" || args[1] != `{"value":2}` || ids[1] != "call_b" {
+		t.Fatalf("second tool identity collapsed: names=%#v args=%#v ids=%#v", names, args, ids)
+	}
+}

--- a/sdk/llm/openai/responses_stream_test.go
+++ b/sdk/llm/openai/responses_stream_test.go
@@ -515,3 +515,55 @@ func TestResponsesStreamKeepsItemAndCallIDNamespacesSeparate(t *testing.T) {
 		t.Fatalf("second tool identity collapsed: names=%#v args=%#v ids=%#v", names, args, ids)
 	}
 }
+
+func TestResponsesStreamRejectsIdentityFirstItemIDConflict(t *testing.T) {
+	t.Parallel()
+	body := strings.Join([]string{
+		`data: {"type":"response.output_item.added","output_index":0,"item":{"id":"fc_a","call_id":"call_a","type":"function_call","name":"lookup","arguments":""}}`,
+		"",
+		`data: {"type":"response.function_call_arguments.delta","output_index":0,"item_id":"fc_b","delta":"{\"wrong\":true}"}`,
+		"",
+	}, "\n")
+	assertResponsesStreamItemIDConflict(t, body)
+}
+
+func TestResponsesStreamRejectsDeltaFirstItemIDConflict(t *testing.T) {
+	t.Parallel()
+	body := strings.Join([]string{
+		`data: {"type":"response.function_call_arguments.delta","output_index":0,"item_id":"fc_a","delta":"{\"first\":true}"}`,
+		"",
+		`data: {"type":"response.function_call_arguments.delta","output_index":0,"item_id":"fc_b","delta":"{\"wrong\":true}"}`,
+		"",
+	}, "\n")
+	assertResponsesStreamItemIDConflict(t, body)
+}
+
+func assertResponsesStreamItemIDConflict(t *testing.T, body string) {
+	t.Helper()
+	httpClient := &http.Client{Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+		return &http.Response{StatusCode: http.StatusOK, Status: "200 OK", Header: make(http.Header), Body: io.NopCloser(strings.NewReader(body)), Request: r}, nil
+	})}
+	client := &ResponsesClient{HTTPClient: httpClient, BaseURL: "https://example.com", ModelName: "test-model", MaxRetries: 1}
+	ch, err := client.InvokeStream(context.Background(), llm.InvokeRequest{Messages: []llm.Message{{Role: llm.RoleUser, Content: llm.TextContent("hi")}}})
+	if err != nil {
+		t.Fatalf("invoke stream: %v", err)
+	}
+
+	errSeen := false
+	for ev := range ch {
+		switch e := ev.(type) {
+		case llm.StreamToolCallDeltaEvent:
+			if strings.Contains(e.ArgumentsDelta, "wrong") {
+				t.Fatalf("conflicting item arguments were emitted before rejection: %#v", e)
+			}
+		case llm.StreamErrorEvent:
+			errSeen = true
+			if !strings.Contains(e.AsError().Error(), "changed item_id") {
+				t.Fatalf("conflict error = %v", e.AsError())
+			}
+		}
+	}
+	if !errSeen {
+		t.Fatal("conflicting stream item_id did not produce StreamErrorEvent")
+	}
+}

--- a/sdk/llm/openai/responses_stream_test.go
+++ b/sdk/llm/openai/responses_stream_test.go
@@ -381,3 +381,49 @@ func TestResponsesStreamAcceptsObjectArgumentsInOutputItemDone(t *testing.T) {
 		t.Fatalf("tool args = %q, want %q", toolArgs, `{"query":"golang"}`)
 	}
 }
+
+func TestResponsesStreamSeparatesItemIDFromFunctionCallID(t *testing.T) {
+	t.Parallel()
+	body := strings.Join([]string{
+		`data: {"type":"response.output_item.added","output_index":0,"item":{"id":"fc_stream","call_id":"call_stream","type":"function_call","name":"lookup","arguments":""}}`,
+		"",
+		`data: {"type":"response.function_call_arguments.delta","output_index":0,"item_id":"fc_stream","delta":"{\"query\":"}`,
+		"",
+		`data: {"type":"response.function_call_arguments.delta","output_index":0,"item_id":"fc_stream","delta":"\"golang\"}"}`,
+		"",
+		`data: {"type":"response.output_item.done","output_index":0,"item":{"id":"fc_stream","call_id":"call_stream","type":"function_call","name":"lookup","arguments":"{\"query\":\"golang\"}"}}`,
+		"",
+		"data: [DONE]",
+		"",
+	}, "\n")
+
+	httpClient := &http.Client{Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+		return &http.Response{StatusCode: http.StatusOK, Status: "200 OK", Header: make(http.Header), Body: io.NopCloser(strings.NewReader(body)), Request: r}, nil
+	})}
+	client := &ResponsesClient{HTTPClient: httpClient, BaseURL: "https://example.com", ModelName: "test-model", MaxRetries: 1}
+	ch, err := client.InvokeStream(context.Background(), llm.InvokeRequest{Messages: []llm.Message{{Role: llm.RoleUser, Content: llm.TextContent("hi")}}})
+	if err != nil {
+		t.Fatalf("invoke stream: %v", err)
+	}
+
+	name := ""
+	args := ""
+	for ev := range ch {
+		switch e := ev.(type) {
+		case llm.StreamToolCallDeltaEvent:
+			if e.ID != "" && e.ID != "call_stream" {
+				t.Fatalf("stream exposed item id as tool-call id: %#v", e)
+			}
+			name += e.NameDelta
+			args += e.ArgumentsDelta
+		case llm.StreamErrorEvent:
+			t.Fatalf("unexpected stream error: %v", e.AsError())
+		}
+	}
+	if name != "lookup" {
+		t.Fatalf("tool name = %q, want lookup", name)
+	}
+	if args != `{"query":"golang"}` {
+		t.Fatalf("tool args = %q, want complete arguments", args)
+	}
+}


### PR DESCRIPTION
## Summary

- keep Responses output item IDs separate from function `call_id` values
- expose `call_id` as the provider-neutral tool-call ID used by follow-up outputs
- bind both identifiers to one streaming index so interleaved argument deltas remain correlated
- retain the single-ID fallback used by compatible gateways

## Validation

- strict buffered official dual-ID fixture
- strict streaming `item_id=fc_*` / `call_id=call_*` fixture
- strict two-request fixture asserting `function_call_output.call_id=call_*`
- `go test -count=1 ./sdk/llm/openai`
- `go test -race -count=1 ./sdk/llm/openai`
- `go test -count=1 ./...`
- `go vet ./sdk/llm/openai`
- `git diff --check`

Closes #55
