### PR TITLE
Make sandbox timeout test compile on Windows

### DIFF
--- a/sdk/tools/sandbox/sandbox_process_group_unix_test.go
+++ b/sdk/tools/sandbox/sandbox_process_group_unix_test.go
@@ -1,4 +1,4 @@
-//go:build aix || android || darwin || dragonfly || freebsd || illumos || linux || netbsd || openbsd || solaris
+//go:build unix
 
 package sandbox
 

--- a/sdk/tools/sandbox/sandbox_process_group_unix_test.go
+++ b/sdk/tools/sandbox/sandbox_process_group_unix_test.go
@@ -1,0 +1,77 @@
+//go:build aix || android || darwin || dragonfly || freebsd || illumos || linux || netbsd || openbsd || solaris
+
+package sandbox
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/timwhitez/agent-sdk-golang/sdk/tools"
+)
+
+func TestBashTool_KillsProcessGroupOnTimeout(t *testing.T) {
+	root := t.TempDir()
+	s, err := New(root)
+	if err != nil {
+		t.Fatalf("new: %v", err)
+	}
+	deps := tools.NewContainer()
+	tools.Provide(deps, Key, func(context.Context) (*Sandbox, error) { return s, nil })
+	tools.Provide(deps, ConfirmKey, func(context.Context) (Confirmer, error) { return allowConfirmer{}, nil })
+
+	ctx := tools.WithToolResultMetadata(context.Background())
+	command := `sleep 30 & child=$!; echo $child > child.pid; wait $child`
+	out, err := bashTool().Execute(ctx, fmt.Sprintf(`{"command":%q,"timeout":1}`, command), deps)
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("expected deadline exceeded, got %v", err)
+	}
+	if !strings.Contains(strings.ToLower(out.PlainText()), "timed out") {
+		t.Fatalf("expected timed out output, got %q", out.PlainText())
+	}
+
+	pidPath := filepath.Join(root, "child.pid")
+	var pid int
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		data, readErr := os.ReadFile(pidPath)
+		if readErr == nil {
+			pid, err = strconv.Atoi(strings.TrimSpace(string(data)))
+			if err != nil {
+				t.Fatalf("parse child pid: %v", err)
+			}
+			break
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	if pid <= 0 {
+		t.Fatalf("expected child pid to be written at %s", pidPath)
+	}
+	t.Cleanup(func() {
+		_ = syscall.Kill(pid, syscall.SIGKILL)
+	})
+
+	aliveDeadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(aliveDeadline) {
+		if !processExists(pid) {
+			return
+		}
+		time.Sleep(25 * time.Millisecond)
+	}
+	t.Fatalf("expected child process %d to be terminated with parent timeout", pid)
+}
+
+func processExists(pid int) bool {
+	if pid <= 0 {
+		return false
+	}
+	err := syscall.Kill(pid, 0)
+	return err == nil || errors.Is(err, syscall.EPERM)
+}

--- a/sdk/tools/sandbox/sandbox_test.go
+++ b/sdk/tools/sandbox/sandbox_test.go
@@ -13,12 +13,9 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
-	"strconv"
 	"strings"
 	"sync"
-	"syscall"
 	"testing"
-	"time"
 
 	"github.com/timwhitez/agent-sdk-golang/sdk/tools"
 	"github.com/timwhitez/agent-sdk-golang/sdk/tools/execenv"
@@ -817,69 +814,6 @@ func TestBashTool_StreamLimitsOutput(t *testing.T) {
 	if info.Size() <= int64(execrunner.DefaultMaxOutputBytes) {
 		t.Fatalf("expected artifact > %d bytes, got %d", execrunner.DefaultMaxOutputBytes, info.Size())
 	}
-}
-
-func TestBashTool_KillsProcessGroupOnTimeout(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("process-group timeout test uses POSIX shell commands")
-	}
-
-	root := t.TempDir()
-	s, err := New(root)
-	if err != nil {
-		t.Fatalf("new: %v", err)
-	}
-	deps := tools.NewContainer()
-	tools.Provide(deps, Key, func(context.Context) (*Sandbox, error) { return s, nil })
-	tools.Provide(deps, ConfirmKey, func(context.Context) (Confirmer, error) { return allowConfirmer{}, nil })
-
-	ctx := tools.WithToolResultMetadata(context.Background())
-	command := `sleep 30 & child=$!; echo $child > child.pid; wait $child`
-	out, err := bashTool().Execute(ctx, fmt.Sprintf(`{"command":%q,"timeout":1}`, command), deps)
-	if !errors.Is(err, context.DeadlineExceeded) {
-		t.Fatalf("expected deadline exceeded, got %v", err)
-	}
-	if !strings.Contains(strings.ToLower(out.PlainText()), "timed out") {
-		t.Fatalf("expected timed out output, got %q", out.PlainText())
-	}
-
-	pidPath := filepath.Join(root, "child.pid")
-	var pid int
-	deadline := time.Now().Add(2 * time.Second)
-	for time.Now().Before(deadline) {
-		data, readErr := os.ReadFile(pidPath)
-		if readErr == nil {
-			pid, err = strconv.Atoi(strings.TrimSpace(string(data)))
-			if err != nil {
-				t.Fatalf("parse child pid: %v", err)
-			}
-			break
-		}
-		time.Sleep(20 * time.Millisecond)
-	}
-	if pid <= 0 {
-		t.Fatalf("expected child pid to be written at %s", pidPath)
-	}
-	t.Cleanup(func() {
-		_ = syscall.Kill(pid, syscall.SIGKILL)
-	})
-
-	aliveDeadline := time.Now().Add(2 * time.Second)
-	for time.Now().Before(aliveDeadline) {
-		if !processExists(pid) {
-			return
-		}
-		time.Sleep(25 * time.Millisecond)
-	}
-	t.Fatalf("expected child process %d to be terminated with parent timeout", pid)
-}
-
-func processExists(pid int) bool {
-	if pid <= 0 {
-		return false
-	}
-	err := syscall.Kill(pid, 0)
-	return err == nil || errors.Is(err, syscall.EPERM)
 }
 
 func TestWriteToolPreservesMode(t *testing.T) {


### PR DESCRIPTION
Fixes #75.

## What changed

- Move the POSIX shell/process-group timeout regression and its `syscall.Kill` helper into a test file guarded by Go's canonical built-in `//go:build unix` constraint.
- Keep all unrelated sandbox tests compiled on Windows.
- Remove now-unused POSIX-only imports from the shared test file.
- Production SDK code is unchanged.

## Exact revision

- Base: `618501028a89a7475bc1d7c295ee108ce0fad723`.
- Head: `3261bc63ad10fdf5b3ecf72ff40c24a49f28f3f2`.
- Head tree and clean merge-tree: `939ac913f1924f3011b42d91137d21ffffac9824`.

## Direct local evidence

- Original Windows cross-vet: deterministic `undefined: syscall.Kill` failure.
- Fixed Windows/amd64 `go vet ./...`: PASS.
- Fixed Windows/amd64 `go build ./...`: PASS.
- Windows sandbox test-binary compilation: PASS.
- POSIX owning test: exact-head count 10 PASS and race count 5 PASS; the preceding candidate also passed count 50/race count 20 before the constraint-only review correction.
- Full Linux uncached normal/race: 13/13 packages PASS.
- Full Linux vet/build and `go mod verify`: PASS.

Separate pre-existing Wine test-authority problems are tracked in #76 (unobservable symlink fixtures) and #78 (unsupported Unix executable-bit assertion). This PR changes neither behavior.

No GitHub Actions were used or queried. Independent exact-head review is required before merge.