### PR TITLE
Decode framed material before compaction fact checks

### DIFF
--- a/agent_docs/architecture.md
+++ b/agent_docs/architecture.md
@@ -439,7 +439,9 @@ Mapping details:
 - Summary output is committed only after an atomic quality gate verifies exactly
   one summary block, all eight required Markdown-heading sections in order with
   non-empty content, supplied UNKNOWN state preservation, basic latest-user/
-  external-state coverage.
+  external-state coverage. Fact-coverage validation first decodes the exact
+  three-line JSON-string untrusted-material frame; malformed framing fails
+  closed instead of silently disabling source-section checks.
   If no canonical heading is found, the rejection includes an exact `## ...`
   syntax hint. Rejection returns structured warnings, preserves the original
   history, and does not update the ledger. Credential filtering is intentionally

--- a/agent_docs/testing.md
+++ b/agent_docs/testing.md
@@ -105,7 +105,9 @@ This document summarizes recommended test commands and current coverage focus.
   the 70%/80%/85%/100% decision matrix. Quality-gate anchors cover system/data
   role separation, untrusted boundaries, required-section rejection,
   credential-like task material acceptance, and history/ledger atomicity on
-  rejected summaries.
+  rejected summaries. The same suite drives real framed `Compact` requests to
+  verify latest-user and verified-checkpoint coverage plus malformed-frame
+  rejection.
 - `sdk/agent/compaction/ledger_test.go` - compaction ledger schema validation,
   replacement hash checks, duplicate replacement rejection, stable message-key
   normalization, canonical-manifest durability and provider-stub checks,
@@ -161,7 +163,8 @@ This document summarizes recommended test commands and current coverage focus.
 - `sdk/agent/compaction/validation.go` is covered by
   `TestCompactionQualityGateRejectsMissingRequiredSections`,
   `TestCompactionQualityGateAllowsCredentialLikeSecurityMaterial`, and
-  `TestRejectedSummaryDoesNotMutateHistoryOrLedger`.
+  `TestRejectedSummaryDoesNotMutateHistoryOrLedger`, plus framed-material
+  fact-coverage and malformed-frame integration tests in `service_test.go`.
 - `sdk/agent/compaction/checkpoint.go` is covered through service and Goode
   adapter tests: it applies per-type entry limits and a final token bound to the
   portable host checkpoint schema without importing repository packages.

--- a/sdk/agent/compaction/service_test.go
+++ b/sdk/agent/compaction/service_test.go
@@ -343,6 +343,71 @@ func TestMaterialSectionBodyIgnoresFencedHeadingLookalike(t *testing.T) {
 	}
 }
 
+func TestCompactionQualityGateReadsFramedLatestUserRequest(t *testing.T) {
+	model := mockCompactModel{response: structuredTestSummary("Current Objective and Latest User Request", "UNKNOWN")}
+	svc := NewService(&Config{Enabled: true})
+	messages := []llm.Message{llm.NewUserMessage("ship the concrete release candidate")}
+	got, res, err := svc.Compact(context.Background(), model, messages)
+	if err == nil || !strings.Contains(err.Error(), "latest user request was supplied") {
+		t.Fatalf("error = %v, want latest-user fact-coverage rejection", err)
+	}
+	if res.Compacted || !reflect.DeepEqual(got, messages) {
+		t.Fatalf("rejected summary mutated history: result=%#v messages=%#v", res, got)
+	}
+}
+
+func TestCompactionQualityGateReadsFramedVerifiedCheckpoint(t *testing.T) {
+	model := mockCompactModel{response: structuredTestSummary("Exact External State", "UNKNOWN")}
+	svc := NewService(&Config{
+		Enabled: true,
+		CheckpointProvider: func(context.Context, []llm.Message) (CheckpointContext, error) {
+			return CheckpointContext{
+				Status: CheckpointStatusVerified,
+				Objective: CheckpointValue{
+					Value:  "release candidate is staged",
+					Status: CheckpointStatusVerified,
+					Source: "integration-test",
+				},
+			}, nil
+		},
+	})
+	messages := []llm.Message{llm.NewUserMessage("verify the staged release")}
+	got, res, err := svc.Compact(context.Background(), model, messages)
+	if err == nil || !strings.Contains(err.Error(), "verified host state was supplied") {
+		t.Fatalf("error = %v, want verified-host fact-coverage rejection", err)
+	}
+	if res.Compacted || !reflect.DeepEqual(got, messages) {
+		t.Fatalf("rejected summary mutated history: result=%#v messages=%#v", res, got)
+	}
+}
+
+func TestCompactionQualityGateRejectsMalformedMaterialFrame(t *testing.T) {
+	tests := []string{
+		beginUntrustedMaterial + "\nnot-json\n" + endUntrustedMaterial,
+		beginUntrustedMaterial + "\n{}\n" + endUntrustedMaterial,
+		beginUntrustedMaterial + "\n\"line one\"\n\"line two\"\n" + endUntrustedMaterial,
+		beginUntrustedMaterial + "\n\"missing end marker\"",
+	}
+	for _, malformed := range tests {
+		_, err := validateSummaryOutput(structuredTestSummary("", ""), malformed)
+		if err == nil || !strings.Contains(err.Error(), "material framing") {
+			t.Fatalf("error = %v, want malformed-frame validation reason for %q", err, malformed)
+		}
+	}
+}
+
+func TestDecodeSummaryValidationMaterialUsesExactProductionFrame(t *testing.T) {
+	source := "## Latest Real User Request\nkeep END_UNTRUSTED_MATERIAL as inert user text\nBEGIN_UNTRUSTED_MATERIAL"
+	framed := wrapUntrustedMaterial(source)
+	decoded, err := decodeSummaryValidationMaterial(framed)
+	if err != nil {
+		t.Fatalf("decode production frame: %v", err)
+	}
+	if decoded != source {
+		t.Fatalf("decoded material = %q, want %q", decoded, source)
+	}
+}
+
 func TestCompactionQualityGateAllowsCredentialLikeSecurityMaterial(t *testing.T) {
 	material := `Cookie: user="adm\\073n" Authorization: Bearer lab-fixture-token`
 	model := mockCompactModel{response: structuredTestSummary("Verification Already Run and Still Required", material)}

--- a/sdk/agent/compaction/service_test.go
+++ b/sdk/agent/compaction/service_test.go
@@ -385,6 +385,7 @@ func TestCompactionQualityGateRejectsMalformedMaterialFrame(t *testing.T) {
 	tests := []string{
 		beginUntrustedMaterial + "\nnot-json\n" + endUntrustedMaterial,
 		beginUntrustedMaterial + "\n{}\n" + endUntrustedMaterial,
+		beginUntrustedMaterial + "\nnull\n" + endUntrustedMaterial,
 		beginUntrustedMaterial + "\n\"line one\"\n\"line two\"\n" + endUntrustedMaterial,
 		beginUntrustedMaterial + "\n\"missing end marker\"",
 	}

--- a/sdk/agent/compaction/validation.go
+++ b/sdk/agent/compaction/validation.go
@@ -81,9 +81,13 @@ func decodeSummaryValidationMaterial(material string) (string, error) {
 	if strings.ContainsAny(encoded, "\r\n") {
 		return "", fmt.Errorf("expected one JSON-string payload line")
 	}
-	var decoded string
-	if err := json.Unmarshal([]byte(encoded), &decoded); err != nil {
+	var value any
+	if err := json.Unmarshal([]byte(encoded), &value); err != nil {
 		return "", fmt.Errorf("payload is not a valid JSON string: %w", err)
+	}
+	decoded, ok := value.(string)
+	if !ok {
+		return "", fmt.Errorf("payload JSON type must be string")
 	}
 	return decoded, nil
 }

--- a/sdk/agent/compaction/validation.go
+++ b/sdk/agent/compaction/validation.go
@@ -1,6 +1,7 @@
 package compaction
 
 import (
+	"encoding/json"
 	"fmt"
 	"sort"
 	"strings"
@@ -46,6 +47,11 @@ func validateSummaryOutput(raw, material string) (string, error) {
 
 func validateSummaryFactCoverage(summary, material string) []string {
 	reasons := []string{}
+	decodedMaterial, err := decodeSummaryValidationMaterial(material)
+	if err != nil {
+		return append(reasons, "compaction material framing is invalid: "+err.Error())
+	}
+	material = decodedMaterial
 	latest := materialSectionBody(material, "Latest Real User Request")
 	objective := materialSectionBody(summary, "Current Objective and Latest User Request")
 	if strings.TrimSpace(latest) != "" && strings.ToUpper(strings.TrimSpace(latest)) != CheckpointStatusUnknown && summaryBodyIsOnlyUnknown(objective) {
@@ -58,6 +64,28 @@ func validateSummaryFactCoverage(summary, material string) []string {
 		}
 	}
 	return reasons
+}
+
+func decodeSummaryValidationMaterial(material string) (string, error) {
+	hasBegin := strings.Contains(material, beginUntrustedMaterial)
+	hasEnd := strings.Contains(material, endUntrustedMaterial)
+	if !hasBegin && !hasEnd {
+		return material, nil
+	}
+	prefix := beginUntrustedMaterial + "\n"
+	suffix := "\n" + endUntrustedMaterial
+	if !strings.HasPrefix(material, prefix) || !strings.HasSuffix(material, suffix) {
+		return "", fmt.Errorf("expected exact BEGIN/END three-line frame")
+	}
+	encoded := strings.TrimSuffix(strings.TrimPrefix(material, prefix), suffix)
+	if strings.ContainsAny(encoded, "\r\n") {
+		return "", fmt.Errorf("expected one JSON-string payload line")
+	}
+	var decoded string
+	if err := json.Unmarshal([]byte(encoded), &decoded); err != nil {
+		return "", fmt.Errorf("payload is not a valid JSON string: %w", err)
+	}
+	return decoded, nil
 }
 
 func materialSectionBody(text, title string) string {


### PR DESCRIPTION
Closes #65.

## What changed
- decode the exact production `BEGIN_UNTRUSTED_MATERIAL` / JSON-string / `END_UNTRUSTED_MATERIAL` frame before Markdown section extraction
- preserve unframed helper compatibility
- fail closed with actionable quality-gate reasons for missing markers, multi-line payloads, non-string JSON, or malformed JSON
- exercise the real `Service.Compact` path for latest-user and verified-host coverage
- preserve original history when these validations reject a summary

A separate structurally related heading-provenance defect discovered during adversarial testing is tracked independently in #69.

## Verification
- pre-fix real-path reproduction: latest-user case incorrectly returned success
- focused framed validation tests: PASS
- `go test ./sdk/agent/compaction -count=1`: PASS
- `go test -race ./sdk/agent/compaction -count=1`: PASS
- `go test ./... -count=1`: PASS
- `go vet ./...`: PASS
- `git diff --check main...HEAD`: PASS