### PR TITLE
fix(sandbox): keep WebFetch redirects within the confirmed origin

### DIFF
--- a/agent_docs/tools-and-sandbox.md
+++ b/agent_docs/tools-and-sandbox.md
@@ -162,6 +162,11 @@ provider-facing schemas, metadata propagation, and sandbox safety gates.
 ## Confirmation-Gated Operations
 - Network fetch confirmation (`sdk/tools/sandbox/sandbox.go:377`, `sdk/tools/sandbox/sandbox.go:411`)
 - `webfetch` now reports response-body read failures with explicit partial-body diagnostics instead of silently returning incomplete content (`sdk/tools/sandbox/sandbox.go:446`)
+- `webfetch` follows redirects only within the confirmed URL origin (scheme,
+  host, and effective port). An origin-changing redirect fails before target
+  DNS lookup or connection and tells the caller to request the target URL
+  directly for a new confirmation; embedded URL userinfo is rejected without
+  echoing credential values (`sdk/tools/sandbox/sandbox_webfetch.go`).
 - Shell command confirmation and timeout-guarded execution (`sdk/tools/sandbox/sandbox.go:558`, `sdk/tools/sandbox/sandbox.go:572`)
 - Write/edit/multiedit/apply_patch confirmations with diff context (`sdk/tools/sandbox/sandbox.go:887`, `sdk/tools/sandbox/sandbox.go:938`, `sdk/tools/sandbox/sandbox.go:1006`, `sdk/tools/sandbox/sandbox.go:1083`)
 

--- a/sdk/tools/sandbox/sandbox_test.go
+++ b/sdk/tools/sandbox/sandbox_test.go
@@ -1798,7 +1798,12 @@ func TestWebfetchToolBlocksPrivateDestination(t *testing.T) {
 }
 
 func TestWebfetchToolBlocksRedirectToPrivateDestination(t *testing.T) {
-	useSandboxPublicWebfetchResolver(t)
+	useSandboxWebfetchResolver(t, func(_ context.Context, host string) ([]net.IPAddr, error) {
+		if host == "public.test" {
+			return []net.IPAddr{{IP: net.ParseIP("10.20.30.40")}}, nil
+		}
+		return nil, fmt.Errorf("lookup %s: no such host", host)
+	})
 
 	origDo := webfetchDoRequest
 	var calls int
@@ -1807,7 +1812,7 @@ func TestWebfetchToolBlocksRedirectToPrivateDestination(t *testing.T) {
 		if calls > 1 {
 			t.Fatalf("redirect request should not run for blocked private destination")
 		}
-		redirectRequest, requestErr := http.NewRequestWithContext(r.Context(), http.MethodGet, "http://internal.test/private", nil)
+		redirectRequest, requestErr := http.NewRequestWithContext(r.Context(), http.MethodGet, "http://public.test/private", nil)
 		if requestErr != nil {
 			return nil, requestErr
 		}

--- a/sdk/tools/sandbox/sandbox_webfetch.go
+++ b/sdk/tools/sandbox/sandbox_webfetch.go
@@ -119,6 +119,17 @@ func webfetchTool() tools.Tool {
 			if req == nil || req.URL == nil {
 				return fmt.Errorf("invalid redirect target")
 			}
+			if len(via) == 0 || via[len(via)-1] == nil || via[len(via)-1].URL == nil {
+				return fmt.Errorf("invalid redirect source")
+			}
+			previous := via[len(via)-1].URL
+			if !sameWebfetchOrigin(previous, req.URL) {
+				return fmt.Errorf(
+					"redirect target changes origin from %s to %s; retry the target URL directly so the new origin is confirmed",
+					webfetchOriginLabel(previous),
+					webfetchOriginLabel(req.URL),
+				)
+			}
 			return validateWebfetchDestinationURL(req.Context(), req.URL, "redirect target")
 		}
 		req, err := http.NewRequestWithContext(ctx, method, rawURL, nil)
@@ -208,6 +219,9 @@ func validateWebfetchPreConfirmationURL(target *url.URL, stage string) error {
 	if target == nil {
 		return fmt.Errorf("invalid url: missing host")
 	}
+	if target.User != nil {
+		return fmt.Errorf("%s must not include embedded URL credentials; remove userinfo and retry with an explicitly confirmed header", stage)
+	}
 	host := strings.TrimSpace(target.Hostname())
 	if host == "" {
 		return fmt.Errorf("invalid url: missing host")
@@ -220,10 +234,52 @@ func validateWebfetchPreConfirmationURL(target *url.URL, stage string) error {
 	return nil
 }
 
+func sameWebfetchOrigin(left, right *url.URL) bool {
+	if left == nil || right == nil {
+		return false
+	}
+	return strings.EqualFold(strings.TrimSpace(left.Scheme), strings.TrimSpace(right.Scheme)) &&
+		strings.EqualFold(strings.TrimSpace(left.Hostname()), strings.TrimSpace(right.Hostname())) &&
+		webfetchEffectivePort(left) == webfetchEffectivePort(right)
+}
+
+func webfetchEffectivePort(target *url.URL) string {
+	if target == nil {
+		return ""
+	}
+	if port := strings.TrimSpace(target.Port()); port != "" {
+		return port
+	}
+	switch strings.ToLower(strings.TrimSpace(target.Scheme)) {
+	case "http":
+		return "80"
+	case "https":
+		return "443"
+	default:
+		return ""
+	}
+}
+
+func webfetchOriginLabel(target *url.URL) string {
+	if target == nil {
+		return "(invalid origin)"
+	}
+	scheme := strings.ToLower(strings.TrimSpace(target.Scheme))
+	host := strings.ToLower(strings.TrimSpace(target.Hostname()))
+	port := webfetchEffectivePort(target)
+	if host == "" || port == "" {
+		return "(invalid origin)"
+	}
+	return scheme + "://" + net.JoinHostPort(host, port)
+}
+
 // validateWebfetchDestinationURL validates that a URL destination is safe.
 func validateWebfetchDestinationURL(ctx context.Context, target *url.URL, stage string) error {
 	if target == nil {
 		return fmt.Errorf("invalid url: missing host")
+	}
+	if target.User != nil {
+		return fmt.Errorf("%s must not include embedded URL credentials", stage)
 	}
 	host := strings.TrimSpace(target.Hostname())
 	if host == "" {

--- a/sdk/tools/sandbox/sandbox_webfetch.go
+++ b/sdk/tools/sandbox/sandbox_webfetch.go
@@ -115,23 +115,26 @@ func webfetchTool() tools.Tool {
 		hc := newWebfetchHTTPClient(time.Duration(timeout) * time.Second)
 		hc.CheckRedirect = func(req *http.Request, via []*http.Request) error {
 			if len(via) >= webfetchMaxRedirects {
-				return fmt.Errorf("stopped after %d redirects", webfetchMaxRedirects)
+				return newWebfetchSafeRequestDiagnostic(fmt.Errorf("stopped after %d redirects", webfetchMaxRedirects))
 			}
 			if req == nil || req.URL == nil {
-				return fmt.Errorf("invalid redirect target")
+				return newWebfetchSafeRequestDiagnostic(errors.New("invalid redirect target"))
 			}
 			if len(via) == 0 || via[len(via)-1] == nil || via[len(via)-1].URL == nil {
-				return fmt.Errorf("invalid redirect source")
+				return newWebfetchSafeRequestDiagnostic(errors.New("invalid redirect source"))
 			}
 			previous := via[len(via)-1].URL
 			if !sameWebfetchOrigin(previous, req.URL) {
-				return fmt.Errorf(
+				return newWebfetchSafeRequestDiagnostic(fmt.Errorf(
 					"redirect target changes origin from %s to %s; retry the target URL directly so the new origin is confirmed",
 					webfetchOriginLabel(previous),
 					webfetchOriginLabel(req.URL),
-				)
+				))
 			}
-			return validateWebfetchDestinationURL(req.Context(), req.URL, "redirect target")
+			if err := validateWebfetchDestinationURL(req.Context(), req.URL, "redirect target"); err != nil {
+				return newWebfetchSafeRequestDiagnostic(err)
+			}
+			return nil
 		}
 		req, err := http.NewRequestWithContext(ctx, method, rawURL, nil)
 		if err != nil {
@@ -197,11 +200,11 @@ func newWebfetchHTTPClient(timeout time.Duration) *http.Client {
 func dialValidatedWebfetchDestination(ctx context.Context, network, address string) (net.Conn, error) {
 	host, port, err := net.SplitHostPort(address)
 	if err != nil {
-		return nil, fmt.Errorf("invalid webfetch dial address %q: %w", address, err)
+		return nil, newWebfetchSafeRequestDiagnostic(fmt.Errorf("invalid webfetch dial address: %w", err))
 	}
 	addrs, err := resolveAndValidateWebfetchHost(ctx, host, "socket target")
 	if err != nil {
-		return nil, err
+		return nil, newWebfetchSafeRequestDiagnostic(err)
 	}
 	var dialErrors []string
 	for _, ip := range addrs {
@@ -211,7 +214,7 @@ func dialValidatedWebfetchDestination(ctx context.Context, network, address stri
 		}
 		dialErrors = append(dialErrors, dialErr.Error())
 	}
-	return nil, fmt.Errorf("cannot connect to validated socket target %q: %s", host, strings.Join(dialErrors, "; "))
+	return nil, newWebfetchSafeRequestDiagnostic(fmt.Errorf("cannot connect to validated socket target %q: %s", host, strings.Join(dialErrors, "; ")))
 }
 
 // validateWebfetchPreConfirmationURL performs only local checks. A hostname is
@@ -286,7 +289,47 @@ func sanitizeWebfetchRequestError(err error) error {
 	if parsed, parseErr := url.Parse(urlErr.URL); parseErr == nil {
 		safeURL = webfetchOriginLabel(parsed)
 	}
-	return &url.Error{Op: urlErr.Op, URL: safeURL, Err: urlErr.Err}
+	var cause error = errors.New("HTTP request failed")
+	var safeDiagnostic *webfetchSafeRequestDiagnostic
+	if errors.As(urlErr.Err, &safeDiagnostic) && safeDiagnostic != nil {
+		cause = safeDiagnostic
+	} else if errors.Is(urlErr.Err, context.Canceled) {
+		cause = context.Canceled
+	} else if errors.Is(urlErr.Err, context.DeadlineExceeded) {
+		cause = context.DeadlineExceeded
+	} else {
+		var netErr net.Error
+		if errors.As(urlErr.Err, &netErr) && netErr.Timeout() {
+			cause = errors.New("network request timed out")
+		}
+	}
+	return &url.Error{Op: urlErr.Op, URL: safeURL, Err: cause}
+}
+
+// webfetchSafeRequestDiagnostic marks errors built exclusively from
+// destination-validation state controlled by this package. net/http may place
+// an untrusted Location header verbatim in a nested *url.Error; only marked
+// diagnostics are safe to expose after Client.Do returns.
+type webfetchSafeRequestDiagnostic struct {
+	err error
+}
+
+func newWebfetchSafeRequestDiagnostic(err error) *webfetchSafeRequestDiagnostic {
+	return &webfetchSafeRequestDiagnostic{err: err}
+}
+
+func (e *webfetchSafeRequestDiagnostic) Error() string {
+	if e == nil || e.err == nil {
+		return "HTTP request failed"
+	}
+	return e.err.Error()
+}
+
+func (e *webfetchSafeRequestDiagnostic) Unwrap() error {
+	if e == nil {
+		return nil
+	}
+	return e.err
 }
 
 // validateWebfetchDestinationURL validates that a URL destination is safe.

--- a/sdk/tools/sandbox/sandbox_webfetch.go
+++ b/sdk/tools/sandbox/sandbox_webfetch.go
@@ -2,6 +2,7 @@ package sandbox
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -145,7 +146,7 @@ func webfetchTool() tools.Tool {
 		}
 		resp, err := webfetchDoRequest(hc, req)
 		if err != nil {
-			return "", fmt.Errorf("request failed: %w", err)
+			return "", fmt.Errorf("request failed: %w", sanitizeWebfetchRequestError(err))
 		}
 		defer func() { _ = resp.Body.Close() }()
 
@@ -271,6 +272,21 @@ func webfetchOriginLabel(target *url.URL) string {
 		return "(invalid origin)"
 	}
 	return scheme + "://" + net.JoinHostPort(host, port)
+}
+
+func sanitizeWebfetchRequestError(err error) error {
+	if err == nil {
+		return nil
+	}
+	var urlErr *url.Error
+	if !errors.As(err, &urlErr) || urlErr == nil {
+		return err
+	}
+	safeURL := "(redacted URL)"
+	if parsed, parseErr := url.Parse(urlErr.URL); parseErr == nil {
+		safeURL = webfetchOriginLabel(parsed)
+	}
+	return &url.Error{Op: urlErr.Op, URL: safeURL, Err: urlErr.Err}
 }
 
 // validateWebfetchDestinationURL validates that a URL destination is safe.

--- a/sdk/tools/sandbox/sandbox_webfetch.go
+++ b/sdk/tools/sandbox/sandbox_webfetch.go
@@ -300,7 +300,7 @@ func sanitizeWebfetchRequestError(err error) error {
 	} else {
 		var netErr net.Error
 		if errors.As(urlErr.Err, &netErr) && netErr.Timeout() {
-			cause = errors.New("network request timed out")
+			cause = webfetchRequestTimeoutError{}
 		}
 	}
 	return &url.Error{Op: urlErr.Op, URL: safeURL, Err: cause}
@@ -313,6 +313,12 @@ func sanitizeWebfetchRequestError(err error) error {
 type webfetchSafeRequestDiagnostic struct {
 	err error
 }
+
+type webfetchRequestTimeoutError struct{}
+
+func (webfetchRequestTimeoutError) Error() string   { return "network request timed out" }
+func (webfetchRequestTimeoutError) Timeout() bool   { return true }
+func (webfetchRequestTimeoutError) Temporary() bool { return true }
 
 func newWebfetchSafeRequestDiagnostic(err error) *webfetchSafeRequestDiagnostic {
 	return &webfetchSafeRequestDiagnostic{err: err}

--- a/sdk/tools/sandbox/sandbox_webfetch_redirect_origin_test.go
+++ b/sdk/tools/sandbox/sandbox_webfetch_redirect_origin_test.go
@@ -1,0 +1,137 @@
+package sandbox
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net"
+	"net/http"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/timwhitez/agent-sdk-golang/sdk/tools"
+)
+
+func TestSameWebfetchOrigin(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name  string
+		left  string
+		right string
+		want  bool
+	}{
+		{name: "same origin path", left: "https://example.test/start", right: "https://example.test/next", want: true},
+		{name: "explicit default port", left: "https://example.test/start", right: "https://example.test:443/next", want: true},
+		{name: "different host", left: "https://example.test/start", right: "https://other.test/next", want: false},
+		{name: "different port", left: "https://example.test:443/start", right: "https://example.test:8443/next", want: false},
+		{name: "scheme downgrade", left: "https://example.test/start", right: "http://example.test/next", want: false},
+		{name: "scheme upgrade", left: "http://example.test/start", right: "https://example.test/next", want: false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			left, err := url.Parse(tc.left)
+			if err != nil {
+				t.Fatal(err)
+			}
+			right, err := url.Parse(tc.right)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got := sameWebfetchOrigin(left, right); got != tc.want {
+				t.Fatalf("sameWebfetchOrigin(%q, %q) = %v, want %v", tc.left, tc.right, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestWebfetchToolRejectsCrossOriginRedirectBeforeLookupOrCredentialForward(t *testing.T) {
+	const secret = "redirect-secret-sentinel"
+	useSandboxWebfetchResolver(t, func(_ context.Context, host string) ([]net.IPAddr, error) {
+		if host == "other.test" {
+			t.Fatalf("cross-origin redirect performed DNS lookup before new confirmation")
+		}
+		return []net.IPAddr{{IP: net.ParseIP("93.184.216.34")}}, nil
+	})
+
+	origDo := webfetchDoRequest
+	calls := 0
+	webfetchDoRequest = func(client *http.Client, initial *http.Request) (*http.Response, error) {
+		calls++
+		if initial.Header.Get("X-API-Key") != secret || initial.Header.Get("Authorization") != "Bearer "+secret {
+			return nil, errors.New("initial credential headers missing")
+		}
+		redirect, err := http.NewRequestWithContext(initial.Context(), http.MethodGet, "https://other.test/next", nil)
+		if err != nil {
+			return nil, err
+		}
+		redirect.Header = initial.Header.Clone()
+		if client.CheckRedirect == nil {
+			return nil, errors.New("WebFetch client has no redirect policy")
+		}
+		return nil, client.CheckRedirect(redirect, []*http.Request{initial})
+	}
+	t.Cleanup(func() { webfetchDoRequest = origDo })
+
+	deps := tools.NewContainer()
+	tools.Provide(deps, ConfirmKey, func(context.Context) (Confirmer, error) { return allowConfirmer{}, nil })
+	result, err := webfetchTool().Execute(context.Background(), `{"url":"https://example.test/start","headers":{"X-API-Key":"`+secret+`","Authorization":"Bearer `+secret+`"}}`, deps)
+	if err == nil {
+		t.Fatalf("cross-origin redirect unexpectedly succeeded: %q", result.PlainText())
+	}
+	if calls != 1 {
+		t.Fatalf("outbound call count = %d, want one", calls)
+	}
+	message := err.Error()
+	if !strings.Contains(message, "changes origin") || !strings.Contains(message, "directly") {
+		t.Fatalf("redirect error is not actionable: %q", message)
+	}
+	if strings.Contains(message, secret) {
+		t.Fatalf("redirect error exposed credential value: %q", message)
+	}
+}
+
+func TestWebfetchToolAllowsSameOriginRedirect(t *testing.T) {
+	useSandboxPublicWebfetchResolver(t)
+	origDo := webfetchDoRequest
+	webfetchDoRequest = func(client *http.Client, initial *http.Request) (*http.Response, error) {
+		redirect, err := http.NewRequestWithContext(initial.Context(), http.MethodGet, "https://example.test/next", nil)
+		if err != nil {
+			return nil, err
+		}
+		redirect.Header = initial.Header.Clone()
+		if err := client.CheckRedirect(redirect, []*http.Request{initial}); err != nil {
+			return nil, err
+		}
+		return &http.Response{
+			Status:     "200 OK",
+			StatusCode: http.StatusOK,
+			Header:     make(http.Header),
+			Body:       io.NopCloser(strings.NewReader("ok")),
+			Request:    redirect,
+		}, nil
+	}
+	t.Cleanup(func() { webfetchDoRequest = origDo })
+
+	deps := tools.NewContainer()
+	tools.Provide(deps, ConfirmKey, func(context.Context) (Confirmer, error) { return allowConfirmer{}, nil })
+	result, err := webfetchTool().Execute(context.Background(), `{"url":"https://example.test/start","headers":{"X-Trace":"ok"}}`, deps)
+	if err != nil {
+		t.Fatalf("same-origin redirect: %v", err)
+	}
+	if !strings.Contains(result.PlainText(), "ok") {
+		t.Fatalf("same-origin response = %q", result.PlainText())
+	}
+}
+
+func TestWebfetchRejectsEmbeddedURLCredentialsWithoutEchoingThem(t *testing.T) {
+	deps := tools.NewContainer()
+	tools.Provide(deps, ConfirmKey, func(context.Context) (Confirmer, error) { return allowConfirmer{}, nil })
+	result, err := webfetchTool().Execute(context.Background(), `{"url":"https://audit-user:audit-password@example.test/private"}`, deps)
+	if err == nil {
+		t.Fatalf("embedded credentials unexpectedly accepted: %q", result.PlainText())
+	}
+	if strings.Contains(err.Error(), "audit-user") || strings.Contains(err.Error(), "audit-password") {
+		t.Fatalf("embedded credential error echoed userinfo: %q", err.Error())
+	}
+}

--- a/sdk/tools/sandbox/sandbox_webfetch_redirect_origin_test.go
+++ b/sdk/tools/sandbox/sandbox_webfetch_redirect_origin_test.go
@@ -145,6 +145,7 @@ func TestWebfetchRedirectErrorSanitizesCredentialBearingLocation(t *testing.T) {
 	}{
 		{name: "cross origin", location: "https://audit-user:audit-password@other.test/private?token=audit-query-secret", wantOrigin: "other.test:443"},
 		{name: "same origin userinfo", location: "https://audit-user:audit-password@example.test/private?token=audit-query-secret", wantOrigin: "example.test:443"},
+		{name: "malformed location", location: "https://audit-user:audit-password@other.test/%zz?token=audit-query-secret", wantOrigin: "example.test:443"},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {

--- a/sdk/tools/sandbox/sandbox_webfetch_redirect_origin_test.go
+++ b/sdk/tools/sandbox/sandbox_webfetch_redirect_origin_test.go
@@ -135,3 +135,54 @@ func TestWebfetchRejectsEmbeddedURLCredentialsWithoutEchoingThem(t *testing.T) {
 		t.Fatalf("embedded credential error echoed userinfo: %q", err.Error())
 	}
 }
+
+func TestWebfetchRedirectErrorSanitizesCredentialBearingLocation(t *testing.T) {
+	useSandboxPublicWebfetchResolver(t)
+	tests := []struct {
+		name       string
+		location   string
+		wantOrigin string
+	}{
+		{name: "cross origin", location: "https://audit-user:audit-password@other.test/private?token=audit-query-secret", wantOrigin: "other.test:443"},
+		{name: "same origin userinfo", location: "https://audit-user:audit-password@example.test/private?token=audit-query-secret", wantOrigin: "example.test:443"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			origDo := webfetchDoRequest
+			webfetchDoRequest = func(client *http.Client, initial *http.Request) (*http.Response, error) {
+				calls := 0
+				client.Transport = roundTripFunc(func(request *http.Request) (*http.Response, error) {
+					calls++
+					if calls > 1 {
+						t.Fatal("credential-bearing redirect reached a second transport request")
+					}
+					return &http.Response{
+						Status:     "302 Found",
+						StatusCode: http.StatusFound,
+						Header:     http.Header{"Location": []string{tc.location}},
+						Body:       io.NopCloser(strings.NewReader("")),
+						Request:    request,
+					}, nil
+				})
+				return client.Do(initial)
+			}
+			t.Cleanup(func() { webfetchDoRequest = origDo })
+
+			deps := tools.NewContainer()
+			tools.Provide(deps, ConfirmKey, func(context.Context) (Confirmer, error) { return allowConfirmer{}, nil })
+			result, err := webfetchTool().Execute(context.Background(), `{"url":"https://example.test/start"}`, deps)
+			if err == nil {
+				t.Fatalf("credential-bearing redirect unexpectedly succeeded: %q", result.PlainText())
+			}
+			combined := err.Error() + "\n" + result.PlainText()
+			for _, secret := range []string{"audit-user", "audit-password", "audit-query-secret", "/private"} {
+				if strings.Contains(combined, secret) {
+					t.Fatalf("redirect diagnostics leaked %q: %q", secret, combined)
+				}
+			}
+			if !strings.Contains(combined, tc.wantOrigin) {
+				t.Fatalf("sanitized diagnostics lost actionable origin: %q", combined)
+			}
+		})
+	}
+}

--- a/sdk/tools/sandbox/sandbox_webfetch_redirect_origin_test.go
+++ b/sdk/tools/sandbox/sandbox_webfetch_redirect_origin_test.go
@@ -187,3 +187,30 @@ func TestWebfetchRedirectErrorSanitizesCredentialBearingLocation(t *testing.T) {
 		})
 	}
 }
+
+func TestSanitizeWebfetchRequestErrorPreservesTimeoutSemanticsWithoutDetails(t *testing.T) {
+	const secret = "audit-timeout-secret"
+	err := sanitizeWebfetchRequestError(&url.Error{
+		Op:  "Get",
+		URL: "https://example.test/private?token=" + secret,
+		Err: secretWebfetchTimeoutError{message: secret},
+	})
+	var sanitized *url.Error
+	if !errors.As(err, &sanitized) {
+		t.Fatalf("sanitized error = %T, want *url.Error", err)
+	}
+	if !sanitized.Timeout() {
+		t.Fatalf("sanitized timeout error lost Timeout semantics: %v", sanitized)
+	}
+	if strings.Contains(sanitized.Error(), secret) || strings.Contains(sanitized.Error(), "/private") {
+		t.Fatalf("sanitized timeout error leaked request details: %q", sanitized.Error())
+	}
+}
+
+type secretWebfetchTimeoutError struct {
+	message string
+}
+
+func (e secretWebfetchTimeoutError) Error() string { return e.message }
+func (secretWebfetchTimeoutError) Timeout() bool   { return true }
+func (secretWebfetchTimeoutError) Temporary() bool { return true }


### PR DESCRIPTION
## Summary

- reject origin-changing WebFetch redirects before target DNS lookup or connection
- define origin by scheme, hostname, and effective port
- keep same-origin path redirects and destination IP validation working
- reject embedded URL userinfo without echoing credential values
- document the new confirmation boundary

## Validation

- cross-host custom/API-key/Authorization redirect rejection before lookup
- same-host/different-port, downgrade, upgrade, and same-origin matrix
- same-origin redirect success and private destination regression
- embedded URL credential negative test
- `go test -count=1 ./sdk/tools/sandbox`
- `go test -race -count=1 ./sdk/tools/sandbox`
- `go test -count=1 ./...`
- `go vet ./sdk/tools/sandbox`
- `git diff --check`

Closes #58
