### PR TITLE
fix(openai): keep bearer credentials on the configured origin

### DIFF
--- a/agent_docs/providers.md
+++ b/agent_docs/providers.md
@@ -100,6 +100,15 @@ stream normalization, and response metadata behavior.
 - Anthropic populates IDs in both sync and streaming paths (`sdk/llm/anthropic/client.go:718`, `sdk/llm/anthropic/client.go:1219`)
 - OpenAI Chat completions currently do not expose response IDs in parsed completion objects (`sdk/llm/openai/chat.go:904`)
 
+## OpenAI redirect credential boundary
+
+OpenAI Chat and Responses clients, in buffered and streaming modes, follow
+only same-origin redirects. Origin includes scheme, host, and effective port;
+HTTPS-to-HTTP downgrades are rejected before a redirected request is sent.
+Caller-provided redirect callbacks run only for an initially allowed target,
+and the target URL is checked again after the callback returns so it cannot
+move bearer credentials onto another origin.
+
 ## Usage and Optional Cost Calculation
 - Providers populate a versioned `Usage` contract; downstream cost calculation is optional (`sdk/llm/types.go`, `sdk/llm/usage.go`, `sdk/tokens/cost.go:80`).
 - Under `prompt_tokens_semantics=total_input_v1`, `PromptTokens` is the complete effective input size. `PromptCachedTokens`, `PromptCacheCreationTokens`, `PromptImageTokens`, and `PromptUncachedTokens` are breakdown fields and consumers must not add them to `PromptTokens` again.

--- a/agent_docs/providers.md
+++ b/agent_docs/providers.md
@@ -107,7 +107,9 @@ only same-origin redirects. Origin includes scheme, host, and effective port;
 HTTPS-to-HTTP downgrades are rejected before a redirected request is sent.
 Caller-provided redirect callbacks run only for an initially allowed target,
 and the target URL is checked again after the callback returns so it cannot
-move bearer credentials onto another origin.
+move bearer credentials onto another origin. Redirect-policy and malformed
+Location failures are fail-fast and their diagnostics never echo URL
+userinfo, path, or query data.
 
 ## Usage and Optional Cost Calculation
 - Providers populate a versioned `Usage` contract; downstream cost calculation is optional (`sdk/llm/types.go`, `sdk/llm/usage.go`, `sdk/tokens/cost.go:80`).

--- a/sdk/llm/openai/chat.go
+++ b/sdk/llm/openai/chat.go
@@ -123,6 +123,7 @@ func (c *ChatClient) Invoke(ctx context.Context, req llm.InvokeRequest) (*llm.Co
 		}
 
 		resp, err := client.Do(httpReq)
+		err = sanitizeOpenAIHTTPError(err)
 		if err == nil {
 			data, readErr := readResponseBodyLimited(resp.Body, endpoint)
 			if readErr != nil {
@@ -256,6 +257,7 @@ func (c *ChatClient) InvokeStream(ctx context.Context, req llm.InvokeRequest) (<
 			}
 
 			resp, err := client.Do(httpReq)
+			err = sanitizeOpenAIHTTPError(err)
 			if err != nil {
 				if ctxErr := ctx.Err(); ctxErr != nil {
 					out <- llm.StreamErrorEvent{Err: ctxErr}
@@ -593,9 +595,9 @@ func streamHTTPClient(base *http.Client) *http.Client {
 
 func (c *ChatClient) httpClient() *http.Client {
 	if c.HTTPClient != nil {
-		return c.HTTPClient
+		return redirectSafeOpenAIHTTPClient(c.HTTPClient)
 	}
-	return &http.Client{Timeout: 60 * time.Second}
+	return redirectSafeOpenAIHTTPClient(&http.Client{Timeout: 60 * time.Second})
 }
 
 func (c *ChatClient) baseURL() string {

--- a/sdk/llm/openai/chat.go
+++ b/sdk/llm/openai/chat.go
@@ -934,6 +934,10 @@ func isRetryableNetErr(err error) bool {
 	if err == nil {
 		return false
 	}
+	var retryDecision openAIRetryDecision
+	if errors.As(err, &retryDecision) {
+		return retryDecision.openAIRetryable()
+	}
 	var timeoutErr interface{ Timeout() bool }
 	if errors.As(err, &timeoutErr) && timeoutErr.Timeout() {
 		return true

--- a/sdk/llm/openai/redirect.go
+++ b/sdk/llm/openai/redirect.go
@@ -1,6 +1,7 @@
 package openai
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"net"
@@ -16,6 +17,55 @@ type openAIOrigin struct {
 	host   string
 	port   string
 }
+
+type openAIRetryDecision interface {
+	openAIRetryable() bool
+}
+
+type openAIRedirectPolicyError struct {
+	err error
+}
+
+func newOpenAIRedirectPolicyError(err error) *openAIRedirectPolicyError {
+	return &openAIRedirectPolicyError{err: err}
+}
+
+func (e *openAIRedirectPolicyError) Error() string {
+	if e == nil || e.err == nil {
+		return "openai: redirect rejected"
+	}
+	return e.err.Error()
+}
+
+func (e *openAIRedirectPolicyError) Unwrap() error {
+	if e == nil {
+		return nil
+	}
+	return e.err
+}
+
+func (*openAIRedirectPolicyError) openAIRetryable() bool { return false }
+
+type openAISanitizedRequestError struct{}
+
+func (openAISanitizedRequestError) Error() string         { return "HTTP request failed" }
+func (openAISanitizedRequestError) openAIRetryable() bool { return false }
+
+type openAISanitizedNetworkError struct {
+	retryable bool
+}
+
+func (openAISanitizedNetworkError) Error() string { return "network request failed" }
+func (e openAISanitizedNetworkError) openAIRetryable() bool {
+	return e.retryable
+}
+
+type openAISanitizedTimeoutError struct{}
+
+func (openAISanitizedTimeoutError) Error() string         { return "network request timed out" }
+func (openAISanitizedTimeoutError) Timeout() bool         { return true }
+func (openAISanitizedTimeoutError) Temporary() bool       { return true }
+func (openAISanitizedTimeoutError) openAIRetryable() bool { return true }
 
 func originForOpenAIURL(value *url.URL) (openAIOrigin, error) {
 	if value == nil {
@@ -49,6 +99,9 @@ func validateOpenAIRedirectTarget(origin openAIOrigin, target *url.URL) error {
 	if origin != destination {
 		return fmt.Errorf("openai: refusing cross-origin redirect to %s://%s:%s", destination.scheme, destination.host, destination.port)
 	}
+	if target.User != nil {
+		return errors.New("openai: refusing redirect with embedded URL credentials")
+	}
 	return nil
 }
 
@@ -72,7 +125,38 @@ func sanitizeOpenAIHTTPError(err error) error {
 	if parsed, parseErr := url.Parse(urlErr.URL); parseErr == nil {
 		safeURL = openAIOriginLabel(parsed)
 	}
-	return &url.Error{Op: urlErr.Op, URL: safeURL, Err: urlErr.Err}
+	var cause error = openAISanitizedRequestError{}
+	var policyErr *openAIRedirectPolicyError
+	if errors.As(urlErr.Err, &policyErr) && policyErr != nil {
+		cause = policyErr
+	} else if errors.Is(urlErr.Err, context.Canceled) {
+		cause = context.Canceled
+	} else if errors.Is(urlErr.Err, context.DeadlineExceeded) {
+		cause = context.DeadlineExceeded
+	} else {
+		var netErr net.Error
+		if errors.As(urlErr.Err, &netErr) {
+			if netErr.Timeout() {
+				cause = openAISanitizedTimeoutError{}
+			} else {
+				cause = openAISanitizedNetworkError{retryable: retryableOpenAINetworkError(urlErr.Err)}
+			}
+		}
+	}
+	return &url.Error{Op: urlErr.Op, URL: safeURL, Err: cause}
+}
+
+func retryableOpenAINetworkError(err error) bool {
+	var dnsErr *net.DNSError
+	if errors.As(err, &dnsErr) && dnsErr != nil && dnsErr.IsNotFound {
+		return false
+	}
+	var opErr *net.OpError
+	if errors.As(err, &opErr) && opErr != nil {
+		return true
+	}
+	var temporary interface{ Temporary() bool }
+	return errors.As(err, &temporary) && temporary.Temporary()
 }
 
 // redirectSafeOpenAIHTTPClient clones base and installs a mandatory policy
@@ -87,27 +171,27 @@ func redirectSafeOpenAIHTTPClient(base *http.Client) *http.Client {
 	callerCheck := base.CheckRedirect
 	cloned.CheckRedirect = func(req *http.Request, via []*http.Request) error {
 		if len(via) == 0 || via[0] == nil || via[0].URL == nil {
-			return fmt.Errorf("openai: redirect is missing its origin request")
+			return newOpenAIRedirectPolicyError(errors.New("openai: redirect is missing its origin request"))
 		}
 		if len(via) >= openAIMaxRedirects {
-			return fmt.Errorf("openai: stopped after %d redirects", openAIMaxRedirects)
+			return newOpenAIRedirectPolicyError(fmt.Errorf("openai: stopped after %d redirects", openAIMaxRedirects))
 		}
 		origin, err := originForOpenAIURL(via[0].URL)
 		if err != nil {
-			return err
+			return newOpenAIRedirectPolicyError(err)
 		}
 		if req == nil {
-			return fmt.Errorf("openai: redirect request is missing")
+			return newOpenAIRedirectPolicyError(errors.New("openai: redirect request is missing"))
 		}
 		if err := validateOpenAIRedirectTarget(origin, req.URL); err != nil {
-			return err
+			return newOpenAIRedirectPolicyError(err)
 		}
 		if callerCheck != nil {
 			if err := callerCheck(req, via); err != nil {
 				return err
 			}
 			if err := validateOpenAIRedirectTarget(origin, req.URL); err != nil {
-				return err
+				return newOpenAIRedirectPolicyError(err)
 			}
 		}
 		return nil

--- a/sdk/llm/openai/redirect.go
+++ b/sdk/llm/openai/redirect.go
@@ -1,0 +1,116 @@
+package openai
+
+import (
+	"errors"
+	"fmt"
+	"net"
+	"net/http"
+	"net/url"
+	"strings"
+)
+
+const openAIMaxRedirects = 10
+
+type openAIOrigin struct {
+	scheme string
+	host   string
+	port   string
+}
+
+func originForOpenAIURL(value *url.URL) (openAIOrigin, error) {
+	if value == nil {
+		return openAIOrigin{}, fmt.Errorf("openai: redirect URL is missing")
+	}
+	scheme := strings.ToLower(strings.TrimSpace(value.Scheme))
+	host := strings.ToLower(strings.TrimSpace(value.Hostname()))
+	if scheme == "" || host == "" {
+		return openAIOrigin{}, fmt.Errorf("openai: redirect URL has no origin")
+	}
+	port := strings.TrimSpace(value.Port())
+	if port == "" {
+		switch scheme {
+		case "http":
+			port = "80"
+		case "https":
+			port = "443"
+		}
+	}
+	return openAIOrigin{scheme: scheme, host: host, port: port}, nil
+}
+
+func validateOpenAIRedirectTarget(origin openAIOrigin, target *url.URL) error {
+	destination, err := originForOpenAIURL(target)
+	if err != nil {
+		return err
+	}
+	if origin.scheme == "https" && destination.scheme != "https" {
+		return fmt.Errorf("openai: refusing HTTPS redirect downgrade to %s://%s:%s", destination.scheme, destination.host, destination.port)
+	}
+	if origin != destination {
+		return fmt.Errorf("openai: refusing cross-origin redirect to %s://%s:%s", destination.scheme, destination.host, destination.port)
+	}
+	return nil
+}
+
+func openAIOriginLabel(value *url.URL) string {
+	origin, err := originForOpenAIURL(value)
+	if err != nil {
+		return "(redacted URL)"
+	}
+	return origin.scheme + "://" + net.JoinHostPort(origin.host, origin.port)
+}
+
+func sanitizeOpenAIHTTPError(err error) error {
+	if err == nil {
+		return nil
+	}
+	var urlErr *url.Error
+	if !errors.As(err, &urlErr) || urlErr == nil {
+		return err
+	}
+	safeURL := "(redacted URL)"
+	if parsed, parseErr := url.Parse(urlErr.URL); parseErr == nil {
+		safeURL = openAIOriginLabel(parsed)
+	}
+	return &url.Error{Op: urlErr.Op, URL: safeURL, Err: urlErr.Err}
+}
+
+// redirectSafeOpenAIHTTPClient clones base and installs a mandatory policy
+// before any redirected request is sent. Allowed same-origin redirects still
+// invoke the caller callback, after which the target is checked again in case
+// that callback changed req.URL.
+func redirectSafeOpenAIHTTPClient(base *http.Client) *http.Client {
+	if base == nil {
+		base = &http.Client{}
+	}
+	cloned := *base
+	callerCheck := base.CheckRedirect
+	cloned.CheckRedirect = func(req *http.Request, via []*http.Request) error {
+		if len(via) == 0 || via[0] == nil || via[0].URL == nil {
+			return fmt.Errorf("openai: redirect is missing its origin request")
+		}
+		if len(via) >= openAIMaxRedirects {
+			return fmt.Errorf("openai: stopped after %d redirects", openAIMaxRedirects)
+		}
+		origin, err := originForOpenAIURL(via[0].URL)
+		if err != nil {
+			return err
+		}
+		if req == nil {
+			return fmt.Errorf("openai: redirect request is missing")
+		}
+		if err := validateOpenAIRedirectTarget(origin, req.URL); err != nil {
+			return err
+		}
+		if callerCheck != nil {
+			if err := callerCheck(req, via); err != nil {
+				return err
+			}
+			if err := validateOpenAIRedirectTarget(origin, req.URL); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+	return &cloned
+}

--- a/sdk/llm/openai/redirect_test.go
+++ b/sdk/llm/openai/redirect_test.go
@@ -1,0 +1,198 @@
+package openai
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/timwhitez/agent-sdk-golang/sdk/llm"
+)
+
+func openAIRedirectTestRequest() llm.InvokeRequest {
+	return llm.InvokeRequest{Messages: []llm.Message{llm.NewUserMessage("ping")}}
+}
+
+func invokeOpenAIRedirectTest(t *testing.T, provider string, streaming bool, baseURL, apiKey string) error {
+	t.Helper()
+	request := openAIRedirectTestRequest()
+	var model llm.ChatModel
+	switch provider {
+	case "chat":
+		model = &ChatClient{HTTPClient: &http.Client{Timeout: 2 * time.Second}, BaseURL: baseURL, APIKey: apiKey, ModelName: "test-model", MaxRetries: 1}
+	case "responses":
+		model = &ResponsesClient{HTTPClient: &http.Client{Timeout: 2 * time.Second}, BaseURL: baseURL, APIKey: apiKey, ModelName: "test-model", MaxRetries: 1}
+	default:
+		t.Fatalf("unknown provider %q", provider)
+	}
+	if !streaming {
+		_, err := model.Invoke(context.Background(), request)
+		return err
+	}
+	streamingModel, ok := model.(llm.StreamingChatModel)
+	if !ok {
+		t.Fatalf("provider %q is not streaming", provider)
+	}
+	events, err := streamingModel.InvokeStream(context.Background(), request)
+	if err != nil {
+		return err
+	}
+	for event := range events {
+		if failure, ok := event.(llm.StreamErrorEvent); ok {
+			return failure.AsError()
+		}
+	}
+	return nil
+}
+
+func TestOpenAIClientsRejectCrossOriginRedirectWithoutLeakingBearerToken(t *testing.T) {
+	for _, provider := range []string{"chat", "responses"} {
+		for _, streaming := range []bool{false, true} {
+			provider := provider
+			streaming := streaming
+			t.Run(provider+map[bool]string{false: "_buffered", true: "_streaming"}[streaming], func(t *testing.T) {
+				const secret = "redirect-bearer-sentinel"
+				var destinationCalls atomic.Int32
+				destination := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					destinationCalls.Add(1)
+					if got := r.Header.Get("Authorization"); got != "" {
+						t.Errorf("redirect destination received Authorization %q", got)
+					}
+					w.WriteHeader(http.StatusInternalServerError)
+				}))
+				defer destination.Close()
+				redirectTarget := strings.Replace(destination.URL, "://", "://audit-user:audit-password@", 1) + "/private?token=audit-query-secret"
+
+				redirector := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					http.Redirect(w, r, redirectTarget, http.StatusTemporaryRedirect)
+				}))
+				defer redirector.Close()
+
+				err := invokeOpenAIRedirectTest(t, provider, streaming, redirector.URL, secret)
+				if err == nil || !strings.Contains(err.Error(), "cross-origin redirect") {
+					t.Fatalf("redirect error = %v, want cross-origin rejection", err)
+				}
+				for _, credential := range []string{secret, "audit-user", "audit-password", "audit-query-secret", "/private"} {
+					if strings.Contains(err.Error(), credential) {
+						t.Fatalf("redirect error exposed %q: %v", credential, err)
+					}
+				}
+				if got := destinationCalls.Load(); got != 0 {
+					t.Fatalf("redirect destination received %d request(s)", got)
+				}
+			})
+		}
+	}
+}
+
+func TestOpenAIClientsAllowSameOriginRedirect(t *testing.T) {
+	for _, provider := range []string{"chat", "responses"} {
+		for _, streaming := range []bool{false, true} {
+			provider := provider
+			streaming := streaming
+			t.Run(provider+map[bool]string{false: "_buffered", true: "_streaming"}[streaming], func(t *testing.T) {
+				const secret = "same-origin-secret"
+				var server *httptest.Server
+				server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					if r.URL.Path != "/redirected" {
+						http.Redirect(w, r, server.URL+"/redirected", http.StatusTemporaryRedirect)
+						return
+					}
+					if got := r.Header.Get("Authorization"); got != "Bearer "+secret {
+						t.Errorf("same-origin Authorization = %q", got)
+					}
+					if streaming {
+						w.Header().Set("Content-Type", "text/event-stream")
+						if provider == "chat" {
+							_, _ = io.WriteString(w, "data: {\"choices\":[{\"delta\":{\"content\":\"ok\"},\"finish_reason\":\"stop\"}]}\n\ndata: [DONE]\n\n")
+						} else {
+							_, _ = io.WriteString(w, "data: {\"type\":\"response.output_text.delta\",\"delta\":\"ok\"}\n\ndata: [DONE]\n\n")
+						}
+						return
+					}
+					w.Header().Set("Content-Type", "application/json")
+					if provider == "chat" {
+						_, _ = io.WriteString(w, `{"id":"chat_1","choices":[{"message":{"role":"assistant","content":"ok"},"finish_reason":"stop"}]}`)
+					} else {
+						_, _ = io.WriteString(w, `{"id":"resp_1","status":"completed","output":[{"type":"message","role":"assistant","content":[{"type":"output_text","text":"ok"}]}]}`)
+					}
+				}))
+				defer server.Close()
+
+				if err := invokeOpenAIRedirectTest(t, provider, streaming, server.URL, secret); err != nil {
+					t.Fatalf("same-origin redirect: %v", err)
+				}
+			})
+		}
+	}
+}
+
+func TestRedirectSafeOpenAIHTTPClientComposesAndRechecksCallerCallback(t *testing.T) {
+	origin, _ := url.Parse("https://api.example.test/v1/responses")
+	sameOrigin, _ := url.Parse("https://api.example.test/v2/responses")
+	foreign, _ := url.Parse("https://attacker.example.test/steal")
+
+	called := false
+	base := &http.Client{CheckRedirect: func(req *http.Request, _ []*http.Request) error {
+		called = true
+		req.URL = foreign
+		return nil
+	}}
+	safe := redirectSafeOpenAIHTTPClient(base)
+	request := &http.Request{URL: sameOrigin}
+	err := safe.CheckRedirect(request, []*http.Request{{URL: origin}})
+	if !called {
+		t.Fatal("caller CheckRedirect was not invoked for same-origin target")
+	}
+	if err == nil || !strings.Contains(err.Error(), "cross-origin redirect") {
+		t.Fatalf("post-callback error = %v, want cross-origin rejection", err)
+	}
+	if base.CheckRedirect == nil {
+		t.Fatal("base client was mutated")
+	}
+}
+
+func TestRedirectSafeOpenAIHTTPClientRejectsHTTPSDowngrade(t *testing.T) {
+	origin, _ := url.Parse("https://api.example.test/v1/responses")
+	downgrade, _ := url.Parse("http://api.example.test/v1/responses")
+	safe := redirectSafeOpenAIHTTPClient(&http.Client{})
+	err := safe.CheckRedirect(&http.Request{URL: downgrade}, []*http.Request{{URL: origin}})
+	if err == nil || !strings.Contains(err.Error(), "HTTPS redirect downgrade") {
+		t.Fatalf("downgrade error = %v", err)
+	}
+}
+
+func TestRedirectSafeOpenAIHTTPClientPreservesCallerStopDecision(t *testing.T) {
+	origin, _ := url.Parse("https://api.example.test/v1/responses")
+	target, _ := url.Parse("https://api.example.test/v2/responses")
+	safe := redirectSafeOpenAIHTTPClient(&http.Client{CheckRedirect: func(*http.Request, []*http.Request) error {
+		return http.ErrUseLastResponse
+	}})
+	err := safe.CheckRedirect(&http.Request{URL: target}, []*http.Request{{URL: origin}})
+	if !errors.Is(err, http.ErrUseLastResponse) {
+		t.Fatalf("caller redirect decision = %v, want ErrUseLastResponse", err)
+	}
+}
+
+func TestStreamHTTPClientRetainsOpenAIRedirectPolicy(t *testing.T) {
+	origin, _ := url.Parse("https://api.example.test/v1/responses")
+	foreign, _ := url.Parse("https://api.example.test:8443/v1/responses")
+	base := redirectSafeOpenAIHTTPClient(&http.Client{Timeout: time.Second})
+	stream := streamHTTPClient(base)
+	if stream.Timeout != 0 {
+		t.Fatalf("stream timeout = %s, want zero", stream.Timeout)
+	}
+	if stream.CheckRedirect == nil {
+		t.Fatal("stream client dropped redirect policy")
+	}
+	err := stream.CheckRedirect(&http.Request{URL: foreign}, []*http.Request{{URL: origin}})
+	if err == nil || !strings.Contains(err.Error(), "cross-origin redirect") {
+		t.Fatalf("stream redirect error = %v", err)
+	}
+}

--- a/sdk/llm/openai/redirect_test.go
+++ b/sdk/llm/openai/redirect_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"io"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -20,14 +21,18 @@ func openAIRedirectTestRequest() llm.InvokeRequest {
 }
 
 func invokeOpenAIRedirectTest(t *testing.T, provider string, streaming bool, baseURL, apiKey string) error {
+	return invokeOpenAIRedirectTestWithRetries(t, provider, streaming, baseURL, apiKey, 1)
+}
+
+func invokeOpenAIRedirectTestWithRetries(t *testing.T, provider string, streaming bool, baseURL, apiKey string, maxRetries int) error {
 	t.Helper()
 	request := openAIRedirectTestRequest()
 	var model llm.ChatModel
 	switch provider {
 	case "chat":
-		model = &ChatClient{HTTPClient: &http.Client{Timeout: 2 * time.Second}, BaseURL: baseURL, APIKey: apiKey, ModelName: "test-model", MaxRetries: 1}
+		model = &ChatClient{HTTPClient: &http.Client{Timeout: 2 * time.Second}, BaseURL: baseURL, APIKey: apiKey, ModelName: "test-model", MaxRetries: maxRetries, RetryBaseDelay: time.Nanosecond, RetryMaxDelay: time.Nanosecond}
 	case "responses":
-		model = &ResponsesClient{HTTPClient: &http.Client{Timeout: 2 * time.Second}, BaseURL: baseURL, APIKey: apiKey, ModelName: "test-model", MaxRetries: 1}
+		model = &ResponsesClient{HTTPClient: &http.Client{Timeout: 2 * time.Second}, BaseURL: baseURL, APIKey: apiKey, ModelName: "test-model", MaxRetries: maxRetries, RetryBaseDelay: time.Nanosecond, RetryMaxDelay: time.Nanosecond}
 	default:
 		t.Fatalf("unknown provider %q", provider)
 	}
@@ -50,6 +55,159 @@ func invokeOpenAIRedirectTest(t *testing.T, provider string, streaming bool, bas
 	}
 	return nil
 }
+
+func TestOpenAIClientsRedactMalformedLocationAndDoNotRetry(t *testing.T) {
+	for _, provider := range []string{"chat", "responses"} {
+		for _, streaming := range []bool{false, true} {
+			provider := provider
+			streaming := streaming
+			t.Run(provider+map[bool]string{false: "_buffered", true: "_streaming"}[streaming], func(t *testing.T) {
+				const secret = "malformed-location-secret"
+				var sourceCalls atomic.Int32
+				redirector := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+					sourceCalls.Add(1)
+					w.Header().Set("Location", "https://audit-user:audit-password@connection.invalid/%zz?token="+secret)
+					w.WriteHeader(http.StatusTemporaryRedirect)
+				}))
+				defer redirector.Close()
+
+				err := invokeOpenAIRedirectTestWithRetries(t, provider, streaming, redirector.URL, secret, 3)
+				if err == nil {
+					t.Fatal("malformed redirect unexpectedly succeeded")
+				}
+				for _, value := range []string{secret, "audit-user", "audit-password", "connection.invalid", "/%zz", "token="} {
+					if strings.Contains(err.Error(), value) {
+						t.Fatalf("malformed redirect error exposed %q: %v", value, err)
+					}
+				}
+				if got := sourceCalls.Load(); got != 1 {
+					t.Fatalf("malformed redirect source received %d requests, want fail-fast 1", got)
+				}
+			})
+		}
+	}
+}
+
+func TestOpenAIClientsDoNotRetryPolicyErrorWithRetryKeyword(t *testing.T) {
+	for _, provider := range []string{"chat", "responses"} {
+		for _, streaming := range []bool{false, true} {
+			provider := provider
+			streaming := streaming
+			t.Run(provider+map[bool]string{false: "_buffered", true: "_streaming"}[streaming], func(t *testing.T) {
+				var sourceCalls atomic.Int32
+				redirector := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+					sourceCalls.Add(1)
+					w.Header().Set("Location", "http://connection.invalid/private")
+					w.WriteHeader(http.StatusTemporaryRedirect)
+				}))
+				defer redirector.Close()
+
+				err := invokeOpenAIRedirectTestWithRetries(t, provider, streaming, redirector.URL, "policy-secret", 3)
+				if err == nil || !strings.Contains(err.Error(), "cross-origin redirect") {
+					t.Fatalf("policy redirect error = %v", err)
+				}
+				if isRetryableNetErr(err) {
+					t.Fatalf("redirect policy error was classified retryable: %v", err)
+				}
+				if got := sourceCalls.Load(); got != 1 {
+					t.Fatalf("policy redirect source received %d requests, want fail-fast 1", got)
+				}
+			})
+		}
+	}
+}
+
+func TestOpenAIClientsRejectSameOriginRedirectURLCredentials(t *testing.T) {
+	for _, provider := range []string{"chat", "responses"} {
+		for _, streaming := range []bool{false, true} {
+			provider := provider
+			streaming := streaming
+			t.Run(provider+map[bool]string{false: "_buffered", true: "_streaming"}[streaming], func(t *testing.T) {
+				var sourceCalls atomic.Int32
+				var redirectedCalls atomic.Int32
+				var server *httptest.Server
+				server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					sourceCalls.Add(1)
+					if r.URL.Path == "/redirected" {
+						redirectedCalls.Add(1)
+						w.WriteHeader(http.StatusInternalServerError)
+						return
+					}
+					target := strings.Replace(server.URL, "://", "://audit-user:audit-password@", 1) + "/redirected?token=audit-query-secret"
+					w.Header().Set("Location", target)
+					w.WriteHeader(http.StatusTemporaryRedirect)
+				}))
+				defer server.Close()
+
+				err := invokeOpenAIRedirectTestWithRetries(t, provider, streaming, server.URL, "bearer-secret", 3)
+				if err == nil || !strings.Contains(err.Error(), "embedded URL credentials") {
+					t.Fatalf("redirect credential error = %v", err)
+				}
+				for _, value := range []string{"audit-user", "audit-password", "audit-query-secret", "/redirected"} {
+					if strings.Contains(err.Error(), value) {
+						t.Fatalf("redirect credential error exposed %q: %v", value, err)
+					}
+				}
+				if sourceCalls.Load() != 1 || redirectedCalls.Load() != 0 {
+					t.Fatalf("source/redirected calls = %d/%d, want 1/0", sourceCalls.Load(), redirectedCalls.Load())
+				}
+			})
+		}
+	}
+}
+
+func TestSanitizeOpenAIHTTPErrorPreservesSafeRetrySemantics(t *testing.T) {
+	t.Parallel()
+	const secret = "network-error-secret"
+	tests := []struct {
+		name        string
+		cause       error
+		wantRetry   bool
+		wantTimeout bool
+	}{
+		{name: "timeout", cause: secretOpenAITimeoutError{message: secret}, wantRetry: true, wantTimeout: true},
+		{name: "network operation", cause: &net.OpError{Op: "dial", Net: "tcp", Err: errors.New(secret)}, wantRetry: true},
+		{name: "permanent network error", cause: secretOpenAIPermanentNetError{message: secret}},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := sanitizeOpenAIHTTPError(&url.Error{
+				Op:  "Post",
+				URL: "https://api.example.test/private?token=" + secret,
+				Err: tc.cause,
+			})
+			var sanitized *url.Error
+			if !errors.As(err, &sanitized) {
+				t.Fatalf("sanitized error = %T, want *url.Error", err)
+			}
+			if strings.Contains(sanitized.Error(), secret) || strings.Contains(sanitized.Error(), "/private") {
+				t.Fatalf("sanitized error leaked request details: %q", sanitized.Error())
+			}
+			if got := isRetryableNetErr(sanitized); got != tc.wantRetry {
+				t.Fatalf("retryable = %t, want %t: %v", got, tc.wantRetry, sanitized)
+			}
+			if got := sanitized.Timeout(); got != tc.wantTimeout {
+				t.Fatalf("timeout = %t, want %t: %v", got, tc.wantTimeout, sanitized)
+			}
+		})
+	}
+}
+
+type secretOpenAITimeoutError struct {
+	message string
+}
+
+func (e secretOpenAITimeoutError) Error() string { return e.message }
+func (secretOpenAITimeoutError) Timeout() bool   { return true }
+func (secretOpenAITimeoutError) Temporary() bool { return true }
+
+type secretOpenAIPermanentNetError struct {
+	message string
+}
+
+func (e secretOpenAIPermanentNetError) Error() string { return e.message }
+func (secretOpenAIPermanentNetError) Timeout() bool   { return false }
+func (secretOpenAIPermanentNetError) Temporary() bool { return false }
 
 func TestOpenAIClientsRejectCrossOriginRedirectWithoutLeakingBearerToken(t *testing.T) {
 	for _, provider := range []string{"chat", "responses"} {

--- a/sdk/llm/openai/responses.go
+++ b/sdk/llm/openai/responses.go
@@ -98,6 +98,7 @@ func (c *ResponsesClient) Invoke(ctx context.Context, req llm.InvokeRequest) (*l
 		}
 
 		resp, err := client.Do(httpReq)
+		err = sanitizeOpenAIHTTPError(err)
 		if err == nil {
 			data, readErr := readResponseBodyLimited(resp.Body, endpoint)
 			if readErr != nil {
@@ -184,9 +185,9 @@ func (c *ResponsesClient) Invoke(ctx context.Context, req llm.InvokeRequest) (*l
 
 func (c *ResponsesClient) httpClient() *http.Client {
 	if c.HTTPClient != nil {
-		return c.HTTPClient
+		return redirectSafeOpenAIHTTPClient(c.HTTPClient)
 	}
-	return &http.Client{Timeout: 60 * time.Second}
+	return redirectSafeOpenAIHTTPClient(&http.Client{Timeout: 60 * time.Second})
 }
 
 func (c *ResponsesClient) baseURL() string {
@@ -429,6 +430,7 @@ func (c *ResponsesClient) InvokeStream(ctx context.Context, req llm.InvokeReques
 			}
 
 			resp, err := client.Do(httpReq)
+			err = sanitizeOpenAIHTTPError(err)
 			if err != nil {
 				if ctxErr := ctx.Err(); ctxErr != nil {
 					out <- llm.StreamErrorEvent{Err: ctxErr}


### PR DESCRIPTION
## Summary

- install one mandatory same-origin redirect policy for OpenAI Chat and Responses
- preserve the policy in buffered and streaming clients
- define origin by scheme, hostname, and effective port; reject HTTPS downgrade
- compose caller redirect callbacks and recheck their mutated target
- sanitize `url.Error` diagnostics to origin-only labels so malicious Location userinfo/path/query cannot leak

## Validation

- Chat/Responses × buffered/streaming cross-origin rejection with zero destination requests
- Chat/Responses × buffered/streaming same-origin success with bearer preservation
- same-host/different-port and HTTPS downgrade tests
- caller callback recheck and `ErrUseLastResponse` tests
- credential-bearing Location diagnostic redaction
- `go test -count=1 ./sdk/llm/openai`
- `go test -race -count=1 ./sdk/llm/openai`
- `go test -count=1 ./...`
- `go vet ./...`
- `git diff --check`

Closes #61
