### PR TITLE
fix(compaction): enforce the exact summary heading contract

### DIFF
--- a/sdk/agent/compaction/service_test.go
+++ b/sdk/agent/compaction/service_test.go
@@ -257,6 +257,57 @@ func TestCompactionQualityGateRequiresUniqueOrderedExactLevelTwoHeadings(t *test
 	}
 }
 
+func TestCompactionQualityGateIgnoresFencedHeadingLookalikes(t *testing.T) {
+	valid, envelopeReasons := validateSummaryEnvelope(structuredTestSummary("", ""))
+	if len(envelopeReasons) != 0 {
+		t.Fatalf("valid summary envelope: %v", envelopeReasons)
+	}
+	fenced := "```markdown\n" + valid + "\n```"
+	reasons := validateRequiredSummarySections(fenced)
+	if len(reasons) == 0 || !strings.Contains(strings.Join(reasons, "; "), "missing required section") {
+		t.Fatalf("fenced heading lookalikes passed validation: %v", reasons)
+	}
+}
+
+func TestCompactionQualityGateAcceptsCRLFHeadings(t *testing.T) {
+	valid, envelopeReasons := validateSummaryEnvelope(structuredTestSummary("", ""))
+	if len(envelopeReasons) != 0 {
+		t.Fatalf("valid summary envelope: %v", envelopeReasons)
+	}
+	if reasons := validateRequiredSummarySections(strings.ReplaceAll(valid, "\n", "\r\n")); len(reasons) != 0 {
+		t.Fatalf("CRLF summary rejected: %v", reasons)
+	}
+}
+
+func TestCompactionQualityGateDoesNotCountAnotherHeadingAsSectionBody(t *testing.T) {
+	valid, envelopeReasons := validateSummaryEnvelope(structuredTestSummary("", ""))
+	if len(envelopeReasons) != 0 {
+		t.Fatalf("valid summary envelope: %v", envelopeReasons)
+	}
+	first := requiredSummarySections[0]
+	withEmptyBody := strings.Replace(valid, "## "+first+"\nuser request preserved", "## "+first+"\n### unrelated heading\ntext", 1)
+	reasons := validateRequiredSummarySections(withEmptyBody)
+	if !strings.Contains(strings.Join(reasons, "; "), "empty required section: "+first) {
+		t.Fatalf("extra heading masqueraded as required-section body: %v", reasons)
+	}
+}
+
+func TestMaterialSectionBodyIgnoresFencedHeadingLookalike(t *testing.T) {
+	material := strings.Join([]string{
+		"```markdown",
+		"## Latest Real User Request",
+		"wrong fenced value",
+		"```",
+		"## Latest Real User Request",
+		"real request",
+		"## Host Checkpoint Context",
+		"Status: VERIFIED",
+	}, "\n")
+	if got := materialSectionBody(material, "Latest Real User Request"); got != "real request" {
+		t.Fatalf("material section body = %q, want real request", got)
+	}
+}
+
 func TestCompactionQualityGateAllowsCredentialLikeSecurityMaterial(t *testing.T) {
 	material := `Cookie: user="adm\\073n" Authorization: Bearer lab-fixture-token`
 	model := mockCompactModel{response: structuredTestSummary("Verification Already Run and Still Required", material)}

--- a/sdk/agent/compaction/service_test.go
+++ b/sdk/agent/compaction/service_test.go
@@ -207,6 +207,56 @@ func TestCompactionQualityGateRejectsMissingRequiredSections(t *testing.T) {
 	}
 }
 
+func TestCompactionQualityGateRequiresUniqueOrderedExactLevelTwoHeadings(t *testing.T) {
+	valid, reasons := validateSummaryEnvelope(structuredTestSummary("", ""))
+	if len(reasons) != 0 {
+		t.Fatalf("valid summary envelope: %v", reasons)
+	}
+	first := requiredSummarySections[0]
+	second := requiredSummarySections[1]
+	tests := []struct {
+		name       string
+		summary    string
+		wantReason string
+	}{
+		{
+			name:       "wrong level",
+			summary:    strings.Replace(valid, "## "+first, "# "+first, 1),
+			wantReason: "missing required section: " + first,
+		},
+		{
+			name:       "missing heading space",
+			summary:    strings.Replace(valid, "## "+first, "##"+first, 1),
+			wantReason: "missing required section: " + first,
+		},
+		{
+			name:       "duplicate",
+			summary:    strings.Replace(valid, "## "+second, "## "+first+"\nduplicate\n\n## "+second, 1),
+			wantReason: "duplicate required section: " + first,
+		},
+		{
+			name: "out of order",
+			summary: strings.Replace(
+				strings.Replace(
+					strings.Replace(valid, "## "+first, "## temporary-first", 1),
+					"## "+second, "## "+first, 1,
+				),
+				"## temporary-first", "## "+second, 1,
+			),
+			wantReason: "required section out of order: " + second,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			reasons := validateRequiredSummarySections(tc.summary)
+			if !strings.Contains(strings.Join(reasons, "; "), tc.wantReason) {
+				t.Fatalf("reasons = %v, want %q", reasons, tc.wantReason)
+			}
+		})
+	}
+}
+
 func TestCompactionQualityGateAllowsCredentialLikeSecurityMaterial(t *testing.T) {
 	material := `Cookie: user="adm\\073n" Authorization: Bearer lab-fixture-token`
 	model := mockCompactModel{response: structuredTestSummary("Verification Already Run and Still Required", material)}

--- a/sdk/agent/compaction/service_test.go
+++ b/sdk/agent/compaction/service_test.go
@@ -269,6 +269,28 @@ func TestCompactionQualityGateIgnoresFencedHeadingLookalikes(t *testing.T) {
 	}
 }
 
+func TestCompactionQualityGateIgnoresTildeFencedHeadingLookalikes(t *testing.T) {
+	valid, envelopeReasons := validateSummaryEnvelope(structuredTestSummary("", ""))
+	if len(envelopeReasons) != 0 {
+		t.Fatalf("valid summary envelope: %v", envelopeReasons)
+	}
+	fenced := "~~~markdown\n" + valid + "\n~~~"
+	if reasons := validateRequiredSummarySections(fenced); len(reasons) == 0 {
+		t.Fatal("tilde-fenced heading lookalikes passed validation")
+	}
+}
+
+func TestCompactionQualityGateDoesNotCloseFenceOnUnicodeWhitespace(t *testing.T) {
+	valid, envelopeReasons := validateSummaryEnvelope(structuredTestSummary("", ""))
+	if len(envelopeReasons) != 0 {
+		t.Fatalf("valid summary envelope: %v", envelopeReasons)
+	}
+	fenced := "```markdown\nignored\n```\u00a0\n" + valid
+	if reasons := validateRequiredSummarySections(fenced); len(reasons) == 0 {
+		t.Fatal("non-CommonMark Unicode whitespace closed a code fence")
+	}
+}
+
 func TestCompactionQualityGateAcceptsCRLFHeadings(t *testing.T) {
 	valid, envelopeReasons := validateSummaryEnvelope(structuredTestSummary("", ""))
 	if len(envelopeReasons) != 0 {
@@ -289,6 +311,19 @@ func TestCompactionQualityGateDoesNotCountAnotherHeadingAsSectionBody(t *testing
 	reasons := validateRequiredSummarySections(withEmptyBody)
 	if !strings.Contains(strings.Join(reasons, "; "), "empty required section: "+first) {
 		t.Fatalf("extra heading masqueraded as required-section body: %v", reasons)
+	}
+}
+
+func TestCompactionQualityGateRecognizesIndentedMarkdownHeadingBoundary(t *testing.T) {
+	valid, envelopeReasons := validateSummaryEnvelope(structuredTestSummary("", ""))
+	if len(envelopeReasons) != 0 {
+		t.Fatalf("valid summary envelope: %v", envelopeReasons)
+	}
+	first := requiredSummarySections[0]
+	withEmptyBody := strings.Replace(valid, "## "+first+"\nuser request preserved", "## "+first+"\n   ### indented heading\ntext", 1)
+	reasons := validateRequiredSummarySections(withEmptyBody)
+	if !strings.Contains(strings.Join(reasons, "; "), "empty required section: "+first) {
+		t.Fatalf("indented Markdown heading masqueraded as required-section body: %v", reasons)
 	}
 }
 

--- a/sdk/agent/compaction/validation.go
+++ b/sdk/agent/compaction/validation.go
@@ -62,7 +62,7 @@ func validateSummaryFactCoverage(summary, material string) []string {
 }
 
 func materialSectionBody(text, title string) string {
-	re := regexp.MustCompile(`(?mi)^#{1,6}\s*` + regexp.QuoteMeta(title) + `\s*$`)
+	re := regexp.MustCompile(`(?m)^## ` + regexp.QuoteMeta(title) + `\r?$`)
 	loc := re.FindStringIndex(text)
 	if loc == nil {
 		return ""
@@ -112,13 +112,25 @@ func validateRequiredSummarySections(summary string) []string {
 	last := -1
 	missing := 0
 	for _, title := range requiredSummarySections {
-		re := regexp.MustCompile(`(?mi)^#{1,6}\s*` + regexp.QuoteMeta(title) + `\s*$`)
-		loc := re.FindStringIndex(summary)
-		if loc == nil {
+		exactPattern := regexp.MustCompile(`(?m)^## ` + regexp.QuoteMeta(title) + `\r?$`)
+		exactMatches := exactPattern.FindAllStringIndex(summary, -1)
+		broadPattern := regexp.MustCompile(`(?mi)^#{1,6}[\t ]*` + regexp.QuoteMeta(title) + `[\t ]*\r?$`)
+		broadMatches := broadPattern.FindAllStringIndex(summary, -1)
+		if len(exactMatches) == 0 {
 			missing++
 			reasons = append(reasons, "missing required section: "+title)
+			if len(broadMatches) > 0 {
+				reasons = append(reasons, "required section must use exact level-2 heading: ## "+title)
+			}
 			continue
 		}
+		if len(exactMatches) > 1 {
+			reasons = append(reasons, "duplicate required section: "+title)
+		}
+		if len(broadMatches) != len(exactMatches) {
+			reasons = append(reasons, "required section must use exact level-2 heading: ## "+title)
+		}
+		loc := exactMatches[0]
 		if loc[0] <= last {
 			reasons = append(reasons, "required section out of order: "+title)
 		}
@@ -130,7 +142,9 @@ func validateRequiredSummarySections(summary string) []string {
 	}
 	for i, section := range sections {
 		bodyEnd := len(summary)
-		if i+1 < len(sections) {
+		if nextHeading := regexp.MustCompile(`(?m)^#{1,6}[\t ]+.+\r?$`).FindStringIndex(summary[section.end:]); nextHeading != nil {
+			bodyEnd = section.end + nextHeading[0]
+		} else if i+1 < len(sections) {
 			bodyEnd = sections[i+1].start
 		}
 		if strings.TrimSpace(summary[section.end:bodyEnd]) == "" {

--- a/sdk/agent/compaction/validation.go
+++ b/sdk/agent/compaction/validation.go
@@ -2,7 +2,6 @@ package compaction
 
 import (
 	"fmt"
-	"regexp"
 	"sort"
 	"strings"
 )
@@ -62,16 +61,23 @@ func validateSummaryFactCoverage(summary, material string) []string {
 }
 
 func materialSectionBody(text, title string) string {
-	re := regexp.MustCompile(`(?m)^## ` + regexp.QuoteMeta(title) + `\r?$`)
-	loc := re.FindStringIndex(text)
-	if loc == nil {
+	headings := scanMarkdownHeadings(text)
+	sectionIndex := -1
+	for i, heading := range headings {
+		if heading.line == "## "+title {
+			sectionIndex = i
+			break
+		}
+	}
+	if sectionIndex < 0 {
 		return ""
 	}
-	rest := text[loc[1]:]
-	nextHeading := regexp.MustCompile(`(?m)^#{1,6}\s+.+$`).FindStringIndex(rest)
-	if nextHeading != nil {
-		rest = rest[:nextHeading[0]]
+	section := headings[sectionIndex]
+	bodyEnd := len(text)
+	if sectionIndex+1 < len(headings) {
+		bodyEnd = headings[sectionIndex+1].start
 	}
+	rest := text[section.end:bodyEnd]
 	if end := strings.Index(rest, endUntrustedMaterial); end >= 0 {
 		rest = rest[:end]
 	}
@@ -109,13 +115,20 @@ func validateRequiredSummarySections(summary string) []string {
 	}
 	sections := make([]locatedSection, 0, len(requiredSummarySections))
 	reasons := []string{}
+	headings := scanMarkdownHeadings(summary)
 	last := -1
 	missing := 0
 	for _, title := range requiredSummarySections {
-		exactPattern := regexp.MustCompile(`(?m)^## ` + regexp.QuoteMeta(title) + `\r?$`)
-		exactMatches := exactPattern.FindAllStringIndex(summary, -1)
-		broadPattern := regexp.MustCompile(`(?mi)^#{1,6}[\t ]*` + regexp.QuoteMeta(title) + `[\t ]*\r?$`)
-		broadMatches := broadPattern.FindAllStringIndex(summary, -1)
+		exactMatches := make([]markdownHeading, 0, 1)
+		broadMatches := make([]markdownHeading, 0, 1)
+		for _, heading := range headings {
+			if strings.EqualFold(heading.title, title) {
+				broadMatches = append(broadMatches, heading)
+			}
+			if heading.line == "## "+title {
+				exactMatches = append(exactMatches, heading)
+			}
+		}
 		if len(exactMatches) == 0 {
 			missing++
 			reasons = append(reasons, "missing required section: "+title)
@@ -131,25 +144,102 @@ func validateRequiredSummarySections(summary string) []string {
 			reasons = append(reasons, "required section must use exact level-2 heading: ## "+title)
 		}
 		loc := exactMatches[0]
-		if loc[0] <= last {
+		if loc.start <= last {
 			reasons = append(reasons, "required section out of order: "+title)
 		}
-		last = loc[0]
-		sections = append(sections, locatedSection{title: title, start: loc[0], end: loc[1]})
+		last = loc.start
+		sections = append(sections, locatedSection{title: title, start: loc.start, end: loc.end})
 	}
 	if missing == len(requiredSummarySections) {
 		reasons = append(reasons, "required sections must use exact Markdown heading lines (for example: ## Current Objective and Latest User Request)")
 	}
-	for i, section := range sections {
+	for _, section := range sections {
 		bodyEnd := len(summary)
-		if nextHeading := regexp.MustCompile(`(?m)^#{1,6}[\t ]+.+\r?$`).FindStringIndex(summary[section.end:]); nextHeading != nil {
-			bodyEnd = section.end + nextHeading[0]
-		} else if i+1 < len(sections) {
-			bodyEnd = sections[i+1].start
+		for _, heading := range headings {
+			if heading.start >= section.end {
+				bodyEnd = heading.start
+				break
+			}
 		}
 		if strings.TrimSpace(summary[section.end:bodyEnd]) == "" {
 			reasons = append(reasons, "empty required section: "+section.title)
 		}
 	}
 	return reasons
+}
+
+type markdownHeading struct {
+	line  string
+	title string
+	start int
+	end   int
+}
+
+func scanMarkdownHeadings(text string) []markdownHeading {
+	headings := []markdownHeading{}
+	fenceChar := byte(0)
+	fenceWidth := 0
+	for start := 0; start <= len(text); {
+		lineEnd := strings.IndexByte(text[start:], '\n')
+		next := len(text) + 1
+		if lineEnd < 0 {
+			lineEnd = len(text)
+		} else {
+			lineEnd += start
+			next = lineEnd + 1
+		}
+		line := strings.TrimSuffix(text[start:lineEnd], "\r")
+
+		if marker, width, closing := markdownFenceMarker(line, fenceChar, fenceWidth); marker != 0 {
+			if fenceChar == 0 && !closing {
+				fenceChar = marker
+				fenceWidth = width
+			} else if fenceChar == marker && closing {
+				fenceChar = 0
+				fenceWidth = 0
+			}
+		} else if fenceChar == 0 && strings.HasPrefix(line, "#") {
+			level := 0
+			for level < len(line) && level < 6 && line[level] == '#' {
+				level++
+			}
+			if level > 0 {
+				title := strings.TrimSpace(line[level:])
+				headings = append(headings, markdownHeading{line: line, title: title, start: start, end: min(next, len(text))})
+			}
+		}
+
+		if next > len(text) {
+			break
+		}
+		start = next
+	}
+	return headings
+}
+
+func markdownFenceMarker(line string, active byte, activeWidth int) (marker byte, width int, closing bool) {
+	indent := 0
+	for indent < len(line) && indent < 4 && line[indent] == ' ' {
+		indent++
+	}
+	if indent > 3 || indent >= len(line) {
+		return 0, 0, false
+	}
+	marker = line[indent]
+	if marker != '`' && marker != '~' {
+		return 0, 0, false
+	}
+	for indent+width < len(line) && line[indent+width] == marker {
+		width++
+	}
+	if width < 3 {
+		return 0, 0, false
+	}
+	if active == 0 {
+		return marker, width, false
+	}
+	if marker != active || width < activeWidth || strings.TrimSpace(line[indent+width:]) != "" {
+		return 0, 0, false
+	}
+	return marker, width, true
 }

--- a/sdk/agent/compaction/validation.go
+++ b/sdk/agent/compaction/validation.go
@@ -198,13 +198,24 @@ func scanMarkdownHeadings(text string) []markdownHeading {
 				fenceChar = 0
 				fenceWidth = 0
 			}
-		} else if fenceChar == 0 && strings.HasPrefix(line, "#") {
+		} else if fenceChar == 0 {
+			headingOffset := 0
+			for headingOffset < len(line) && headingOffset < 4 && line[headingOffset] == ' ' {
+				headingOffset++
+			}
+			if headingOffset > 3 || headingOffset >= len(line) || line[headingOffset] != '#' {
+				if next > len(text) {
+					break
+				}
+				start = next
+				continue
+			}
 			level := 0
-			for level < len(line) && level < 6 && line[level] == '#' {
+			for headingOffset+level < len(line) && level < 6 && line[headingOffset+level] == '#' {
 				level++
 			}
 			if level > 0 {
-				title := strings.TrimSpace(line[level:])
+				title := strings.TrimSpace(line[headingOffset+level:])
 				headings = append(headings, markdownHeading{line: line, title: title, start: start, end: min(next, len(text))})
 			}
 		}
@@ -238,8 +249,17 @@ func markdownFenceMarker(line string, active byte, activeWidth int) (marker byte
 	if active == 0 {
 		return marker, width, false
 	}
-	if marker != active || width < activeWidth || strings.TrimSpace(line[indent+width:]) != "" {
+	if marker != active || width < activeWidth || !onlyASCIISpaceOrTab(line[indent+width:]) {
 		return 0, 0, false
 	}
 	return marker, width, true
+}
+
+func onlyASCIISpaceOrTab(text string) bool {
+	for i := 0; i < len(text); i++ {
+		if text[i] != ' ' && text[i] != '\t' {
+			return false
+		}
+	}
+	return true
 }


### PR DESCRIPTION
## Summary

- require exact `## <title>` lines for all required compaction sections
- reject wrong heading levels, missing spaces, malformed lookalikes, duplicates, and ordering drift
- stop section bodies at the next Markdown heading so another heading cannot masquerade as content
- use the same exact level-2 contract when extracting material sections

## Validation

- focused shape/order/duplicate regression matrix
- `go test -count=1 ./sdk/agent/compaction`
- `go test -race -count=1 ./sdk/agent/compaction`
- `go test -count=1 ./...`
- `go vet ./sdk/agent/compaction`
- `git diff --check`

Closes #59
