### PR TITLE
Stop provider admission after tool-stage cancellation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,7 +19,7 @@ and progressive disclosure through `agent_docs/`.
 - Compaction service: `compaction.Service` (`sdk/agent/compaction/service.go:10`)
 
 ### Runtime Capabilities
-- Boundary-aware steering before LLM calls and after each tool call (`sdk/agent/agent.go:226`, `sdk/agent/agent.go:448`, `sdk/agent/agent.go:959`)
+- Boundary-aware steering before LLM calls and after each tool call, plus a root-context cancellation gate before every provider admission (`sdk/agent/agent.go`, `sdk/agent/agent_cancel_boundary_test.go`)
 - Stream delta aggregation into a unified `Completion`, with response metadata propagated into `Completion.ResponseID` and surfaced on `UsageEvent` / `AutoContinueEvent` / `FinalResponseEvent` for downstream UI/aggregators (`sdk/agent/agent.go:255`, `sdk/agent/agent.go:285`, `sdk/agent/agent.go:348`, `sdk/agent/agent.go:646`)
 - Versioned prompt-usage normalization (`total_input_v1`) keeps cache/image counters as breakdowns, preserves raw provider zeroes, and falls back to one SDK history estimate plus a deduplicated warning when compatible gateways omit prompt tokens (`sdk/llm/usage.go`, `sdk/agent/agent.go`).
 - Versioned accounting projection emits one bounded, allowlisted

--- a/agent_docs/architecture.md
+++ b/agent_docs/architecture.md
@@ -170,6 +170,14 @@ Entry point: `QueryStreamWithSteering` (`sdk/agent/agent.go:197`).
 	 synthetic skipped results so provider history remains valid.
    - References: `sdk/agent/agent.go:448`, `sdk/agent/agent.go:959`
 
+   Root-turn cancellation is checked separately at the start of every loop
+   iteration, again at the final provider-admission boundary, and after each
+   tool execution. A tool handler that cancels the root context therefore
+   terminates the turn with a cancellation event: task-complete cannot override
+   it, unstarted sibling calls receive cancellation-specific skipped results
+   without executing, and even context-ignoring providers are not invoked for
+   another request.
+
 10. **Compaction gate and completion decision**
     - Check token thresholds and compact if needed.
     - If no further tool calls are required, emit final response.

--- a/agent_docs/testing.md
+++ b/agent_docs/testing.md
@@ -60,6 +60,12 @@ This document summarizes recommended test commands and current coverage focus.
   cancellation, partial history, continuation after steering, and the delayed
   host-acknowledgement race where steering is already in history before the
   current provider stage is canceled.
+- `sdk/agent/agent_cancel_boundary_test.go` proves that root-context
+  cancellation inside a tool handler stops before the next provider admission,
+  takes precedence over task-complete, closes but does not execute unstarted
+  sibling tool calls with cancellation-specific results (never false task-
+  completion text), and is rechecked after pre-provider steering delivery,
+  including with fake tools/models that intentionally ignore their context.
 - `sdk/agent/agent_max_iterations_test.go` covers max-iteration error/final
   events plus require-done recovery: an empty/text-only post-tool stop forces
   the next auto request to `tool_choice=required` with `DisableThinking` set (so

--- a/sdk/agent/agent.go
+++ b/sdk/agent/agent.go
@@ -641,6 +641,13 @@ func (a *Agent) QueryStreamWithSteering(ctx context.Context, input llm.Content, 
 		// tool-loop guards, idle detection, and context cancellation.
 		unlimitedIter := a.maxIterations < 0
 		for iter := 0; unlimitedIter || iter < a.maxIterations; iter++ {
+			// A synchronous tool callback may cancel the turn after returning its
+			// result. Enforce cancellation at the provider-admission boundary so a
+			// context-ignoring model cannot receive one more stale request.
+			if err := ctx.Err(); err != nil {
+				emitErr(a.errEvent(err))
+				return
+			}
 			if a.compactionInFlight.Load() {
 				if err := a.waitForCompactionIdle(ctx, out); err != nil {
 					emitErr(a.errEvent(err))
@@ -676,6 +683,13 @@ func (a *Agent) QueryStreamWithSteering(ctx context.Context, input llm.Content, 
 				case "", "auto":
 					requestToolChoice = llm.ToolChoice("required")
 				}
+			}
+			// Steering delivery and request preparation above can synchronously
+			// unblock a host that cancels the root turn. Recheck at the actual
+			// provider-admission boundary, not only at iteration entry.
+			if err := ctx.Err(); err != nil {
+				emitErr(a.errEvent(err))
+				return
 			}
 			comp, streamedText, err := a.invokeCompletionWithRetryAndSteering(ctx, llm.InvokeRequest{
 				Messages:   messages,
@@ -1120,6 +1134,15 @@ func (a *Agent) QueryStreamWithSteering(ctx context.Context, input llm.Content, 
 			// once every tool_use in the block has a matching tool_result.
 			var pendingBlockMessages []llm.Message
 			for idx, tc := range comp.ToolCalls {
+				if err := ctx.Err(); err != nil {
+					// Close every unstarted tool call before terminating so a later
+					// turn never inherits an unpaired assistant tool-call block.
+					a.appendCancellationSkippedToolResults(comp.ToolCalls[idx:])
+					a.appendMessages(pendingBlockMessages)
+					pendingBlockMessages = nil
+					emitErr(a.errEvent(err))
+					return
+				}
 				step := idx + 1
 				originalName := tc.Function.Name
 
@@ -1285,6 +1308,13 @@ func (a *Agent) QueryStreamWithSteering(ctx context.Context, input llm.Content, 
 				ctxTool, finishToolStage := a.beginSteeringInterruptibleStage(ctxToolBase)
 				content, toolErr := a.executeToolSafely(ctxTool, tool, execArgs)
 				stageInterruptedForSteering := finishToolStage()
+				rootCancelErr := ctx.Err()
+				if rootCancelErr != nil {
+					// Root cancellation outranks a tool's ordinary or task-complete
+					// return. Keep a contiguous result for this call, then terminate.
+					toolErr = rootCancelErr
+					content = llm.TextContent("Tool execution canceled before turn continuation: " + rootCancelErr.Error())
+				}
 				isError := toolErr != nil
 				if unknownToolFallback {
 					isError = true
@@ -1307,7 +1337,7 @@ func (a *Agent) QueryStreamWithSteering(ctx context.Context, input llm.Content, 
 
 				// Tool completion special-case.
 				var tce *tools.TaskCompleteError
-				if errors.As(toolErr, &tce) {
+				if rootCancelErr == nil && errors.As(toolErr, &tce) {
 					isError = false
 					status = "completed"
 					content = llm.TextContent("Task completed: " + tce.Message)
@@ -1319,6 +1349,13 @@ func (a *Agent) QueryStreamWithSteering(ctx context.Context, input llm.Content, 
 					a.mu.Unlock()
 					a.emitToolResultWithAccounting(out, ToolResultEvent{Tool: resolvedName, Result: content.PlainText(), ToolCallID: tc.ID, IsError: false, Metadata: meta}, originalResult, time.Since(start))
 					a.emitEvent(out, StepCompleteEvent{StepID: tc.ID, Status: status, DurationMS: time.Since(start).Milliseconds()})
+					if err := ctx.Err(); err != nil {
+						a.appendCancellationSkippedToolResults(comp.ToolCalls[idx+1:])
+						a.appendMessages(pendingBlockMessages)
+						pendingBlockMessages = nil
+						emitErr(a.errEvent(err))
+						return
+					}
 					// The turn ends here, but the assistant tool-call block must
 					// still be closed: a parallel `done` that is not the last
 					// call would otherwise leave tool_use blocks with no result,
@@ -1357,6 +1394,16 @@ func (a *Agent) QueryStreamWithSteering(ctx context.Context, input llm.Content, 
 
 				a.emitToolResultWithAccounting(out, ToolResultEvent{Tool: resolvedName, Result: content.PlainText(), ToolCallID: tc.ID, IsError: isError, Metadata: meta}, originalResult, time.Since(start))
 				a.emitEvent(out, StepCompleteEvent{StepID: tc.ID, Status: status, DurationMS: time.Since(start).Milliseconds()})
+				if rootCancelErr == nil {
+					rootCancelErr = ctx.Err()
+				}
+				if rootCancelErr != nil {
+					a.appendCancellationSkippedToolResults(comp.ToolCalls[idx+1:])
+					a.appendMessages(pendingBlockMessages)
+					pendingBlockMessages = nil
+					emitErr(a.errEvent(rootCancelErr))
+					return
+				}
 				if strings.EqualFold(strings.TrimSpace(resolvedName), "done") {
 					requireDoneRecoveryDisableThinkingActive = false
 				}
@@ -1843,9 +1890,15 @@ func (a *Agent) invokeCompletionWithSteering(ctx context.Context, req llm.Invoke
 		}
 		req.Messages = repaired
 	}
+	if err := ctx.Err(); err != nil {
+		return nil, false, err
+	}
 	if sm, ok := a.llm.(llm.StreamingChatModel); ok {
 		invokeCtx, finishStage := a.beginSteeringInterruptibleStage(ctx)
 		defer finishStage()
+		if err := invokeCtx.Err(); err != nil {
+			return nil, false, err
+		}
 		finishProviderStage := func(comp *llm.Completion, streamedText bool, fallbackErr error) (*llm.Completion, bool, error) {
 			stageInterruptedForSteering := finishStage()
 			if ctx.Err() == nil && stageInterruptedForSteering {
@@ -2060,6 +2113,10 @@ func (a *Agent) invokeCompletionWithSteering(ctx context.Context, req llm.Invoke
 		}
 	}
 	invokeCtx, finishStage := a.beginSteeringInterruptibleStage(ctx)
+	if err := invokeCtx.Err(); err != nil {
+		finishStage()
+		return nil, false, err
+	}
 	comp, err := a.llm.Invoke(invokeCtx, req)
 	stageInterruptedForSteering := finishStage()
 	if ctx.Err() == nil && stageInterruptedForSteering {
@@ -2067,6 +2124,9 @@ func (a *Agent) invokeCompletionWithSteering(ctx context.Context, req llm.Invoke
 			return comp, false, &llm.SteeringInterruptError{Message: msg.Content}
 		}
 		return comp, false, &llm.SteeringInterruptError{}
+	}
+	if err == nil && ctx.Err() != nil {
+		err = ctx.Err()
 	}
 	return comp, false, err
 }
@@ -2091,6 +2151,9 @@ func (a *Agent) invokeCompletionWithRetryAndSteering(ctx context.Context, req ll
 	var lastStreamed bool
 	var lastErr error
 	for attempt := 1; attempt <= maxAttempts; attempt++ {
+		if err := ctx.Err(); err != nil {
+			return lastComp, lastStreamed, err
+		}
 		comp, streamedText, err := a.invokeCompletionWithSteering(ctx, req, out, steeringCh)
 		if err == nil {
 			return comp, streamedText, nil
@@ -2263,9 +2326,19 @@ func (a *Agent) appendTurnEndSkippedToolResults(calls []llm.ToolCall) {
 	a.appendMessages(skippedToolResults(calls, toolSkippedByTurnEndText))
 }
 
+// appendCancellationSkippedToolResults closes a tool-call block whose
+// remaining calls were never executed because the root turn was canceled.
+func (a *Agent) appendCancellationSkippedToolResults(calls []llm.ToolCall) {
+	if a == nil || len(calls) == 0 {
+		return
+	}
+	a.appendMessages(skippedToolResults(calls, toolSkippedByCancellationText))
+}
+
 const (
-	toolSkippedBySteeringText = "[INFO] Tool call skipped because user steering changed the current direction before execution."
-	toolSkippedByTurnEndText  = "[INFO] Tool call skipped because the task was completed before this call ran."
+	toolSkippedBySteeringText     = "[INFO] Tool call skipped because user steering changed the current direction before execution."
+	toolSkippedByTurnEndText      = "[INFO] Tool call skipped because the task was completed before this call ran."
+	toolSkippedByCancellationText = "[ERROR] Tool call skipped because the active turn was canceled before this call ran."
 )
 
 // skippedToolResults builds the synthetic tool results that close an assistant

--- a/sdk/agent/agent_cancel_boundary_test.go
+++ b/sdk/agent/agent_cancel_boundary_test.go
@@ -1,0 +1,230 @@
+package agent
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/timwhitez/agent-sdk-golang/sdk/llm"
+	"github.com/timwhitez/agent-sdk-golang/sdk/tools"
+)
+
+type contextIgnoringCancelBoundaryModel struct {
+	calls atomic.Int32
+}
+
+type cancelBoundaryScriptModel struct {
+	calls     atomic.Int32
+	toolCalls []llm.ToolCall
+}
+
+type cancelOnInvokeBoundaryModel struct {
+	cancel context.CancelFunc
+	calls  atomic.Int32
+}
+
+func (m *cancelOnInvokeBoundaryModel) Provider() string { return "fake" }
+func (m *cancelOnInvokeBoundaryModel) Model() string    { return "cancel-on-invoke" }
+func (m *cancelOnInvokeBoundaryModel) Invoke(context.Context, llm.InvokeRequest) (*llm.Completion, error) {
+	m.calls.Add(1)
+	m.cancel()
+	return &llm.Completion{Content: llm.TextContent("must not become final")}, nil
+}
+
+func (m *cancelBoundaryScriptModel) Provider() string { return "fake" }
+func (m *cancelBoundaryScriptModel) Model() string    { return "cancel-boundary-script" }
+func (m *cancelBoundaryScriptModel) Invoke(context.Context, llm.InvokeRequest) (*llm.Completion, error) {
+	if m.calls.Add(1) == 1 {
+		return &llm.Completion{StopReason: "tool_calls", ToolCalls: m.toolCalls}, nil
+	}
+	return &llm.Completion{Content: llm.TextContent("unexpected provider continuation")}, nil
+}
+
+type cancelBoundaryTerminals struct {
+	canceled int
+	maxIter  int
+	finals   int
+}
+
+func collectCancelBoundaryTerminals(ch <-chan Event) cancelBoundaryTerminals {
+	var got cancelBoundaryTerminals
+	for event := range ch {
+		switch event := event.(type) {
+		case ErrorEvent:
+			switch event.Kind {
+			case "canceled":
+				got.canceled++
+			case "max_iterations":
+				got.maxIter++
+			}
+		case FinalResponseEvent:
+			got.finals++
+		}
+	}
+	return got
+}
+
+func cancelBoundaryCall(id, name string) llm.ToolCall {
+	return llm.ToolCall{ID: id, Type: "function", Function: llm.FunctionCall{Name: name, Arguments: `{}`}}
+}
+
+func (m *contextIgnoringCancelBoundaryModel) Provider() string { return "fake" }
+func (m *contextIgnoringCancelBoundaryModel) Model() string    { return "cancel-boundary" }
+func (m *contextIgnoringCancelBoundaryModel) Invoke(context.Context, llm.InvokeRequest) (*llm.Completion, error) {
+	call := m.calls.Add(1)
+	if call == 1 {
+		return &llm.Completion{StopReason: "tool_calls", ToolCalls: []llm.ToolCall{{
+			ID:   "cancel-turn-1",
+			Type: "function",
+			Function: llm.FunctionCall{
+				Name:      "cancel_turn",
+				Arguments: `{}`,
+			},
+		}}}, nil
+	}
+	return &llm.Completion{Content: llm.TextContent("provider must not be invoked")}, nil
+}
+
+func TestToolStageCancellationStopsBeforeNextProviderInvocation(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	model := &contextIgnoringCancelBoundaryModel{}
+	cancelTool := tools.Func[struct{}]("cancel_turn", "cancel the active turn", func(context.Context, struct{}, *tools.Container) (any, error) {
+		cancel()
+		return nil, errors.New("host authority became indeterminate")
+	})
+	ag, err := New(Config{LLM: model, Tools: []tools.Tool{cancelTool}, MaxIterations: 4})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	var canceled *ErrorEvent
+	for event := range ag.QueryStream(ctx, llm.TextContent("run")) {
+		if eventErr, ok := event.(ErrorEvent); ok && eventErr.Kind == "canceled" {
+			copy := eventErr
+			canceled = &copy
+		}
+	}
+	if got := model.calls.Load(); got != 1 {
+		t.Fatalf("provider calls = %d, want 1", got)
+	}
+	if canceled == nil || !strings.Contains(strings.ToLower(canceled.Message), "cancel") {
+		t.Fatalf("cancellation event = %#v", canceled)
+	}
+}
+
+func TestCancellationPrecedesTaskCompleteTerminal(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	model := &cancelBoundaryScriptModel{toolCalls: []llm.ToolCall{cancelBoundaryCall("done-1", "done")}}
+	doneTool := tools.Func[struct{}]("done", "done", func(context.Context, struct{}, *tools.Container) (any, error) {
+		cancel()
+		return nil, &tools.TaskCompleteError{Message: "must not complete after cancellation"}
+	})
+	ag, err := New(Config{LLM: model, Tools: []tools.Tool{doneTool}, MaxIterations: 4})
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := collectCancelBoundaryTerminals(ag.QueryStream(ctx, llm.TextContent("run")))
+	if model.calls.Load() != 1 || got.canceled != 1 || got.maxIter != 0 || got.finals != 0 {
+		t.Fatalf("calls=%d canceled=%d max_iterations=%d finals=%d; want 1/1/0/0", model.calls.Load(), got.canceled, got.maxIter, got.finals)
+	}
+}
+
+func TestRootCancellationSkipsUnstartedSiblingTools(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	model := &cancelBoundaryScriptModel{toolCalls: []llm.ToolCall{
+		cancelBoundaryCall("cancel-1", "cancel_turn"),
+		cancelBoundaryCall("mutate-2", "mutate_after_cancel"),
+	}}
+	var secondRuns atomic.Int32
+	cancelTool := tools.Func[struct{}]("cancel_turn", "cancel", func(context.Context, struct{}, *tools.Container) (any, error) {
+		cancel()
+		return nil, errors.New("authority indeterminate")
+	})
+	secondTool := tools.Func[struct{}]("mutate_after_cancel", "must not run", func(context.Context, struct{}, *tools.Container) (any, error) {
+		secondRuns.Add(1)
+		return "mutated", nil
+	})
+	ag, err := New(Config{LLM: model, Tools: []tools.Tool{cancelTool, secondTool}, MaxIterations: 4})
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := collectCancelBoundaryTerminals(ag.QueryStream(ctx, llm.TextContent("run")))
+	if secondRuns.Load() != 0 || model.calls.Load() != 1 || got.canceled != 1 || got.finals != 0 {
+		t.Fatalf("second_runs=%d provider_calls=%d canceled=%d finals=%d; want 0/1/1/0", secondRuns.Load(), model.calls.Load(), got.canceled, got.finals)
+	}
+	foundSkipped := false
+	for _, message := range ag.Messages() {
+		if message.Role == llm.RoleTool && message.ToolCallID == "mutate-2" && message.IsError {
+			foundSkipped = true
+			text := strings.ToLower(message.Content.PlainText())
+			if !strings.Contains(text, "cancel") {
+				t.Fatalf("canceled sibling result does not identify cancellation: %q", text)
+			}
+			if strings.Contains(text, "task was completed") {
+				t.Fatalf("canceled sibling result falsely identifies task completion: %q", text)
+			}
+		}
+	}
+	if !foundSkipped {
+		t.Fatalf("canceled sibling tool topology was not closed: %#v", ag.Messages())
+	}
+}
+
+func TestCancellationDuringPreProviderSteeringDrainPreventsAdmission(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	model := &cancelBoundaryScriptModel{}
+	steering := make(chan SteeringMsg, 3)
+	steering <- SteeringMsg{Content: "first steering"}
+	steering <- SteeringMsg{Content: "second steering"}
+	steering <- SteeringMsg{Content: "third steering"}
+	ag, err := New(Config{LLM: model, MaxIterations: 1, EventBufferSize: 1})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var got cancelBoundaryTerminals
+	canceledAtBoundary := false
+	for event := range ag.QueryStreamWithSteering(ctx, llm.TextContent("run"), steering) {
+		switch event := event.(type) {
+		case SteeringReceivedEvent:
+			if !canceledAtBoundary {
+				cancel()
+				canceledAtBoundary = true
+			}
+		case ErrorEvent:
+			if event.Kind == "canceled" {
+				got.canceled++
+			}
+			if event.Kind == "max_iterations" {
+				got.maxIter++
+			}
+		case FinalResponseEvent:
+			got.finals++
+		}
+	}
+	if !canceledAtBoundary {
+		t.Fatal("did not observe steering boundary")
+	}
+	if model.calls.Load() != 0 || got.canceled != 1 || got.maxIter != 0 || got.finals != 0 {
+		t.Fatalf("calls=%d canceled=%d max_iterations=%d finals=%d; want 0/1/0/0", model.calls.Load(), got.canceled, got.maxIter, got.finals)
+	}
+}
+
+func TestContextIgnoringProviderCompletionCannotOverrideRootCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	model := &cancelOnInvokeBoundaryModel{cancel: cancel}
+	ag, err := New(Config{LLM: model, MaxIterations: 1})
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := collectCancelBoundaryTerminals(ag.QueryStream(ctx, llm.TextContent("run")))
+	if model.calls.Load() != 1 || got.canceled != 1 || got.maxIter != 0 || got.finals != 0 {
+		t.Fatalf("calls=%d canceled=%d max_iterations=%d finals=%d; want 1/1/0/0", model.calls.Load(), got.canceled, got.maxIter, got.finals)
+	}
+}


### PR DESCRIPTION
## Summary

- enforce root-context cancellation at the top of every Agent iteration before compaction or provider admission
- prevent a tool-stage authority failure from becoming one more provider call, even when the model implementation ignores context
- document the distinct root-cancellation boundary and add a deterministic context-ignoring regression

Closes #81.

## Local verification

No GitHub Actions were used or queried.

- `go test ./...`
- `go test -race ./...`
- `go vet ./...`
- `go build ./...`
- focused regression count 20 on Linux
- Windows amd64 cross-build of all packages
- Windows amd64 Agent test binary compile
- focused regression count 20 under Wine
- Goode ACP integration regression count 20: indeterminate plan-prompt commit makes exactly one provider call
