### PR TITLE
Reject duplicate tool call IDs before execution

### DIFF
--- a/agent_docs/architecture.md
+++ b/agent_docs/architecture.md
@@ -74,6 +74,9 @@ Entry point: `QueryStreamWithSteering` (`sdk/agent/agent.go:197`).
      thinking blocks retain their opaque signature alongside the exact thinking
      text so a following tool-result request can serialize the assistant turn
      without dropping provider-required state.
+   - A provider response containing duplicate non-empty tool-call IDs is
+     rejected before the assistant block enters history or any handler runs;
+     already-reported usage remains accounted.
    - References: `sdk/agent/agent.go:268`
 
 7. **Continuation gate**

--- a/sdk/agent/agent.go
+++ b/sdk/agent/agent.go
@@ -1708,19 +1708,16 @@ func duplicateToolCallIDPositions(toolCalls []llm.ToolCall) (first, second int, 
 
 func (a *toolCallAccumulator) finalize() []llm.ToolCall {
 	out := []llm.ToolCall{}
-	for i, it := range a.items {
+	for _, it := range a.items {
 		name := strings.TrimSpace(it.name.String())
 		args := strings.TrimSpace(it.args.String())
 		if name == "" {
 			continue
 		}
 		id := strings.TrimSpace(it.id)
-		if id == "" {
-			id = fmt.Sprintf("%s%d", syntheticToolCallIDPrefix, i)
-		}
 		out = append(out, llm.ToolCall{ID: id, Type: "function", Function: llm.FunctionCall{Name: name, Arguments: args}})
 	}
-	return out
+	return ensureSyntheticToolCallIDs(out)
 }
 
 type repeatedToolSignatureGuard struct {

--- a/sdk/agent/agent.go
+++ b/sdk/agent/agent.go
@@ -841,6 +841,14 @@ func (a *Agent) QueryStreamWithSteering(ctx context.Context, input llm.Content, 
 			if comp.Usage != nil {
 				a.emitUsageWithAccounting(out, *comp.Usage, responseID)
 			}
+			if first, second, duplicate := duplicateToolCallIDPositions(comp.ToolCalls); duplicate {
+				emitErr(ErrorEvent{
+					Provider: a.llm.Provider(),
+					Kind:     "invalid_tool_call_block",
+					Message:  fmt.Sprintf("provider returned duplicate tool_call_id values at positions %d and %d; no tools were executed", first+1, second+1),
+				})
+				return
+			}
 
 			if comp.Thinking != "" {
 				a.emitEvent(out, ThinkingEvent{Content: comp.Thinking})
@@ -1684,6 +1692,18 @@ func ensureSyntheticToolCallIDs(toolCalls []llm.ToolCall) []llm.ToolCall {
 		}
 	}
 	return out
+}
+
+func duplicateToolCallIDPositions(toolCalls []llm.ToolCall) (first, second int, duplicate bool) {
+	seen := make(map[string]int, len(toolCalls))
+	for i, toolCall := range toolCalls {
+		id := strings.TrimSpace(toolCall.ID)
+		if previous, exists := seen[id]; exists {
+			return previous, i, true
+		}
+		seen[id] = i
+	}
+	return 0, 0, false
 }
 
 func (a *toolCallAccumulator) finalize() []llm.ToolCall {

--- a/sdk/agent/agent_duplicate_tool_call_id_test.go
+++ b/sdk/agent/agent_duplicate_tool_call_id_test.go
@@ -3,6 +3,7 @@ package agent
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"strings"
 	"sync/atomic"
 	"testing"
@@ -13,6 +14,31 @@ import (
 
 type duplicateToolCallIDModel struct {
 	calls int
+}
+
+type streamingSyntheticIDCollisionModel struct {
+	calls int
+}
+
+func (m *streamingSyntheticIDCollisionModel) Provider() string { return "stub" }
+func (m *streamingSyntheticIDCollisionModel) Model() string    { return "stub" }
+func (m *streamingSyntheticIDCollisionModel) Invoke(context.Context, llm.InvokeRequest) (*llm.Completion, error) {
+	return nil, errors.New("non-streaming invoke should not be called")
+}
+
+func (m *streamingSyntheticIDCollisionModel) InvokeStream(context.Context, llm.InvokeRequest) (<-chan llm.StreamEvent, error) {
+	m.calls++
+	events := make(chan llm.StreamEvent, 5)
+	if m.calls == 1 {
+		events <- llm.StreamToolCallDeltaEvent{Index: 0, NameDelta: "mutate", ArgumentsDelta: `{}`}
+		events <- llm.StreamToolCallDeltaEvent{Index: 1, ID: "call_0", NameDelta: "mutate", ArgumentsDelta: `{}`}
+		events <- llm.StreamDoneEvent{StopReason: "tool_calls"}
+	} else {
+		events <- llm.StreamTextDeltaEvent{Delta: "recovered"}
+		events <- llm.StreamDoneEvent{StopReason: "stop"}
+	}
+	close(events)
+	return events, nil
 }
 
 func (m *duplicateToolCallIDModel) Provider() string { return "stub" }
@@ -83,4 +109,44 @@ func TestDuplicateToolCallIDsFailBeforeAnyHandler(t *testing.T) {
 	if err != nil || response != "recovered" {
 		t.Fatalf("next query response=%q err=%v", response, err)
 	}
+}
+
+func TestStreamingMissingIDDoesNotCollideWithExistingSyntheticPrefix(t *testing.T) {
+	var executions atomic.Int32
+	model := &streamingSyntheticIDCollisionModel{}
+	agent, err := New(Config{
+		LLM: model,
+		Tools: []tools.Tool{{
+			Name: "mutate",
+			Handler: func(context.Context, json.RawMessage, *tools.Container) (llm.Content, error) {
+				executions.Add(1)
+				return llm.TextContent("applied"), nil
+			},
+		}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	response, err := agent.Query(context.Background(), "run both")
+	if err != nil || response != "recovered" {
+		t.Fatalf("response=%q err=%v", response, err)
+	}
+	if got := executions.Load(); got != 2 {
+		t.Fatalf("handler executions = %d, want 2", got)
+	}
+	messages := agent.Messages()
+	for i, message := range messages {
+		if message.Role != llm.RoleAssistant || len(message.ToolCalls) != 2 {
+			continue
+		}
+		if message.ToolCalls[0].ID == message.ToolCalls[1].ID {
+			t.Fatalf("assistant message %d has colliding IDs: %#v", i, message.ToolCalls)
+		}
+		if message.ToolCalls[1].ID != "call_0" {
+			t.Fatalf("explicit ID changed: %#v", message.ToolCalls)
+		}
+		return
+	}
+	t.Fatal("missing assistant tool block")
 }

--- a/sdk/agent/agent_duplicate_tool_call_id_test.go
+++ b/sdk/agent/agent_duplicate_tool_call_id_test.go
@@ -1,0 +1,86 @@
+package agent
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/timwhitez/agent-sdk-golang/sdk/llm"
+	"github.com/timwhitez/agent-sdk-golang/sdk/tools"
+)
+
+type duplicateToolCallIDModel struct {
+	calls int
+}
+
+func (m *duplicateToolCallIDModel) Provider() string { return "stub" }
+func (m *duplicateToolCallIDModel) Model() string    { return "stub" }
+
+func (m *duplicateToolCallIDModel) Invoke(context.Context, llm.InvokeRequest) (*llm.Completion, error) {
+	m.calls++
+	if m.calls > 1 {
+		return &llm.Completion{Content: llm.TextContent("recovered"), StopReason: "stop"}, nil
+	}
+	return &llm.Completion{
+		ToolCalls: []llm.ToolCall{
+			{ID: "sensitive-duplicate-id", Type: "function", Function: llm.FunctionCall{Name: "mutate", Arguments: `{}`}},
+			{ID: " sensitive-duplicate-id ", Type: "function", Function: llm.FunctionCall{Name: "mutate", Arguments: `{}`}},
+		},
+		Usage:      &llm.Usage{PromptTokens: 2, CompletionTokens: 1, TotalTokens: 3},
+		StopReason: "tool_calls",
+	}, nil
+}
+
+func TestDuplicateToolCallIDsFailBeforeAnyHandler(t *testing.T) {
+	var executions atomic.Int32
+	model := &duplicateToolCallIDModel{}
+	agent, err := New(Config{
+		LLM: model,
+		Tools: []tools.Tool{{
+			Name: "mutate",
+			Handler: func(context.Context, json.RawMessage, *tools.Container) (llm.Content, error) {
+				executions.Add(1)
+				return llm.TextContent("applied"), nil
+			},
+		}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	events := collectEvents(agent.QueryStream(context.Background(), llm.TextContent("run both")))
+	if got := executions.Load(); got != 0 {
+		t.Fatalf("handler executions = %d, want 0", got)
+	}
+	var foundError, foundUsage bool
+	for _, event := range events {
+		switch event := event.(type) {
+		case ErrorEvent:
+			if event.Kind == "invalid_tool_call_block" {
+				foundError = true
+				if strings.Contains(event.Message, "sensitive-duplicate-id") {
+					t.Fatalf("error leaked provider tool-call ID: %q", event.Message)
+				}
+			}
+		case UsageEvent:
+			foundUsage = true
+		case ToolCallEvent, ToolResultEvent:
+			t.Fatalf("malformed block emitted tool lifecycle event: %#v", event)
+		}
+	}
+	if !foundError || !foundUsage {
+		t.Fatalf("events missing fail-closed error or billed usage: %#v", events)
+	}
+	for _, message := range agent.Messages() {
+		if message.Role == llm.RoleAssistant && len(message.ToolCalls) > 0 {
+			t.Fatalf("malformed assistant tool block entered history: %#v", message)
+		}
+	}
+
+	response, err := agent.Query(context.Background(), "recover")
+	if err != nil || response != "recovered" {
+		t.Fatalf("next query response=%q err=%v", response, err)
+	}
+}

--- a/sdk/agent/events.go
+++ b/sdk/agent/events.go
@@ -36,7 +36,7 @@ type ErrorEvent struct {
 	StatusCode   int
 	Message      string
 	RetryAfterMS int64
-	Kind         string // "rate_limit"|"provider"|"network"|"timeout"|"canceled"|"auth"|"permission"|"invalid_request"|"decode"|"max_iterations"|"loop_guard"|"doom_loop"|"unknown"
+	Kind         string // "rate_limit"|"provider"|"network"|"timeout"|"canceled"|"auth"|"permission"|"invalid_request"|"invalid_tool_call_block"|"decode"|"max_iterations"|"loop_guard"|"doom_loop"|"unknown"
 	// StallRecoveries records how many automatic stream-idle recoveries were
 	// applied earlier in the same turn before this terminal error surfaced.
 	StallRecoveries int


### PR DESCRIPTION
First safety slice of #84; this PR does not close the multi-phase Issue.

## Behavior

- synthesize missing IDs collision-safely in buffered and streaming paths;
- after recording billed Usage, reject a provider Tool Block containing duplicate non-empty IDs;
- do not append the malformed Assistant Tool Block;
- do not emit tool lifecycle events or invoke any Handler;
- do not echo the provider-supplied duplicate ID in diagnostics;
- allow a later Query to recover from clean history.

## Non-goals

No ToolBlockState, Scheduler, concurrency, cancellation semantics, Provider serializer changes, Prompt changes, or persistence changes.

## Local validation at ce8e6320adb6c67c021d7e4bcfa79f1de77c43d4 on Go 1.22.12

- go test ./... -count=1
- go vet ./...
- go test -race ./sdk/agent -count=1
- focused duplicate/missing/stream collision tests x20
- git diff --check

All passed. The earlier 52fd790 exact head received REQUEST_CHANGES; its streaming blocker is fixed and a fresh exact-head review is required before merge.