### PR TITLE
Make sandbox mode-preservation tests portable on Windows

### DIFF
--- a/sdk/tools/sandbox/sandbox_test.go
+++ b/sdk/tools/sandbox/sandbox_test.go
@@ -826,13 +826,7 @@ func TestWriteToolPreservesMode(t *testing.T) {
 	if err := os.WriteFile(path, []byte("echo hi\n"), 0o755); err != nil {
 		t.Fatalf("write: %v", err)
 	}
-	if runtime.GOOS != "windows" {
-		if st, err := os.Stat(path); err != nil {
-			t.Fatalf("stat: %v", err)
-		} else if st.Mode().Perm() != 0o755 {
-			t.Skipf("filesystem does not preserve exec perms (got %o)", st.Mode().Perm())
-		}
-	}
+	wantMode := observableModeForPreservationTest(t, path, 0o755)
 	deps := tools.NewContainer()
 	tools.Provide(deps, Key, func(context.Context) (*Sandbox, error) { return s, nil })
 	tools.Provide(deps, ConfirmKey, func(context.Context) (Confirmer, error) { return allowConfirmer{}, nil })
@@ -845,9 +839,32 @@ func TestWriteToolPreservesMode(t *testing.T) {
 	if err != nil {
 		t.Fatalf("stat: %v", err)
 	}
-	if st.Mode().Perm() != 0o755 {
-		t.Fatalf("expected mode 0755, got %o", st.Mode().Perm())
+	if st.Mode().Perm() != wantMode {
+		t.Fatalf("expected observable mode %04o to be preserved, got %04o", wantMode, st.Mode().Perm())
 	}
+}
+
+func observableModeForPreservationTest(t *testing.T, path string, requested os.FileMode) os.FileMode {
+	t.Helper()
+	st, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat mode fixture: %v", err)
+	}
+	observed := st.Mode().Perm()
+	requested = requested.Perm()
+	if observed == requested {
+		return observed
+	}
+	if runtime.GOOS != "windows" {
+		t.Skipf("filesystem does not preserve requested mode %04o (observed %04o)", requested, observed)
+	}
+	// Windows projects the writable/read-only file attribute into Go mode
+	// bits; executable bits are not part of its filesystem contract. Keep the
+	// test active and verify that the writable projection itself is preserved.
+	if requested&0o200 != 0 && observed&0o200 == 0 {
+		t.Fatalf("writable fixture became read-only: requested %04o, observed %04o", requested, observed)
+	}
+	return observed
 }
 
 func TestWriteTool_DiffPreviewLimitsLargeExistingFile(t *testing.T) {
@@ -3428,13 +3445,7 @@ func TestApplyUpdateFilePreservesMode(t *testing.T) {
 	if err := os.WriteFile(path, []byte("hello\n"), 0o755); err != nil {
 		t.Fatalf("write: %v", err)
 	}
-	if runtime.GOOS != "windows" {
-		if st, err := os.Stat(path); err != nil {
-			t.Fatalf("stat: %v", err)
-		} else if st.Mode().Perm() != 0o755 {
-			t.Skipf("filesystem does not preserve exec perms (got %o)", st.Mode().Perm())
-		}
-	}
+	wantMode := observableModeForPreservationTest(t, path, 0o755)
 	if err := applyUpdateFile(s, "script.sh", []patchHunk{{lines: []string{"-hello", "+hi"}}}); err != nil {
 		t.Fatalf("applyUpdateFile: %v", err)
 	}
@@ -3442,8 +3453,8 @@ func TestApplyUpdateFilePreservesMode(t *testing.T) {
 	if err != nil {
 		t.Fatalf("stat: %v", err)
 	}
-	if st.Mode().Perm() != 0o755 {
-		t.Fatalf("expected mode 0755, got %o", st.Mode().Perm())
+	if st.Mode().Perm() != wantMode {
+		t.Fatalf("expected observable mode %04o to be preserved, got %04o", wantMode, st.Mode().Perm())
 	}
 }
 


### PR DESCRIPTION
Fixes #78.

## What changed

- Capture each fixture's mode as actually exposed by the target filesystem before the write/update.
- Preserve the exact `0755` assertion on filesystems that expose it.
- On Windows, keep the tests active and validate preservation of the supported writable/read-only mode projection instead of demanding Unix executable bits.
- Change tests only; sandbox production behavior is unchanged.

## Exact revision

- Base: `47b9bd05b13086d4255244952dd163a8614417fe`.
- Head: `94b3eb131ebcb3749d95808abb5549dac760ee64`.
- Head tree and clean merge-tree: `b601b9e3c4119c013e845a30d8a023d3c23c0d76`.

## Direct local evidence

- Linux owning tests: normal count 100 PASS; race count 20 PASS.
- Linux all packages: uncached normal 13/13 PASS; full race 13/13 PASS; vet/build/module verification PASS.
- Windows/amd64: all-package vet PASS, all-package build PASS, sandbox test-binary compilation PASS.
- Real Wine 9 / Windows 10.0.19043: both owning tests count 100 PASS.
- Real Wine full sandbox excluding the separately tracked symlink-capability scope in #76: PASS.
- A diagnostic readonly target remained `0444` after the expected Windows `Access denied`, confirming that this PR must not change production write semantics.

No GitHub Actions were used or queried. Independent exact-head review is required before merge.
