### PR TITLE
Clear partial tool calls when rejecting a duplicate block

### DIFF
--- a/sdk/agent/agent.go
+++ b/sdk/agent/agent.go
@@ -842,6 +842,11 @@ func (a *Agent) QueryStreamWithSteering(ctx context.Context, input llm.Content, 
 				a.emitUsageWithAccounting(out, *comp.Usage, responseID)
 			}
 			if first, second, duplicate := duplicateToolCallIDPositions(comp.ToolCalls); duplicate {
+				if cont.hasPending() {
+					a.mu.Lock()
+					cont.discardPartialToolCalls(a.messages)
+					a.mu.Unlock()
+				}
 				emitErr(ErrorEvent{
 					Provider: a.llm.Provider(),
 					Kind:     "invalid_tool_call_block",

--- a/sdk/agent/agent_duplicate_continuation_test.go
+++ b/sdk/agent/agent_duplicate_continuation_test.go
@@ -1,0 +1,81 @@
+package agent
+
+import (
+	"context"
+	"encoding/json"
+	"sync/atomic"
+	"testing"
+
+	"github.com/timwhitez/agent-sdk-golang/sdk/llm"
+	"github.com/timwhitez/agent-sdk-golang/sdk/tools"
+)
+
+type duplicateAfterContinuationModel struct {
+	calls int
+}
+
+func (m *duplicateAfterContinuationModel) Provider() string { return "stub" }
+func (m *duplicateAfterContinuationModel) Model() string    { return "stub" }
+
+func (m *duplicateAfterContinuationModel) Invoke(context.Context, llm.InvokeRequest) (*llm.Completion, error) {
+	m.calls++
+	switch m.calls {
+	case 1:
+		return &llm.Completion{
+			ToolCalls:  []llm.ToolCall{{ID: "partial", Type: "function", Function: llm.FunctionCall{Name: "mutate", Arguments: `{"value":`}}},
+			StopReason: "max_tokens",
+		}, nil
+	case 2:
+		return &llm.Completion{
+			ToolCalls: []llm.ToolCall{
+				{ID: "duplicate", Type: "function", Function: llm.FunctionCall{Name: "mutate", Arguments: `{}`}},
+				{ID: " duplicate ", Type: "function", Function: llm.FunctionCall{Name: "mutate", Arguments: `{}`}},
+			},
+			StopReason: "tool_calls",
+		}, nil
+	default:
+		return &llm.Completion{Content: llm.TextContent("recovered"), StopReason: "stop"}, nil
+	}
+}
+
+func TestDuplicateToolCallIDsAfterContinuationRemovePartialHistory(t *testing.T) {
+	var executions atomic.Int32
+	model := &duplicateAfterContinuationModel{}
+	agent, err := New(Config{
+		LLM: model,
+		Tools: []tools.Tool{{
+			Name: "mutate",
+			Handler: func(context.Context, json.RawMessage, *tools.Container) (llm.Content, error) {
+				executions.Add(1)
+				return llm.TextContent("applied"), nil
+			},
+		}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	events := collectEvents(agent.QueryStream(context.Background(), llm.TextContent("continue then run")))
+	if got := executions.Load(); got != 0 {
+		t.Fatalf("handler executions = %d, want 0", got)
+	}
+	foundError := false
+	for _, event := range events {
+		if event, ok := event.(ErrorEvent); ok && event.Kind == "invalid_tool_call_block" {
+			foundError = true
+		}
+	}
+	if !foundError {
+		t.Fatalf("missing invalid_tool_call_block error: %#v", events)
+	}
+	for _, message := range agent.Messages() {
+		if message.Role == llm.RoleAssistant && len(message.ToolCalls) > 0 {
+			t.Fatalf("partial assistant tool block remained in history: %#v", message)
+		}
+	}
+
+	response, err := agent.Query(context.Background(), "recover")
+	if err != nil || response != "recovered" {
+		t.Fatalf("next query response=%q err=%v", response, err)
+	}
+}


### PR DESCRIPTION
Follow-up safety repair for #84 after the post-merge review of PR #91 found a continuation orphan.

## Behavior

When a duplicate-ID block terminates a Query while an earlier max_tokens tool-call continuation is pending, remove every prior partial ToolCall from history before emitting the terminal error. The malformed current block is still never appended and no Handler runs. A later Query must work from valid history without outbound repair.

## Scope

Two production lock-scoped lines plus one focused continuation regression. No Provider payload, Prompt, Scheduler, persistence, or public API changes. This does not close #84.

## Local validation at b6efd3d0f6969f8ffe8488cb04ce6e96079d680f on Go 1.22.12

- focused continuation/duplicate/stream tests x50
- go test ./... -count=1
- go vet ./...
- go test -race ./sdk/agent -count=1
- git diff --check

All passed.