### PR TITLE
Own provider admission snapshots

### DIFF
--- a/agent_docs/architecture.md
+++ b/agent_docs/architecture.md
@@ -51,10 +51,15 @@ Entry point: `QueryStreamWithSteering` (`sdk/agent/agent.go:197`).
 
 4. **Build tool definitions for provider**
    - Only non-hidden tools are sent to the model.
+   - Agent construction owns a deep copy of every tool schema, so the
+     provider-visible definition and runtime resolver cannot drift through a
+     caller-owned map mutation.
    - References: `sdk/agent/agent.go:233`, `sdk/tools/tool.go:30`
 
 5. **Invoke provider and emit immediate content/usage events**
    - Streaming is used when provider implements `StreamingChatModel`.
+   - Framework retries keep one captured model interface and give every
+     attempt an independent deep copy of the same logical request.
    - Provider usage is normalized to the versioned prompt-token contract. A
      zero/missing prompt count inside an otherwise present usage object is
      replaced with the shared history estimate and emits one quality warning

--- a/sdk/agent/agent.go
+++ b/sdk/agent/agent.go
@@ -375,6 +375,7 @@ func New(cfg Config) (*Agent, error) {
 		setter.SetWarningf(cfg.Warningf)
 	}
 
+	ownedTools := make([]tools.Tool, len(cfg.Tools))
 	toolMap := map[string]tools.Tool{}
 	toolPositions := map[string]int{}
 	for i, t := range cfg.Tools {
@@ -384,6 +385,12 @@ func New(cfg Config) (*Agent, error) {
 		if previous, exists := toolPositions[t.Name]; exists {
 			return nil, fmt.Errorf("agent: duplicate tool name %q at positions %d and %d", t.Name, previous+1, i+1)
 		}
+		cloned, err := llm.CloneInvokeRequest(llm.InvokeRequest{Tools: []llm.ToolDefinition{t.Definition()}})
+		if err != nil {
+			return nil, fmt.Errorf("agent: clone tool %q schema: %w", t.Name, err)
+		}
+		t.Schema = cloned.Tools[0].Parameters
+		ownedTools[i] = t
 		toolPositions[t.Name] = i
 		toolMap[t.Name] = t
 	}
@@ -428,9 +435,9 @@ func New(cfg Config) (*Agent, error) {
 		requireDone:           cfg.RequireDoneTool,
 		warningf:              cfg.Warningf,
 		hasCompactor:          hasCompactor,
-		tools:                 append([]tools.Tool(nil), cfg.Tools...),
+		tools:                 ownedTools,
 		toolMap:               toolMap,
-		toolMapNormalized:     buildNormalizedToolMap(toolMap, cfg.Tools),
+		toolMapNormalized:     buildNormalizedToolMap(toolMap, ownedTools),
 		deps:                  cfg.Deps,
 		compactor:             compSvc,
 		toolResultDumps:       make(map[string]toolResultDumpLifecycleEntry),
@@ -1865,8 +1872,20 @@ func (a *Agent) invokeCompletion(ctx context.Context, req llm.InvokeRequest, out
 // sends a steering message. The function returns a SteeringInterruptError in that case,
 // allowing the caller to immediately incorporate the steering message into the conversation.
 func (a *Agent) invokeCompletionWithSteering(ctx context.Context, req llm.InvokeRequest, out chan Event, steeringCh <-chan SteeringMsg) (*llm.Completion, bool, error) {
-	if a == nil || a.llm == nil {
+	if a == nil {
 		return nil, false, fmt.Errorf("agent: nil llm")
+	}
+	return a.invokeModelCompletionWithSteering(ctx, a.llm, req, out, steeringCh)
+}
+
+func (a *Agent) invokeModelCompletionWithSteering(ctx context.Context, model llm.ChatModel, req llm.InvokeRequest, out chan Event, steeringCh <-chan SteeringMsg) (*llm.Completion, bool, error) {
+	if model == nil {
+		return nil, false, fmt.Errorf("agent: nil llm")
+	}
+	var err error
+	req, err = llm.CloneInvokeRequest(req)
+	if err != nil {
+		return nil, false, fmt.Errorf("agent: clone invoke request: %w", err)
 	}
 	if ctx == nil {
 		ctx = context.Background()
@@ -1893,7 +1912,7 @@ func (a *Agent) invokeCompletionWithSteering(ctx context.Context, req llm.Invoke
 	if err := ctx.Err(); err != nil {
 		return nil, false, err
 	}
-	if sm, ok := a.llm.(llm.StreamingChatModel); ok {
+	if sm, ok := model.(llm.StreamingChatModel); ok {
 		invokeCtx, finishStage := a.beginSteeringInterruptibleStage(ctx)
 		defer finishStage()
 		if err := invokeCtx.Err(); err != nil {
@@ -2059,8 +2078,8 @@ func (a *Agent) invokeCompletionWithSteering(ctx context.Context, req llm.Invoke
 					}
 					if !sawDone {
 						return finishPartial(&llm.IncompleteStreamError{
-							Provider: a.llm.Provider(),
-							Model:    a.llm.Model(),
+							Provider: model.Provider(),
+							Model:    model.Model(),
 							Message:  "provider event channel closed before StreamDoneEvent",
 						})
 					}
@@ -2117,7 +2136,7 @@ func (a *Agent) invokeCompletionWithSteering(ctx context.Context, req llm.Invoke
 		finishStage()
 		return nil, false, err
 	}
-	comp, err := a.llm.Invoke(invokeCtx, req)
+	comp, err := model.Invoke(invokeCtx, req)
 	stageInterruptedForSteering := finishStage()
 	if ctx.Err() == nil && stageInterruptedForSteering {
 		if msg, ok := takeNextSteering(steeringCh); ok {
@@ -2139,12 +2158,19 @@ func (a *Agent) invokeCompletionWithRetry(ctx context.Context, req llm.InvokeReq
 // When a steering interrupt occurs, it immediately returns the partial completion along with
 // the SteeringInterruptError, allowing the agent loop to process the steering message.
 func (a *Agent) invokeCompletionWithRetryAndSteering(ctx context.Context, req llm.InvokeRequest, out chan Event, steeringCh <-chan SteeringMsg) (*llm.Completion, bool, error) {
+	if a == nil {
+		return nil, false, fmt.Errorf("agent: nil llm")
+	}
+	return a.invokeModelCompletionWithRetryAndSteering(ctx, a.llm, req, out, steeringCh)
+}
+
+func (a *Agent) invokeModelCompletionWithRetryAndSteering(ctx context.Context, model llm.ChatModel, req llm.InvokeRequest, out chan Event, steeringCh <-chan SteeringMsg) (*llm.Completion, bool, error) {
 	maxAttempts := defaultInvokeRetryMax
 	if a != nil && a.invokeRetryMax > 0 {
 		maxAttempts = a.invokeRetryMax
 	}
 	if maxAttempts <= 1 {
-		return a.invokeCompletionWithSteering(ctx, req, out, steeringCh)
+		return a.invokeModelCompletionWithSteering(ctx, model, req, out, steeringCh)
 	}
 
 	var lastComp *llm.Completion
@@ -2154,7 +2180,7 @@ func (a *Agent) invokeCompletionWithRetryAndSteering(ctx context.Context, req ll
 		if err := ctx.Err(); err != nil {
 			return lastComp, lastStreamed, err
 		}
-		comp, streamedText, err := a.invokeCompletionWithSteering(ctx, req, out, steeringCh)
+		comp, streamedText, err := a.invokeModelCompletionWithSteering(ctx, model, req, out, steeringCh)
 		if err == nil {
 			return comp, streamedText, nil
 		}

--- a/sdk/agent/agent_request_ownership_test.go
+++ b/sdk/agent/agent_request_ownership_test.go
@@ -1,0 +1,92 @@
+package agent
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net"
+	"testing"
+
+	"github.com/timwhitez/agent-sdk-golang/sdk/llm"
+	"github.com/timwhitez/agent-sdk-golang/sdk/tools"
+)
+
+func TestNewOwnsNestedToolSchemas(t *testing.T) {
+	schema := map[string]any{
+		"type": "object",
+		"properties": map[string]any{
+			"path": map[string]any{"type": "string"},
+		},
+	}
+	agent, err := New(Config{
+		LLM: historyCloneModel{},
+		Tools: []tools.Tool{{
+			Name:   "read",
+			Schema: schema,
+			Handler: func(context.Context, json.RawMessage, *tools.Container) (llm.Content, error) {
+				return llm.TextContent("ok"), nil
+			},
+		}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	schema["properties"].(map[string]any)["path"].(map[string]any)["type"] = "number"
+
+	got := agent.toolMap["read"].Schema["properties"].(map[string]any)["path"].(map[string]any)["type"]
+	if got != "string" {
+		t.Fatalf("agent tool schema changed through caller-owned map: %#v", got)
+	}
+}
+
+type requestMutatingRetryModel struct {
+	calls int
+	err   error
+}
+
+func (m *requestMutatingRetryModel) Provider() string { return "stub" }
+func (m *requestMutatingRetryModel) Model() string    { return "stub" }
+
+func (m *requestMutatingRetryModel) Invoke(_ context.Context, request llm.InvokeRequest) (*llm.Completion, error) {
+	m.calls++
+	if m.calls == 1 {
+		request.Messages[0].Content.Text = "mutated"
+		request.Tools[0].Parameters["type"] = "array"
+		request.Responses.OutputSchema["type"] = "array"
+		return nil, &net.DNSError{Err: "i/o timeout", IsTimeout: true}
+	}
+	if got := request.Messages[0].Content.Text; got != "original" {
+		m.err = fmt.Errorf("retry message = %q", got)
+	}
+	if got := request.Tools[0].Parameters["type"]; got != "object" {
+		m.err = fmt.Errorf("retry tool schema = %#v", got)
+	}
+	if got := request.Responses.OutputSchema["type"]; got != "object" {
+		m.err = fmt.Errorf("retry response schema = %#v", got)
+	}
+	return &llm.Completion{Content: llm.TextContent("ok"), StopReason: "stop"}, nil
+}
+
+func TestInvokeRetryUsesFreshRequestClone(t *testing.T) {
+	model := &requestMutatingRetryModel{}
+	agent, err := New(Config{LLM: model, InvokeRetryMaxAttempts: 2})
+	if err != nil {
+		t.Fatal(err)
+	}
+	request := llm.InvokeRequest{
+		Messages: []llm.Message{{Role: llm.RoleUser, Content: llm.TextContent("original")}},
+		Tools:    []llm.ToolDefinition{{Name: "read", Parameters: map[string]any{"type": "object"}}},
+		Responses: &llm.ResponsesOptions{
+			OutputSchema: map[string]any{"type": "object"},
+		},
+	}
+	if _, _, err := agent.invokeCompletionWithRetry(context.Background(), request, make(chan Event, 8)); err != nil {
+		t.Fatal(err)
+	}
+	if model.calls != 2 {
+		t.Fatalf("invoke calls = %d, want 2", model.calls)
+	}
+	if model.err != nil {
+		t.Fatal(model.err)
+	}
+}

--- a/sdk/llm/clone.go
+++ b/sdk/llm/clone.go
@@ -1,8 +1,8 @@
 package llm
 
 import (
-	"encoding/json"
 	"fmt"
+	"reflect"
 )
 
 // CloneInvokeRequest returns a deep copy of a provider request. The clone owns
@@ -44,7 +44,10 @@ func cloneResponsesOptions(options *ResponsesOptions) (*ResponsesOptions, error)
 	out.UseInstructions = cloneBool(options.UseInstructions)
 	out.ParallelToolCalls = cloneBool(options.ParallelToolCalls)
 	out.Store = cloneBool(options.Store)
-	out.Include = append([]string(nil), options.Include...)
+	if options.Include != nil {
+		out.Include = make([]string, len(options.Include))
+		copy(out.Include, options.Include)
+	}
 	if options.Text != nil {
 		text := *options.Text
 		if options.Text.Format != nil {
@@ -82,15 +85,107 @@ func cloneJSONMap(value map[string]any) (map[string]any, error) {
 	if value == nil {
 		return nil, nil
 	}
-	data, err := json.Marshal(value)
+	cloned, err := cloneJSONValue(reflect.ValueOf(value), 0)
 	if err != nil {
 		return nil, err
 	}
-	var out map[string]any
-	if err := json.Unmarshal(data, &out); err != nil {
-		return nil, err
+	out, ok := cloned.Interface().(map[string]any)
+	if !ok {
+		return nil, fmt.Errorf("cloned JSON map has type %T", cloned.Interface())
 	}
 	return out, nil
+}
+
+func cloneJSONValue(value reflect.Value, depth int) (reflect.Value, error) {
+	if !value.IsValid() {
+		return value, nil
+	}
+	if depth > 128 {
+		return reflect.Value{}, fmt.Errorf("JSON value nesting exceeds 128 levels")
+	}
+	switch value.Kind() {
+	case reflect.Interface:
+		if value.IsNil() {
+			return reflect.Zero(value.Type()), nil
+		}
+		item, err := cloneJSONValue(value.Elem(), depth+1)
+		if err != nil {
+			return reflect.Value{}, err
+		}
+		out := reflect.New(value.Type()).Elem()
+		out.Set(item)
+		return out, nil
+	case reflect.Pointer:
+		if value.IsNil() {
+			return reflect.Zero(value.Type()), nil
+		}
+		item, err := cloneJSONValue(value.Elem(), depth+1)
+		if err != nil {
+			return reflect.Value{}, err
+		}
+		out := reflect.New(value.Type().Elem())
+		out.Elem().Set(item)
+		return out, nil
+	case reflect.Map:
+		if value.IsNil() {
+			return reflect.Zero(value.Type()), nil
+		}
+		out := reflect.MakeMapWithSize(value.Type(), value.Len())
+		iter := value.MapRange()
+		for iter.Next() {
+			key, err := cloneJSONValue(iter.Key(), depth+1)
+			if err != nil {
+				return reflect.Value{}, err
+			}
+			item, err := cloneJSONValue(iter.Value(), depth+1)
+			if err != nil {
+				return reflect.Value{}, err
+			}
+			out.SetMapIndex(key, item)
+		}
+		return out, nil
+	case reflect.Slice:
+		if value.IsNil() {
+			return reflect.Zero(value.Type()), nil
+		}
+		out := reflect.MakeSlice(value.Type(), value.Len(), value.Len())
+		for i := 0; i < value.Len(); i++ {
+			item, err := cloneJSONValue(value.Index(i), depth+1)
+			if err != nil {
+				return reflect.Value{}, err
+			}
+			out.Index(i).Set(item)
+		}
+		return out, nil
+	case reflect.Array:
+		out := reflect.New(value.Type()).Elem()
+		for i := 0; i < value.Len(); i++ {
+			item, err := cloneJSONValue(value.Index(i), depth+1)
+			if err != nil {
+				return reflect.Value{}, err
+			}
+			out.Index(i).Set(item)
+		}
+		return out, nil
+	case reflect.Struct:
+		out := reflect.New(value.Type()).Elem()
+		out.Set(value)
+		for i := 0; i < value.NumField(); i++ {
+			if !out.Field(i).CanSet() || !value.Field(i).CanInterface() {
+				continue
+			}
+			item, err := cloneJSONValue(value.Field(i), depth+1)
+			if err != nil {
+				return reflect.Value{}, err
+			}
+			out.Field(i).Set(item)
+		}
+		return out, nil
+	case reflect.Chan, reflect.Func, reflect.UnsafePointer:
+		return reflect.Value{}, fmt.Errorf("unsupported JSON value type %s", value.Type())
+	default:
+		return value, nil
+	}
 }
 
 // CloneMessages returns a deep copy of a conversation history. The returned

--- a/sdk/llm/clone.go
+++ b/sdk/llm/clone.go
@@ -1,5 +1,98 @@
 package llm
 
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// CloneInvokeRequest returns a deep copy of a provider request. The clone owns
+// all mutable message, tool-schema, option, slice, map, and pointer state.
+func CloneInvokeRequest(request InvokeRequest) (InvokeRequest, error) {
+	out := request
+	out.Messages = CloneMessages(request.Messages)
+	if request.Tools != nil {
+		out.Tools = make([]ToolDefinition, len(request.Tools))
+		for i, definition := range request.Tools {
+			parameters, err := cloneJSONMap(definition.Parameters)
+			if err != nil {
+				return InvokeRequest{}, fmt.Errorf("clone tool %q parameters: %w", definition.Name, err)
+			}
+			out.Tools[i] = definition
+			out.Tools[i].Parameters = parameters
+		}
+	}
+	if request.Temperature != nil {
+		value := *request.Temperature
+		out.Temperature = &value
+	}
+	if request.Responses != nil {
+		responses, err := cloneResponsesOptions(request.Responses)
+		if err != nil {
+			return InvokeRequest{}, err
+		}
+		out.Responses = responses
+	}
+	return out, nil
+}
+
+func cloneResponsesOptions(options *ResponsesOptions) (*ResponsesOptions, error) {
+	if options == nil {
+		return nil, nil
+	}
+	out := *options
+	out.UseResponseItems = cloneBool(options.UseResponseItems)
+	out.UseInstructions = cloneBool(options.UseInstructions)
+	out.ParallelToolCalls = cloneBool(options.ParallelToolCalls)
+	out.Store = cloneBool(options.Store)
+	out.Include = append([]string(nil), options.Include...)
+	if options.Text != nil {
+		text := *options.Text
+		if options.Text.Format != nil {
+			format := *options.Text.Format
+			schema, err := cloneJSONMap(options.Text.Format.Schema)
+			if err != nil {
+				return nil, fmt.Errorf("clone responses text schema: %w", err)
+			}
+			format.Schema = schema
+			text.Format = &format
+		}
+		out.Text = &text
+	}
+	if options.Reasoning != nil {
+		reasoning := *options.Reasoning
+		out.Reasoning = &reasoning
+	}
+	outputSchema, err := cloneJSONMap(options.OutputSchema)
+	if err != nil {
+		return nil, fmt.Errorf("clone responses output schema: %w", err)
+	}
+	out.OutputSchema = outputSchema
+	return &out, nil
+}
+
+func cloneBool(value *bool) *bool {
+	if value == nil {
+		return nil
+	}
+	out := *value
+	return &out
+}
+
+func cloneJSONMap(value map[string]any) (map[string]any, error) {
+	if value == nil {
+		return nil, nil
+	}
+	data, err := json.Marshal(value)
+	if err != nil {
+		return nil, err
+	}
+	var out map[string]any
+	if err := json.Unmarshal(data, &out); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 // CloneMessages returns a deep copy of a conversation history. The returned
 // graph owns every mutable slice and pointee carried by Message, so callers may
 // modify it without changing the source history.

--- a/sdk/llm/clone.go
+++ b/sdk/llm/clone.go
@@ -6,7 +6,9 @@ import (
 )
 
 // CloneInvokeRequest returns a deep copy of a provider request. The clone owns
-// all mutable message, tool-schema, option, slice, map, and pointer state.
+// all mutable message, tool-schema, option, slice, map, and pointer state. It
+// fails closed when a concrete value hides mutable state that reflection cannot
+// safely copy without unsafe access.
 func CloneInvokeRequest(request InvokeRequest) (InvokeRequest, error) {
 	out := request
 	out.Messages = CloneMessages(request.Messages)
@@ -171,7 +173,11 @@ func cloneJSONValue(value reflect.Value, depth int) (reflect.Value, error) {
 		out := reflect.New(value.Type()).Elem()
 		out.Set(value)
 		for i := 0; i < value.NumField(); i++ {
-			if !out.Field(i).CanSet() || !value.Field(i).CanInterface() {
+			field := value.Type().Field(i)
+			if !value.Field(i).CanInterface() {
+				if typeContainsMutableState(field.Type, make(map[reflect.Type]bool)) {
+					return reflect.Value{}, fmt.Errorf("cannot deep clone unexported mutable field %s.%s", value.Type(), field.Name)
+				}
 				continue
 			}
 			item, err := cloneJSONValue(value.Field(i), depth+1)
@@ -186,6 +192,30 @@ func cloneJSONValue(value reflect.Value, depth int) (reflect.Value, error) {
 	default:
 		return value, nil
 	}
+}
+
+func typeContainsMutableState(value reflect.Type, visiting map[reflect.Type]bool) bool {
+	if value == nil {
+		return false
+	}
+	switch value.Kind() {
+	case reflect.Chan, reflect.Func, reflect.Interface, reflect.Map, reflect.Pointer, reflect.Slice, reflect.UnsafePointer:
+		return true
+	case reflect.Array:
+		return typeContainsMutableState(value.Elem(), visiting)
+	case reflect.Struct:
+		if visiting[value] {
+			return false
+		}
+		visiting[value] = true
+		defer delete(visiting, value)
+		for i := 0; i < value.NumField(); i++ {
+			if typeContainsMutableState(value.Field(i).Type, visiting) {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 // CloneMessages returns a deep copy of a conversation history. The returned

--- a/sdk/llm/clone_invoke_request_test.go
+++ b/sdk/llm/clone_invoke_request_test.go
@@ -1,0 +1,52 @@
+package llm
+
+import "testing"
+
+func TestCloneInvokeRequestOwnsNestedMutableState(t *testing.T) {
+	enabled := true
+	temperature := 0.25
+	original := InvokeRequest{
+		Messages: []Message{{
+			Role:    RoleUser,
+			Content: Content{Blocks: []ContentBlock{{Type: "image_url", ImageURL: &ImageURL{URL: "before"}}}},
+		}},
+		Tools:       []ToolDefinition{{Name: "read", Parameters: map[string]any{"properties": map[string]any{"path": map[string]any{"type": "string"}}}}},
+		Temperature: &temperature,
+		Responses: &ResponsesOptions{
+			UseResponseItems:  &enabled,
+			Include:           []string{"usage"},
+			Text:              &ResponsesTextControls{Format: &ResponsesTextFormat{Schema: map[string]any{"type": "object"}}},
+			ParallelToolCalls: &enabled,
+			OutputSchema:      map[string]any{"type": "object"},
+		},
+	}
+
+	cloned, err := CloneInvokeRequest(original)
+	if err != nil {
+		t.Fatal(err)
+	}
+	original.Messages[0].Content.Blocks[0].ImageURL.URL = "after"
+	original.Tools[0].Parameters["properties"].(map[string]any)["path"].(map[string]any)["type"] = "number"
+	*original.Temperature = 1
+	*original.Responses.UseResponseItems = false
+	original.Responses.Include[0] = "mutated"
+	original.Responses.Text.Format.Schema["type"] = "array"
+	*original.Responses.ParallelToolCalls = false
+	original.Responses.OutputSchema["type"] = "array"
+
+	if got := cloned.Messages[0].Content.Blocks[0].ImageURL.URL; got != "before" {
+		t.Fatalf("message URL = %q", got)
+	}
+	if got := cloned.Tools[0].Parameters["properties"].(map[string]any)["path"].(map[string]any)["type"]; got != "string" {
+		t.Fatalf("tool schema type = %#v", got)
+	}
+	if *cloned.Temperature != 0.25 || !*cloned.Responses.UseResponseItems || cloned.Responses.Include[0] != "usage" {
+		t.Fatalf("request pointers or slices were shared: %#v", cloned)
+	}
+	if got := cloned.Responses.Text.Format.Schema["type"]; got != "object" {
+		t.Fatalf("text schema type = %#v", got)
+	}
+	if !*cloned.Responses.ParallelToolCalls || cloned.Responses.OutputSchema["type"] != "object" {
+		t.Fatalf("responses state was shared: %#v", cloned.Responses)
+	}
+}

--- a/sdk/llm/clone_invoke_request_test.go
+++ b/sdk/llm/clone_invoke_request_test.go
@@ -1,6 +1,9 @@
 package llm
 
-import "testing"
+import (
+	"encoding/json"
+	"testing"
+)
 
 func TestCloneInvokeRequestOwnsNestedMutableState(t *testing.T) {
 	enabled := true
@@ -10,7 +13,11 @@ func TestCloneInvokeRequestOwnsNestedMutableState(t *testing.T) {
 			Role:    RoleUser,
 			Content: Content{Blocks: []ContentBlock{{Type: "image_url", ImageURL: &ImageURL{URL: "before"}}}},
 		}},
-		Tools:       []ToolDefinition{{Name: "read", Parameters: map[string]any{"properties": map[string]any{"path": map[string]any{"type": "string"}}}}},
+		Tools: []ToolDefinition{{Name: "read", Parameters: map[string]any{
+			"properties": map[string]any{"path": map[string]any{"type": "string", "maximum": uint64(9007199254740993), "multipleOf": json.Number("0.1")}},
+			"required":   []string{"path"},
+			"opaque":     json.RawMessage(`{"type":"string"}`),
+		}}},
 		Temperature: &temperature,
 		Responses: &ResponsesOptions{
 			UseResponseItems:  &enabled,
@@ -40,6 +47,19 @@ func TestCloneInvokeRequestOwnsNestedMutableState(t *testing.T) {
 	if got := cloned.Tools[0].Parameters["properties"].(map[string]any)["path"].(map[string]any)["type"]; got != "string" {
 		t.Fatalf("tool schema type = %#v", got)
 	}
+	pathSchema := cloned.Tools[0].Parameters["properties"].(map[string]any)["path"].(map[string]any)
+	if got, ok := pathSchema["maximum"].(uint64); !ok || got != 9007199254740993 {
+		t.Fatalf("tool schema maximum = %#v (%T)", pathSchema["maximum"], pathSchema["maximum"])
+	}
+	if got, ok := pathSchema["multipleOf"].(json.Number); !ok || got != json.Number("0.1") {
+		t.Fatalf("tool schema multipleOf = %#v (%T)", pathSchema["multipleOf"], pathSchema["multipleOf"])
+	}
+	if _, ok := cloned.Tools[0].Parameters["required"].([]string); !ok {
+		t.Fatalf("required type = %T, want []string", cloned.Tools[0].Parameters["required"])
+	}
+	if _, ok := cloned.Tools[0].Parameters["opaque"].(json.RawMessage); !ok {
+		t.Fatalf("opaque type = %T, want json.RawMessage", cloned.Tools[0].Parameters["opaque"])
+	}
 	if *cloned.Temperature != 0.25 || !*cloned.Responses.UseResponseItems || cloned.Responses.Include[0] != "usage" {
 		t.Fatalf("request pointers or slices were shared: %#v", cloned)
 	}
@@ -48,5 +68,15 @@ func TestCloneInvokeRequestOwnsNestedMutableState(t *testing.T) {
 	}
 	if !*cloned.Responses.ParallelToolCalls || cloned.Responses.OutputSchema["type"] != "object" {
 		t.Fatalf("responses state was shared: %#v", cloned.Responses)
+	}
+}
+
+func TestCloneInvokeRequestPreservesNonNilEmptyInclude(t *testing.T) {
+	cloned, err := CloneInvokeRequest(InvokeRequest{Responses: &ResponsesOptions{Include: []string{}}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cloned.Responses.Include == nil {
+		t.Fatal("non-nil empty Include became nil")
 	}
 }

--- a/sdk/llm/clone_invoke_request_test.go
+++ b/sdk/llm/clone_invoke_request_test.go
@@ -2,8 +2,17 @@ package llm
 
 import (
 	"encoding/json"
+	"strings"
 	"testing"
 )
+
+type marshalOnlySchemaValue struct {
+	state map[string]any
+}
+
+func (value marshalOnlySchemaValue) MarshalJSON() ([]byte, error) {
+	return json.Marshal(value.state)
+}
 
 func TestCloneInvokeRequestOwnsNestedMutableState(t *testing.T) {
 	enabled := true
@@ -78,5 +87,15 @@ func TestCloneInvokeRequestPreservesNonNilEmptyInclude(t *testing.T) {
 	}
 	if cloned.Responses.Include == nil {
 		t.Fatal("non-nil empty Include became nil")
+	}
+}
+
+func TestCloneInvokeRequestRejectsUnexportedMutableState(t *testing.T) {
+	_, err := CloneInvokeRequest(InvokeRequest{Tools: []ToolDefinition{{
+		Name:       "custom",
+		Parameters: map[string]any{"custom": marshalOnlySchemaValue{state: map[string]any{"type": "string"}}},
+	}}})
+	if err == nil || !strings.Contains(err.Error(), "unexported mutable field") {
+		t.Fatalf("error = %v, want unexported mutable field rejection", err)
 	}
 }

--- a/sdk/llm/openai/responses_clone_parity_test.go
+++ b/sdk/llm/openai/responses_clone_parity_test.go
@@ -1,0 +1,49 @@
+package openai
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+
+	"github.com/timwhitez/agent-sdk-golang/sdk/llm"
+)
+
+func TestCloneInvokeRequestPreservesResponsesPayload(t *testing.T) {
+	request := llm.InvokeRequest{
+		Messages: []llm.Message{llm.NewUserMessage("hello")},
+		Tools: []llm.ToolDefinition{{
+			Name: "bounded",
+			Parameters: map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"value": map[string]any{"type": "integer", "maximum": uint64(9007199254740993)},
+				},
+				"required": []string{"value"},
+			},
+		}},
+	}
+	cloned, err := llm.CloneInvokeRequest(request)
+	if err != nil {
+		t.Fatal(err)
+	}
+	client := &ResponsesClient{ModelName: "test-model"}
+	before, err := client.buildRequest(request)
+	if err != nil {
+		t.Fatal(err)
+	}
+	after, err := client.buildRequest(cloned)
+	if err != nil {
+		t.Fatal(err)
+	}
+	beforeJSON, err := json.Marshal(before)
+	if err != nil {
+		t.Fatal(err)
+	}
+	afterJSON, err := json.Marshal(after)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(beforeJSON, afterJSON) {
+		t.Fatalf("Responses payload changed after clone:\nbefore=%s\nafter=%s", beforeJSON, afterJSON)
+	}
+}


### PR DESCRIPTION
## Scope

First narrow, zero-wire-change slice of #83:

- deep-copy tool schemas when Agent takes ownership of Config.Tools;
- deep-copy every InvokeRequest, including nested Responses options, before each provider attempt;
- capture one ChatModel interface for the framework retry loop;
- fail closed when a concrete custom value hides mutable state that cannot be copied safely without unsafe access;
- document the admission ownership boundary.

## Compatibility

Concrete JSON value types, large integers, json.Number, typed slices, json.RawMessage, nil/non-nil-empty state, and OpenAI Responses payloads are preserved. Standard Prompt, tool order, ToolChoice, retry counts, events, and Provider payloads are unchanged.

## Non-goals

No Frame ID, fingerprint, observer, lineage, scheduler, persistence, prompt change, provider payload change, unsafe reflection, or production concurrency. This PR does not close #83.

## Local validation at exact head fe1323158d213d7a54aa9527fdb51042d9d54b88

- GOTOOLCHAIN=go1.22.12 go test ./... -count=1
- GOTOOLCHAIN=go1.22.12 go vet ./...
- GOTOOLCHAIN=go1.22.12 go test -race ./sdk/agent ./sdk/llm/... -count=1
- git diff --check

All passed locally. Two earlier exact heads received independent REQUEST_CHANGES; both blocker sets were fixed and a fresh exact-head review is required before merge.