### PR TITLE
Scope continuation cleanup to pending blocks

### DIFF
--- a/sdk/agent/agent.go
+++ b/sdk/agent/agent.go
@@ -5008,31 +5008,30 @@ func (c *toolCallContinuation) clearPartialToolCalls(messages []llm.Message, cur
 	if len(c.partialCalls) == 0 {
 		return
 	}
-	ids := make(map[string]bool)
-	for _, tc := range c.partialCalls {
-		if id := strings.TrimSpace(tc.ID); id != "" {
-			ids[id] = true
-		}
-	}
-	if len(ids) == 0 {
-		c.reset()
-		return
-	}
-	for i := 0; i < currentIndex && i < len(messages); i++ {
-		if messages[i].Role != llm.RoleAssistant {
+	for i := 0; i+1 < currentIndex && i+1 < len(messages); i++ {
+		if messages[i].Role != llm.RoleAssistant || len(messages[i].ToolCalls) == 0 {
 			continue
 		}
-		hasPartial := false
-		for _, tc := range messages[i].ToolCalls {
-			if ids[strings.TrimSpace(tc.ID)] {
-				hasPartial = true
+		if messages[i+1].Role != llm.RoleUser || messages[i+1].Name != messageorigin.Name(messageorigin.KindToolCallContinuation) {
+			continue
+		}
+		matchesPending := false
+		for _, historical := range messages[i].ToolCalls {
+			for _, pending := range c.partialCalls {
+				if sameStableToolCallID(historical.ID, pending.ID) {
+					matchesPending = true
+					break
+				}
+			}
+			if matchesPending {
 				break
 			}
 		}
-		if hasPartial {
-			messages[i].ToolCalls = nil
-			messages[i].Content = llm.WithoutProviderState(messages[i].Content)
+		if !matchesPending {
+			continue
 		}
+		messages[i].ToolCalls = nil
+		messages[i].Content = llm.WithoutProviderState(messages[i].Content)
 	}
 	c.reset()
 }

--- a/sdk/agent/agent.go
+++ b/sdk/agent/agent.go
@@ -5012,22 +5012,10 @@ func (c *toolCallContinuation) clearPartialToolCalls(messages []llm.Message, cur
 		if messages[i].Role != llm.RoleAssistant || len(messages[i].ToolCalls) == 0 {
 			continue
 		}
+		// The SDK reminder owns the preceding unfinished block. IDs cannot
+		// identify the episode: providers may rotate them between fragments,
+		// while synthetic IDs are reused by later completed responses.
 		if messages[i+1].Role != llm.RoleUser || messages[i+1].Name != messageorigin.Name(messageorigin.KindToolCallContinuation) {
-			continue
-		}
-		matchesPending := false
-		for _, historical := range messages[i].ToolCalls {
-			for _, pending := range c.partialCalls {
-				if sameStableToolCallID(historical.ID, pending.ID) {
-					matchesPending = true
-					break
-				}
-			}
-			if matchesPending {
-				break
-			}
-		}
-		if !matchesPending {
 			continue
 		}
 		messages[i].ToolCalls = nil

--- a/sdk/agent/agent_duplicate_tool_call_id_test.go
+++ b/sdk/agent/agent_duplicate_tool_call_id_test.go
@@ -24,6 +24,30 @@ type repeatedSyntheticIDContinuationModel struct {
 	calls int
 }
 
+type rotatingContinuationIDModel struct {
+	calls    int
+	contents []llm.Content
+}
+
+func (m *rotatingContinuationIDModel) Provider() string { return "stub" }
+func (m *rotatingContinuationIDModel) Model() string    { return "stub" }
+func (m *rotatingContinuationIDModel) Invoke(context.Context, llm.InvokeRequest) (*llm.Completion, error) {
+	m.calls++
+	switch m.calls {
+	case 1:
+		return &llm.Completion{Content: m.contents[0], ToolCalls: []llm.ToolCall{{ID: "old-partial", Type: "function", Function: llm.FunctionCall{Name: "mutate", Arguments: `{"value":`}}}, StopReason: "max_tokens"}, nil
+	case 2:
+		return &llm.Completion{Content: m.contents[1], ToolCalls: []llm.ToolCall{{ID: "new-partial", Type: "function", Function: llm.FunctionCall{Name: "mutate", Arguments: `{"other":`}}}, StopReason: "tool_calls"}, nil
+	case 3:
+		return &llm.Completion{ToolCalls: []llm.ToolCall{
+			{ID: "duplicate", Type: "function", Function: llm.FunctionCall{Name: "mutate", Arguments: `{}`}},
+			{ID: "duplicate", Type: "function", Function: llm.FunctionCall{Name: "mutate", Arguments: `{}`}},
+		}, StopReason: "tool_calls"}, nil
+	default:
+		return &llm.Completion{Content: llm.TextContent("recovered"), StopReason: "stop"}, nil
+	}
+}
+
 func (m *repeatedSyntheticIDContinuationModel) Provider() string { return "stub" }
 func (m *repeatedSyntheticIDContinuationModel) Model() string    { return "stub" }
 func (m *repeatedSyntheticIDContinuationModel) Invoke(context.Context, llm.InvokeRequest) (*llm.Completion, error) {
@@ -203,6 +227,40 @@ func TestDuplicateAfterContinuationKeepsOlderSyntheticIDBlock(t *testing.T) {
 	}
 	if response != "recovered" {
 		t.Fatalf("recovery response=%q events=%#v", response, events)
+	}
+}
+
+func TestDuplicateAfterRotatingContinuationIDsClearsWholeEpisode(t *testing.T) {
+	model := &rotatingContinuationIDModel{contents: []llm.Content{
+		mustProviderStateContent(t, llm.Content{}, []llm.ProviderState{{Provider: "openai-responses", Kind: "response.output_item.v1", Data: json.RawMessage(`{"type":"function_call","call_id":"old-partial"}`)}}),
+		mustProviderStateContent(t, llm.Content{}, []llm.ProviderState{{Provider: "openai-responses", Kind: "response.output_item.v1", Data: json.RawMessage(`{"type":"function_call","call_id":"new-partial"}`)}}),
+	}}
+	agent, err := New(Config{LLM: model})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	events := collectEvents(agent.QueryStream(context.Background(), llm.TextContent("start partial")))
+	foundDuplicateError := false
+	for _, event := range events {
+		if event, ok := event.(ErrorEvent); ok && event.Kind == "invalid_tool_call_block" {
+			foundDuplicateError = true
+		}
+	}
+	if !foundDuplicateError {
+		t.Fatalf("missing duplicate rejection: %#v", events)
+	}
+	messages := agent.Messages()
+	for i, message := range messages {
+		if message.Role == llm.RoleAssistant && (len(message.ToolCalls) != 0 || providerStateCount(t, message.Content) != 0) {
+			t.Fatalf("partial block %d survived rotating-ID cleanup: %#v", i, message)
+		}
+	}
+	if _, changed, unexpected := repairToolCallPairsDetailed(messages); changed || unexpected {
+		t.Fatalf("history still needs pairing repair: changed=%t unexpected=%t messages=%#v", changed, unexpected, messages)
+	}
+	if response, err := agent.Query(context.Background(), "recover"); err != nil || response != "recovered" {
+		t.Fatalf("recovery response=%q err=%v", response, err)
 	}
 }
 

--- a/sdk/agent/agent_duplicate_tool_call_id_test.go
+++ b/sdk/agent/agent_duplicate_tool_call_id_test.go
@@ -20,6 +20,31 @@ type streamingSyntheticIDCollisionModel struct {
 	calls int
 }
 
+type repeatedSyntheticIDContinuationModel struct {
+	calls int
+}
+
+func (m *repeatedSyntheticIDContinuationModel) Provider() string { return "stub" }
+func (m *repeatedSyntheticIDContinuationModel) Model() string    { return "stub" }
+func (m *repeatedSyntheticIDContinuationModel) Invoke(context.Context, llm.InvokeRequest) (*llm.Completion, error) {
+	m.calls++
+	switch m.calls {
+	case 1:
+		return &llm.Completion{ToolCalls: []llm.ToolCall{{Type: "function", Function: llm.FunctionCall{Name: "mutate", Arguments: `{}`}}}, StopReason: "tool_calls"}, nil
+	case 2:
+		return &llm.Completion{Content: llm.TextContent("first done"), StopReason: "stop"}, nil
+	case 3:
+		return &llm.Completion{ToolCalls: []llm.ToolCall{{Type: "function", Function: llm.FunctionCall{Name: "mutate", Arguments: `{"value":`}}}, StopReason: "max_tokens"}, nil
+	case 4:
+		return &llm.Completion{ToolCalls: []llm.ToolCall{
+			{ID: "duplicate", Type: "function", Function: llm.FunctionCall{Name: "mutate", Arguments: `{}`}},
+			{ID: "duplicate", Type: "function", Function: llm.FunctionCall{Name: "mutate", Arguments: `{}`}},
+		}, StopReason: "tool_calls"}, nil
+	default:
+		return &llm.Completion{Content: llm.TextContent("recovered"), StopReason: "stop"}, nil
+	}
+}
+
 func (m *streamingSyntheticIDCollisionModel) Provider() string { return "stub" }
 func (m *streamingSyntheticIDCollisionModel) Model() string    { return "stub" }
 func (m *streamingSyntheticIDCollisionModel) Invoke(context.Context, llm.InvokeRequest) (*llm.Completion, error) {
@@ -108,6 +133,76 @@ func TestDuplicateToolCallIDsFailBeforeAnyHandler(t *testing.T) {
 	response, err := agent.Query(context.Background(), "recover")
 	if err != nil || response != "recovered" {
 		t.Fatalf("next query response=%q err=%v", response, err)
+	}
+}
+
+func TestDuplicateAfterContinuationKeepsOlderSyntheticIDBlock(t *testing.T) {
+	var executions atomic.Int32
+	model := &repeatedSyntheticIDContinuationModel{}
+	agent, err := New(Config{
+		LLM: model,
+		Tools: []tools.Tool{{
+			Name: "mutate",
+			Handler: func(context.Context, json.RawMessage, *tools.Container) (llm.Content, error) {
+				executions.Add(1)
+				return llm.TextContent("applied"), nil
+			},
+		}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if response, err := agent.Query(context.Background(), "first"); err != nil || response != "first done" {
+		t.Fatalf("first response=%q err=%v", response, err)
+	}
+	events := collectEvents(agent.QueryStream(context.Background(), llm.TextContent("start partial")))
+	if got := executions.Load(); got != 1 {
+		t.Fatalf("handler executions = %d, want only the completed first call", got)
+	}
+	foundDuplicateError := false
+	for _, event := range events {
+		if event, ok := event.(ErrorEvent); ok && event.Kind == "invalid_tool_call_block" {
+			foundDuplicateError = true
+		}
+	}
+	if !foundDuplicateError {
+		t.Fatalf("missing duplicate rejection: %#v", events)
+	}
+
+	messages := agent.Messages()
+	completedCalls, completedResults := 0, 0
+	for _, message := range messages {
+		if message.Role == llm.RoleAssistant {
+			for _, call := range message.ToolCalls {
+				if call.ID == "call_0" {
+					completedCalls++
+				}
+			}
+		}
+		if message.Role == llm.RoleTool && message.ToolCallID == "call_0" {
+			completedResults++
+		}
+	}
+	if completedCalls != 1 || completedResults != 1 {
+		t.Fatalf("older completed block was altered: calls=%d results=%d messages=%#v", completedCalls, completedResults, messages)
+	}
+	if _, changed, unexpected := repairToolCallPairsDetailed(messages); changed || unexpected {
+		t.Fatalf("history still needs pairing repair: changed=%t unexpected=%t", changed, unexpected)
+	}
+
+	events = collectEvents(agent.QueryStream(context.Background(), llm.TextContent("recover")))
+	response := ""
+	for _, event := range events {
+		if event, ok := event.(WarnEvent); ok && event.Kind == "tool_pairing_repaired" {
+			t.Fatalf("recovery required outbound pairing repair: %#v", events)
+		}
+		if event, ok := event.(FinalResponseEvent); ok {
+			response = event.Content
+		}
+	}
+	if response != "recovered" {
+		t.Fatalf("recovery response=%q events=%#v", response, events)
 	}
 }
 

--- a/sdk/agent/agent_test.go
+++ b/sdk/agent/agent_test.go
@@ -12,6 +12,7 @@ import (
 	"unicode/utf8"
 
 	"github.com/timwhitez/agent-sdk-golang/sdk/agent/compaction"
+	"github.com/timwhitez/agent-sdk-golang/sdk/agent/messageorigin"
 	"github.com/timwhitez/agent-sdk-golang/sdk/llm"
 	"github.com/timwhitez/agent-sdk-golang/sdk/tools"
 )
@@ -1014,15 +1015,16 @@ func TestToolCallContinuationClearsPartialAfterIndexShift(t *testing.T) {
 	messages := []llm.Message{
 		{Role: llm.RoleSystem, Content: llm.TextContent("sys")},
 		{Role: llm.RoleAssistant, Content: llm.TextContent(""), ToolCalls: cloneToolCalls(partial)},
+		messageorigin.NewInternalUserMessage(messageorigin.KindToolCallContinuation, messageorigin.ResponseTruncatedContinuationText),
 		{Role: llm.RoleAssistant, Content: llm.TextContent(""), ToolCalls: cloneToolCalls(merged)},
 	}
 
-	cont.clearPartialToolCalls(messages, 2)
+	cont.clearPartialToolCalls(messages, 3)
 
 	if len(messages[1].ToolCalls) != 0 {
 		t.Fatalf("expected stale partial assistant message to be cleared")
 	}
-	if !sameToolCalls(messages[2].ToolCalls, merged) {
+	if !sameToolCalls(messages[3].ToolCalls, merged) {
 		t.Fatalf("expected merged assistant tool calls to stay intact")
 	}
 }

--- a/sdk/agent/provider_state_test.go
+++ b/sdk/agent/provider_state_test.go
@@ -119,10 +119,13 @@ func TestToolContinuationCleanupClearsStaleProviderState(t *testing.T) {
 			Data:     json.RawMessage(`{"type":"function_call","call_id":"call_1"}`),
 		}}),
 		ToolCalls: []llm.ToolCall{call},
-	}}
+	}, messageorigin.NewInternalUserMessage(
+		messageorigin.KindToolCallContinuation,
+		messageorigin.ResponseTruncatedContinuationText,
+	)}
 	continuation := newToolCallContinuation(2)
 	continuation.addPartial(0, []llm.ToolCall{call})
-	continuation.clearPartialToolCalls(messages, 1)
+	continuation.clearPartialToolCalls(messages, 2)
 	if len(messages[0].ToolCalls) != 0 || providerStateCount(t, messages[0].Content) != 0 {
 		t.Fatalf("continuation cleanup retained stale state: %#v", messages[0])
 	}


### PR DESCRIPTION
Follow-up correctness repair for #84 after post-merge review found that PR #92's cleanup searched the full history by tool_call_id. Synthetic IDs restart at call_0 for each completion, so that scan could erase an older completed assistant block and orphan its terminal Tool Result.

## Behavior

Cleanup now targets only assistant partial blocks immediately followed by the SDK's tool-call continuation reminder. The SDK-authored reminder, not a reusable or provider-rotated ID, owns the unfinished block. A completed earlier block with the same synthetic ID remains intact, while every block in a rotating-ID continuation episode is removed.

## Scope

No public API, Provider payload, Prompt, Scheduler, persistence, or execution-policy changes. This does not close #84.

## Local validation at 556ffa2

Using Go 1.22.12:

- focused duplicate/continuation/provider-state tests x100, including stable and rotating continuation IDs
- go test ./... -count=1
- go vet ./...
- go test -race ./sdk/agent -count=1
- git diff --check

All passed.
