### PR TITLE
Require observable symlinks in sandbox security tests

### DIFF
--- a/sdk/tools/sandbox/sandbox_test.go
+++ b/sdk/tools/sandbox/sandbox_test.go
@@ -104,6 +104,39 @@ func useSandboxReadAllHook(t *testing.T, hook func(io.Reader) ([]byte, error)) {
 	})
 }
 
+func requireObservableSymlink(t *testing.T, target, link string) {
+	t.Helper()
+	if err := os.Symlink(target, link); err != nil {
+		t.Skipf("symlink creation is unavailable: %v", err)
+	}
+	linkInfo, err := os.Lstat(link)
+	if err != nil {
+		t.Skipf("symlink creation reported success but Lstat cannot observe %q: %v", link, err)
+	}
+	if linkInfo.Mode()&os.ModeSymlink == 0 {
+		t.Skipf("symlink creation reported success but %q is not observable as a symlink (mode %v)", link, linkInfo.Mode())
+	}
+	resolved, err := filepath.EvalSymlinks(link)
+	if err != nil {
+		t.Skipf("symlink %q is not resolvable after successful creation: %v", link, err)
+	}
+	targetResolved, err := filepath.EvalSymlinks(target)
+	if err != nil {
+		t.Fatalf("resolve known symlink target %q: %v", target, err)
+	}
+	resolvedInfo, err := os.Stat(resolved)
+	if err != nil {
+		t.Skipf("stat resolved symlink %q -> %q: %v", link, resolved, err)
+	}
+	targetInfo, err := os.Stat(targetResolved)
+	if err != nil {
+		t.Fatalf("stat known symlink target %q: %v", targetResolved, err)
+	}
+	if !os.SameFile(resolvedInfo, targetInfo) {
+		t.Fatalf("symlink %q resolved to %q instead of target %q", link, resolved, targetResolved)
+	}
+}
+
 type failAfterReader struct {
 	data []byte
 }
@@ -193,9 +226,7 @@ func TestSandboxAllowExternalDirectoryResolvesSymlinks(t *testing.T) {
 	root := t.TempDir()
 	ext := t.TempDir()
 	link := filepath.Join(t.TempDir(), "ext-link")
-	if err := os.Symlink(ext, link); err != nil {
-		t.Skipf("symlink not supported: %v", err)
-	}
+	requireObservableSymlink(t, ext, link)
 	s, err := New(root)
 	if err != nil {
 		t.Fatalf("new: %v", err)
@@ -241,9 +272,7 @@ func TestSandboxResolveBlocksSymlinkEscape(t *testing.T) {
 	root := t.TempDir()
 	ext := t.TempDir()
 	link := filepath.Join(root, "ext-link")
-	if err := os.Symlink(ext, link); err != nil {
-		t.Skipf("symlink not supported: %v", err)
-	}
+	requireObservableSymlink(t, ext, link)
 	s, err := New(root)
 	if err != nil {
 		t.Fatalf("new: %v", err)
@@ -260,9 +289,7 @@ func TestSandboxResolveAllowsSymlinkInsideRoot(t *testing.T) {
 		t.Fatalf("mkdir: %v", err)
 	}
 	link := filepath.Join(root, "link")
-	if err := os.Symlink(target, link); err != nil {
-		t.Skipf("symlink not supported: %v", err)
-	}
+	requireObservableSymlink(t, target, link)
 	s, err := New(root)
 	if err != nil {
 		t.Fatalf("new: %v", err)
@@ -1854,9 +1881,7 @@ func TestReadTool_BlocksSymlinkSwapAfterResolve(t *testing.T) {
 		t.Fatalf("write outside file: %v", err)
 	}
 	link := filepath.Join(root, "swap")
-	if err := os.Symlink(insideDir, link); err != nil {
-		t.Skipf("symlink not supported: %v", err)
-	}
+	requireObservableSymlink(t, insideDir, link)
 
 	s, err := New(root)
 	if err != nil {
@@ -1916,9 +1941,7 @@ func TestWriteTool_BlocksSymlinkSwapAfterResolve(t *testing.T) {
 		t.Fatalf("write outside file: %v", err)
 	}
 	link := filepath.Join(root, "swap")
-	if err := os.Symlink(insideDir, link); err != nil {
-		t.Skipf("symlink not supported: %v", err)
-	}
+	requireObservableSymlink(t, insideDir, link)
 
 	s, err := New(root)
 	if err != nil {
@@ -1990,9 +2013,7 @@ func TestEditTool_BlocksSymlinkSwapAfterResolve(t *testing.T) {
 		t.Fatalf("write outside file: %v", err)
 	}
 	link := filepath.Join(root, "swap")
-	if err := os.Symlink(insideDir, link); err != nil {
-		t.Skipf("symlink not supported: %v", err)
-	}
+	requireObservableSymlink(t, insideDir, link)
 
 	s, err := New(root)
 	if err != nil {
@@ -2062,9 +2083,7 @@ func TestLsTool_BlocksSymlinkSwapAfterResolve(t *testing.T) {
 		t.Fatalf("write outside file: %v", err)
 	}
 	link := filepath.Join(root, "swap")
-	if err := os.Symlink(insideDir, link); err != nil {
-		t.Skipf("symlink not supported: %v", err)
-	}
+	requireObservableSymlink(t, insideDir, link)
 
 	s, err := New(root)
 	if err != nil {
@@ -2119,9 +2138,7 @@ func TestGlobTool_BlocksSymlinkSwapAfterResolve(t *testing.T) {
 		t.Fatalf("write outside file: %v", err)
 	}
 	link := filepath.Join(root, "swap")
-	if err := os.Symlink(insideDir, link); err != nil {
-		t.Skipf("symlink not supported: %v", err)
-	}
+	requireObservableSymlink(t, insideDir, link)
 
 	s, err := New(root)
 	if err != nil {
@@ -2176,9 +2193,7 @@ func TestGrepTool_BlocksSymlinkSwapAfterResolve(t *testing.T) {
 		t.Fatalf("write outside file: %v", err)
 	}
 	link := filepath.Join(root, "swap")
-	if err := os.Symlink(insideDir, link); err != nil {
-		t.Skipf("symlink not supported: %v", err)
-	}
+	requireObservableSymlink(t, insideDir, link)
 
 	s, err := New(root)
 	if err != nil {
@@ -2230,9 +2245,7 @@ func TestGlobTool_BlocksSymlinkFileEscapeOutsideSandbox(t *testing.T) {
 		t.Fatalf("write outside file: %v", err)
 	}
 	link := filepath.Join(root, "link.txt")
-	if err := os.Symlink(outsideFile, link); err != nil {
-		t.Skipf("symlink not supported: %v", err)
-	}
+	requireObservableSymlink(t, outsideFile, link)
 
 	s, err := New(root)
 	if err != nil {
@@ -2284,9 +2297,7 @@ func TestGrepTool_BlocksSymlinkFileEscapeOutsideSandbox(t *testing.T) {
 		t.Fatalf("write outside file: %v", err)
 	}
 	link := filepath.Join(root, "link.txt")
-	if err := os.Symlink(outsideFile, link); err != nil {
-		t.Skipf("symlink not supported: %v", err)
-	}
+	requireObservableSymlink(t, outsideFile, link)
 
 	s, err := New(root)
 	if err != nil {
@@ -2342,9 +2353,7 @@ func TestGlobTool_BlocksSymlinkFileSwapOutsideSandbox(t *testing.T) {
 		t.Fatalf("write outside file: %v", err)
 	}
 	probe := filepath.Join(root, "probe-link")
-	if err := os.Symlink(outsideFile, probe); err != nil {
-		t.Skipf("symlink not supported: %v", err)
-	}
+	requireObservableSymlink(t, outsideFile, probe)
 	if err := os.Remove(probe); err != nil {
 		t.Fatalf("remove symlink probe: %v", err)
 	}
@@ -2428,9 +2437,7 @@ func TestGrepTool_BlocksSymlinkFileSwapOutsideSandbox(t *testing.T) {
 		t.Fatalf("write outside file: %v", err)
 	}
 	probe := filepath.Join(root, "probe-link")
-	if err := os.Symlink(outsideFile, probe); err != nil {
-		t.Skipf("symlink not supported: %v", err)
-	}
+	requireObservableSymlink(t, outsideFile, probe)
 	if err := os.Remove(probe); err != nil {
 		t.Fatalf("remove symlink probe: %v", err)
 	}

--- a/sdk/tools/sandbox/sandbox_test.go
+++ b/sdk/tools/sandbox/sandbox_test.go
@@ -11,10 +11,12 @@ import (
 	"net"
 	"net/http"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"runtime"
 	"strings"
 	"sync"
+	"syscall"
 	"testing"
 
 	"github.com/timwhitez/agent-sdk-golang/sdk/tools"
@@ -106,34 +108,89 @@ func useSandboxReadAllHook(t *testing.T, hook func(io.Reader) ([]byte, error)) {
 
 func requireObservableSymlink(t *testing.T, target, link string) {
 	t.Helper()
-	if err := os.Symlink(target, link); err != nil {
-		t.Skipf("symlink creation is unavailable: %v", err)
-	}
-	linkInfo, err := os.Lstat(link)
-	if err != nil {
-		t.Skipf("symlink creation reported success but Lstat cannot observe %q: %v", link, err)
-	}
-	if linkInfo.Mode()&os.ModeSymlink == 0 {
-		t.Skipf("symlink creation reported success but %q is not observable as a symlink (mode %v)", link, linkInfo.Mode())
-	}
-	resolved, err := filepath.EvalSymlinks(link)
-	if err != nil {
-		t.Skipf("symlink %q is not resolvable after successful creation: %v", link, err)
-	}
 	targetResolved, err := filepath.EvalSymlinks(target)
 	if err != nil {
 		t.Fatalf("resolve known symlink target %q: %v", target, err)
-	}
-	resolvedInfo, err := os.Stat(resolved)
-	if err != nil {
-		t.Skipf("stat resolved symlink %q -> %q: %v", link, resolved, err)
 	}
 	targetInfo, err := os.Stat(targetResolved)
 	if err != nil {
 		t.Fatalf("stat known symlink target %q: %v", targetResolved, err)
 	}
+	if err := os.Symlink(target, link); err != nil {
+		if symlinkCreationUnavailable(err) {
+			t.Skipf("symlink creation is unavailable: %v", err)
+		}
+		t.Fatalf("create symlink %q -> %q: %v", link, target, err)
+	}
+	linkInfo, err := os.Lstat(link)
+	if err != nil {
+		if runtime.GOOS == "windows" && errors.Is(err, fs.ErrNotExist) {
+			t.Skipf("Windows reported successful symlink creation but Lstat cannot observe %q: %v", link, err)
+		}
+		t.Fatalf("Lstat created symlink %q: %v", link, err)
+	}
+	if linkInfo.Mode()&os.ModeSymlink == 0 {
+		t.Fatalf("symlink creation reported success but %q is not a symlink (mode %v)", link, linkInfo.Mode())
+	}
+	resolved, err := filepath.EvalSymlinks(link)
+	if err != nil {
+		t.Fatalf("resolve created symlink %q: %v", link, err)
+	}
+	resolvedInfo, err := os.Stat(resolved)
+	if err != nil {
+		t.Fatalf("stat resolved symlink %q -> %q: %v", link, resolved, err)
+	}
 	if !os.SameFile(resolvedInfo, targetInfo) {
 		t.Fatalf("symlink %q resolved to %q instead of target %q", link, resolved, targetResolved)
+	}
+}
+
+func symlinkCreationUnavailable(err error) bool {
+	if errors.Is(err, fs.ErrPermission) || errors.Is(err, errors.ErrUnsupported) {
+		return true
+	}
+	if runtime.GOOS != "windows" {
+		return false
+	}
+	var errno syscall.Errno
+	return errors.As(err, &errno) && errno == syscall.Errno(1314) // ERROR_PRIVILEGE_NOT_HELD
+}
+
+func TestRequireObservableSymlinkRejectsInvalidFixtures(t *testing.T) {
+	const scenarioEnv = "GOODE_SANDBOX_SYMLINK_FIXTURE_SCENARIO"
+	if scenario := os.Getenv(scenarioEnv); scenario != "" {
+		root := t.TempDir()
+		target := filepath.Join(root, "target")
+		link := filepath.Join(root, "link")
+		switch scenario {
+		case "missing-target":
+			// Leave target absent.
+		case "preexisting-link":
+			if err := os.WriteFile(target, []byte("target"), 0o600); err != nil {
+				t.Fatalf("write target: %v", err)
+			}
+			if err := os.WriteFile(link, []byte("occupied"), 0o600); err != nil {
+				t.Fatalf("write preexisting link path: %v", err)
+			}
+		default:
+			t.Fatalf("unknown helper scenario %q", scenario)
+		}
+		requireObservableSymlink(t, target, link)
+		t.Fatalf("invalid symlink fixture %q unexpectedly passed", scenario)
+	}
+
+	for _, scenario := range []string{"missing-target", "preexisting-link"} {
+		t.Run(scenario, func(t *testing.T) {
+			cmd := exec.Command(os.Args[0], "-test.run=^TestRequireObservableSymlinkRejectsInvalidFixtures$", "-test.v")
+			cmd.Env = append(os.Environ(), scenarioEnv+"="+scenario)
+			output, err := cmd.CombinedOutput()
+			if err == nil {
+				t.Fatalf("invalid fixture child unexpectedly passed:\n%s", output)
+			}
+			if bytes.Contains(output, []byte("--- SKIP")) {
+				t.Fatalf("invalid fixture child was skipped instead of rejected:\n%s", output)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
Fixes #76.

## What changed

- Add one test-only `requireObservableSymlink` capability helper.
- Validate/stat the known target before creation; missing targets are fatal.
- Permit skips only for explicit creation permission/unsupported failures (including Windows privilege-not-held) and the observed Windows/Wine successful-create-but-`Lstat`-not-found case.
- Treat EEXIST, wrong mode, resolution/stat failures, and target identity mismatches as fatal setup/assertion failures.
- Add subprocess negative regressions proving missing-target and preexisting-link fixtures fail, never skip.
- Apply the helper to all 13 Windows-reachable directory/file symlink tests, including the previously false-green inside-root case.
- Keep dynamic post-capability swaps strict and the POSIX-only Bash swap outside this Windows portability scope.
- Change tests only; sandbox production code is unchanged.

## Exact revision

- Base: `46ad6aa40c67146b6453844671602c8967382a31`.
- Head: `421ab0f937bbe5de6e6e2b340b6a5d6295495b84`.
- Head tree and clean merge-tree: `8b65f1c8bf568c0952b25cc27aa79d54ea77430b`.

## Direct local evidence

- Linux focused matrix including negative fixtures and 13 security tests: normal count 50 PASS; race count 20 PASS.
- Linux all packages: uncached normal/race 13/13 PASS; vet/build/module verification PASS.
- Windows/amd64: all-package vet/build and sandbox test-binary compilation PASS.
- Real Wine 9 / Windows 10.0.19043: both invalid-fixture regressions PASS; all 13 capability tests explicitly SKIP only at the successful-create-but-`Lstat`-not-found condition.
- Real Wine full sandbox: PASS.

A Wine capability skip is not claimed as native-Windows symlink-security coverage; capable Linux filesystems retain the full behavioral assertions. No GitHub Actions were used or queried. Independent exact-head review is required before merge.