### PR TITLE
Add query-wide EventEnvelope foundation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,6 +28,11 @@ and progressive disclosure through `agent_docs/`.
   no session, path, raw result, command, or arbitrary metadata; hosts add
   identity, persistence, rollup, and reporting (`sdk/accounting`,
   `sdk/agent/events.go`).
+- `QueryStreamEnveloped` preserves typed Event payloads while adding a
+  versioned, per-query `QueryID`, pre-delivery monotonic sequence, stable
+  kind/origin, and observational timestamp. Legacy `QueryStream` uses the same
+  direct delivery/backpressure path without metadata; sequence gaps expose
+  dropped events (`sdk/agent/event_envelope.go`, `sdk/agent/agent.go`).
 - Auto-continue on `max_tokens` (including partial tool-call merge) now emits metadata-only `AutoContinueEvent` instead of text markers (`sdk/agent/agent.go:259`, `sdk/agent/agent.go:275`, `sdk/agent/agent.go:298`, `sdk/agent/events.go:113`)
 - Tool resolution via exact + normalized + alias matching (`sdk/agent/tool_resolve.go:107`, `sdk/agent/tool_resolve.go:30`)
 - Argument normalization with conservative loose-object repair + schema-key retry, including schema-derived single-string wrapping for custom tools and tool-specific alias handling for ambiguous keys like `line`/`offset` (`sdk/tools/args_normalize.go:21`, `sdk/tools/args_normalize.go:247`, `sdk/tools/tool.go:363`)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,6 +21,11 @@ and progressive disclosure through `agent_docs/`.
 ### Runtime Capabilities
 - Boundary-aware steering before LLM calls and after each tool call (`sdk/agent/agent.go:226`, `sdk/agent/agent.go:448`, `sdk/agent/agent.go:959`)
 - Stream delta aggregation into a unified `Completion`, with response metadata propagated into `Completion.ResponseID` and surfaced on `UsageEvent` / `AutoContinueEvent` / `FinalResponseEvent` for downstream UI/aggregators (`sdk/agent/agent.go:255`, `sdk/agent/agent.go:285`, `sdk/agent/agent.go:348`, `sdk/agent/agent.go:646`)
+- `QueryStreamEnveloped` preserves typed Event payloads while adding a
+  versioned, per-query `QueryID`, pre-delivery monotonic sequence, stable
+  kind/origin, and observational timestamp. Legacy `QueryStream` uses the same
+  direct delivery/backpressure path without metadata; sequence gaps expose
+  dropped events (`sdk/agent/event_envelope.go`, `sdk/agent/agent.go`).
 - Auto-continue on `max_tokens` (including partial tool-call merge) now emits metadata-only `AutoContinueEvent` instead of text markers (`sdk/agent/agent.go:259`, `sdk/agent/agent.go:275`, `sdk/agent/agent.go:298`, `sdk/agent/events.go:113`)
 - Tool resolution via exact + normalized + alias matching (`sdk/agent/tool_resolve.go:107`, `sdk/agent/tool_resolve.go:30`)
 - Argument normalization with conservative loose-object repair + schema-key retry, including schema-derived single-string wrapping for custom tools and tool-specific alias handling for ambiguous keys like `line`/`offset` (`sdk/tools/args_normalize.go:21`, `sdk/tools/args_normalize.go:247`, `sdk/tools/tool.go:363`)

--- a/sdk/agent/agent.go
+++ b/sdk/agent/agent.go
@@ -108,6 +108,14 @@ type Config struct {
 	// EventDropLogEvery controls backpressure drop log frequency.
 	// Values <= 0 use a safe default.
 	EventDropLogEvery int
+	// QueryIDGenerator optionally supplies opaque query IDs for EventEnvelope.
+	// It may be called concurrently. Empty or whitespace-only results fall back
+	// to an SDK-generated ID.
+	QueryIDGenerator func() string
+	// EventClock supplies observational EventEnvelope timestamps. Sequence is
+	// the only ordering authority. It may be called concurrently. Nil uses
+	// time.Now.
+	EventClock func() time.Time
 	// StreamIdleTimeout bounds how long a streaming response may go without any
 	// event before it is treated as stalled (and auto-recovered). Values <= 0
 	// use the package default (75s). Use a larger value for long single-step
@@ -150,6 +158,8 @@ type Agent struct {
 	eventBufferSize            int
 	eventSendTimeout           time.Duration
 	eventDropLogEvery          uint64
+	queryIDGenerator           func() string
+	eventClock                 func() time.Time
 	streamIdleTimeout          time.Duration
 	streamIdleMaxRecov         int
 	toolChoice                 llm.ToolChoice
@@ -234,7 +244,7 @@ type Agent struct {
 	// preventing overlapping submissions from mutating shared turn state.
 	turnActive      atomic.Bool
 	turnCancelMu    sync.Mutex
-	turnCancelByOut map[chan Event]*turnBackpressure
+	turnCancelByOut map[*eventOutput]*turnBackpressure
 }
 
 // turnBackpressure carries the per-turn state emitEvent needs on the slow path:
@@ -429,6 +439,8 @@ func New(cfg Config) (*Agent, error) {
 		eventBufferSize:       cfg.EventBufferSize,
 		eventSendTimeout:      cfg.EventSendTimeout,
 		eventDropLogEvery:     uint64(cfg.EventDropLogEvery),
+		queryIDGenerator:      cfg.QueryIDGenerator,
+		eventClock:            cfg.EventClock,
 		streamIdleTimeout:     cfg.StreamIdleTimeout,
 		streamIdleMaxRecov:    cfg.StreamIdleMaxRecoveries,
 		toolChoice:            cfg.ToolChoice,
@@ -527,6 +539,13 @@ func (a *Agent) QueryStream(ctx context.Context, input llm.Content) <-chan Event
 	return a.QueryStreamWithSteering(ctx, input, nil)
 }
 
+// QueryStreamEnveloped returns the same typed events as QueryStream with
+// query-wide ordering metadata. It uses the same delivery and backpressure
+// path; only the public channel projection differs.
+func (a *Agent) QueryStreamEnveloped(ctx context.Context, input llm.Content) <-chan EventEnvelope {
+	return a.QueryStreamEnvelopedWithSteering(ctx, input, nil)
+}
+
 // QueryStreamWithSteering is like QueryStream but accepts an optional steering channel.
 // When steeringCh is non-nil, the agent checks for new user messages at natural breakpoints
 // (before each LLM invocation and after each tool execution). Any received steering messages
@@ -535,16 +554,26 @@ func (a *Agent) QueryStream(ctx context.Context, input llm.Content) <-chan Event
 //
 // The steering channel is caller-owned. The agent only reads from it and never closes it.
 func (a *Agent) QueryStreamWithSteering(ctx context.Context, input llm.Content, steeringCh <-chan SteeringMsg) <-chan Event {
+	return a.queryStreamWithSteering(ctx, input, steeringCh, false).legacy
+}
+
+// QueryStreamEnvelopedWithSteering is the enveloped form of
+// QueryStreamWithSteering. The steering channel remains caller-owned.
+func (a *Agent) QueryStreamEnvelopedWithSteering(ctx context.Context, input llm.Content, steeringCh <-chan SteeringMsg) <-chan EventEnvelope {
+	return a.queryStreamWithSteering(ctx, input, steeringCh, true).enveloped
+}
+
+func (a *Agent) queryStreamWithSteering(ctx context.Context, input llm.Content, steeringCh <-chan SteeringMsg, enveloped bool) *eventOutput {
 	bufferSize := defaultEventBufferSize
 	if a != nil && a.eventBufferSize > 0 {
 		bufferSize = a.eventBufferSize
 	}
-	out := make(chan Event, bufferSize)
+	out := newEventOutput(bufferSize, enveloped, a.newQueryID(), a.eventClock)
 	if !a.turnActive.CompareAndSwap(false, true) {
 		// Admission is synchronous and out is buffered, so callers receive a
 		// deterministic terminal rejection without scheduling another goroutine.
-		out <- ErrorEvent{Kind: "agent_busy", Message: ErrAgentBusy.Error()}
-		close(out)
+		out.trySend(out.next(ErrorEvent{Kind: "agent_busy", Message: ErrAgentBusy.Error()}))
+		out.close()
 		return out
 	}
 	// Reserve synchronously when possible so an update made after this call
@@ -556,7 +585,7 @@ func (a *Agent) QueryStreamWithSteering(ctx context.Context, input llm.Content, 
 		// Later defers execute first. Runtime release happens before admission
 		// is reopened and before channel close, so the next accepted operation
 		// observes any queued replacement.
-		defer close(out)
+		defer out.close()
 		defer a.turnActive.Store(false)
 		defer unregisterTurn()
 		if !acquired {
@@ -602,21 +631,12 @@ func (a *Agent) QueryStreamWithSteering(ctx context.Context, input llm.Content, 
 		progressLedger := newEvidenceProgressLedger(a.deps, a.compactionGeneration.Load())
 		loopGuardStrikes := 0
 		hasDoneTool := a.hasToolNamed("done")
-		droppedAtTurnStart := a.eventDropCount.Load()
+		out.setDropBaseline(a.eventDropCount.Load(), a.criticalEventDropCount.Load())
 		droppedThisTurn := func() uint64 {
-			current := a.eventDropCount.Load()
-			if current <= droppedAtTurnStart {
-				return 0
-			}
-			return current - droppedAtTurnStart
+			return dropsSince(a.eventDropCount.Load(), out.dropStart)
 		}
-		criticalDroppedAtTurnStart := a.criticalEventDropCount.Load()
 		criticalDroppedThisTurn := func() uint64 {
-			current := a.criticalEventDropCount.Load()
-			if current <= criticalDroppedAtTurnStart {
-				return 0
-			}
-			return current - criticalDroppedAtTurnStart
+			return dropsSince(a.criticalEventDropCount.Load(), out.criticalDropStart)
 		}
 		emitFinal := func(content, responseID string) {
 			a.emitEvent(out, FinalResponseEvent{
@@ -1466,6 +1486,15 @@ func (a *Agent) QueryStreamWithSteering(ctx context.Context, input llm.Content, 
 	return out
 }
 
+func (a *Agent) newQueryID() string {
+	if a != nil && a.queryIDGenerator != nil {
+		if id := strings.TrimSpace(a.queryIDGenerator()); id != "" {
+			return id
+		}
+	}
+	return newDefaultQueryID()
+}
+
 func (a *Agent) applyToolResultTruncation(ctx context.Context, content llm.Content, meta map[string]any, toolName, toolCallID string) (llm.Content, map[string]any) {
 	return a.applyToolResultBoundary(ctx, content, meta, toolName, toolCallID)
 }
@@ -1885,7 +1914,7 @@ func isVisibleProviderStreamEvent(ev llm.StreamEvent) bool {
 // It returns the completion (possibly partial on error), whether text was streamed, and error.
 // On streaming errors, the partial completion contains whatever text/tools were accumulated
 // before the error occurred, allowing callers to preserve partial output in history.
-func (a *Agent) invokeCompletion(ctx context.Context, req llm.InvokeRequest, out chan Event) (*llm.Completion, bool, error) {
+func (a *Agent) invokeCompletion(ctx context.Context, req llm.InvokeRequest, out *eventOutput) (*llm.Completion, bool, error) {
 	return a.invokeCompletionWithSteering(ctx, req, out, nil)
 }
 
@@ -1893,14 +1922,14 @@ func (a *Agent) invokeCompletion(ctx context.Context, req llm.InvokeRequest, out
 // When steeringCh is non-nil, the stream can be interrupted mid-generation if the user
 // sends a steering message. The function returns a SteeringInterruptError in that case,
 // allowing the caller to immediately incorporate the steering message into the conversation.
-func (a *Agent) invokeCompletionWithSteering(ctx context.Context, req llm.InvokeRequest, out chan Event, steeringCh <-chan SteeringMsg) (*llm.Completion, bool, error) {
+func (a *Agent) invokeCompletionWithSteering(ctx context.Context, req llm.InvokeRequest, out *eventOutput, steeringCh <-chan SteeringMsg) (*llm.Completion, bool, error) {
 	if a == nil {
 		return nil, false, fmt.Errorf("agent: nil llm")
 	}
 	return a.invokeModelCompletionWithSteering(ctx, a.llm, req, out, steeringCh)
 }
 
-func (a *Agent) invokeModelCompletionWithSteering(ctx context.Context, model llm.ChatModel, req llm.InvokeRequest, out chan Event, steeringCh <-chan SteeringMsg) (*llm.Completion, bool, error) {
+func (a *Agent) invokeModelCompletionWithSteering(ctx context.Context, model llm.ChatModel, req llm.InvokeRequest, out *eventOutput, steeringCh <-chan SteeringMsg) (*llm.Completion, bool, error) {
 	if model == nil {
 		return nil, false, fmt.Errorf("agent: nil llm")
 	}
@@ -2172,21 +2201,21 @@ func (a *Agent) invokeModelCompletionWithSteering(ctx context.Context, model llm
 	return comp, false, err
 }
 
-func (a *Agent) invokeCompletionWithRetry(ctx context.Context, req llm.InvokeRequest, out chan Event) (*llm.Completion, bool, error) {
+func (a *Agent) invokeCompletionWithRetry(ctx context.Context, req llm.InvokeRequest, out *eventOutput) (*llm.Completion, bool, error) {
 	return a.invokeCompletionWithRetryAndSteering(ctx, req, out, nil)
 }
 
 // invokeCompletionWithRetryAndSteering extends invokeCompletionWithRetry with steering support.
 // When a steering interrupt occurs, it immediately returns the partial completion along with
 // the SteeringInterruptError, allowing the agent loop to process the steering message.
-func (a *Agent) invokeCompletionWithRetryAndSteering(ctx context.Context, req llm.InvokeRequest, out chan Event, steeringCh <-chan SteeringMsg) (*llm.Completion, bool, error) {
+func (a *Agent) invokeCompletionWithRetryAndSteering(ctx context.Context, req llm.InvokeRequest, out *eventOutput, steeringCh <-chan SteeringMsg) (*llm.Completion, bool, error) {
 	if a == nil {
 		return nil, false, fmt.Errorf("agent: nil llm")
 	}
 	return a.invokeModelCompletionWithRetryAndSteering(ctx, a.llm, req, out, steeringCh)
 }
 
-func (a *Agent) invokeModelCompletionWithRetryAndSteering(ctx context.Context, model llm.ChatModel, req llm.InvokeRequest, out chan Event, steeringCh <-chan SteeringMsg) (*llm.Completion, bool, error) {
+func (a *Agent) invokeModelCompletionWithRetryAndSteering(ctx context.Context, model llm.ChatModel, req llm.InvokeRequest, out *eventOutput, steeringCh <-chan SteeringMsg) (*llm.Completion, bool, error) {
 	maxAttempts := defaultInvokeRetryMax
 	if a != nil && a.invokeRetryMax > 0 {
 		maxAttempts = a.invokeRetryMax
@@ -2564,7 +2593,7 @@ func (a *Agent) executeToolSafely(ctx context.Context, tool tools.Tool, raw stri
 // normal success path (terminal stream error, steering interrupt, idle-timeout
 // recovery, context cancellation). The provider already billed the tokens it
 // produced, so skipping this leaves the accounting journal under-counted.
-func (a *Agent) emitPartialUsage(out chan Event, comp *llm.Completion) {
+func (a *Agent) emitPartialUsage(out *eventOutput, comp *llm.Completion) {
 	if comp == nil || comp.Usage == nil {
 		return
 	}
@@ -2575,7 +2604,7 @@ func (a *Agent) emitPartialUsage(out chan Event, comp *llm.Completion) {
 	a.emitUsageWithAccounting(out, *usage, strings.TrimSpace(comp.ResponseID))
 }
 
-func (a *Agent) emitUsageWithAccounting(out chan Event, usage llm.Usage, responseID string) {
+func (a *Agent) emitUsageWithAccounting(out *eventOutput, usage llm.Usage, responseID string) {
 	if !a.emitEvent(out, UsageEvent{Usage: usage, ResponseID: responseID}) {
 		return
 	}
@@ -2586,7 +2615,7 @@ func (a *Agent) emitUsageWithAccounting(out chan Event, usage llm.Usage, respons
 	})
 }
 
-func (a *Agent) emitToolResultWithAccounting(out chan Event, event ToolResultEvent, original string, duration time.Duration) {
+func (a *Agent) emitToolResultWithAccounting(out *eventOutput, event ToolResultEvent, original string, duration time.Duration) {
 	if !a.emitEvent(out, event) {
 		return
 	}
@@ -2604,7 +2633,7 @@ func (a *Agent) emitToolResultWithAccounting(out chan Event, event ToolResultEve
 	})
 }
 
-func (a *Agent) emitCompactionWithAccounting(out chan Event, event CompactionEvent) {
+func (a *Agent) emitCompactionWithAccounting(out *eventOutput, event CompactionEvent) {
 	if !a.emitEvent(out, event) {
 		return
 	}
@@ -2614,19 +2643,18 @@ func (a *Agent) emitCompactionWithAccounting(out chan Event, event CompactionEve
 	})
 }
 
-func (a *Agent) emitAccounting(out chan Event, event AccountingEvent) {
+func (a *Agent) emitAccounting(out *eventOutput, event AccountingEvent) {
 	event.Sequence = a.accountingSequence.Add(1)
 	a.emitEvent(out, event)
 }
 
-func (a *Agent) emitEvent(out chan Event, ev Event) bool {
+func (a *Agent) emitEvent(out *eventOutput, ev Event) bool {
 	if out == nil {
 		return false
 	}
-	select {
-	case out <- ev:
+	envelope := out.next(ev)
+	if out.trySend(envelope) {
 		return true
-	default:
 	}
 
 	timeout := defaultEventSendTimeout
@@ -2655,7 +2683,7 @@ func (a *Agent) emitEvent(out chan Event, ev Event) bool {
 	}
 	floored := false
 	if isTerminalAgentEvent(ev) {
-		if a.tryEnqueueTerminalEvent(out, ev) {
+		if a.tryEnqueueTerminalEvent(out, envelope) {
 			return true
 		}
 		// Terminal events are not charged against the per-turn floor budget:
@@ -2708,13 +2736,13 @@ func (a *Agent) emitEvent(out chan Event, ev Event) bool {
 	}()
 	// A turn cancelled while this send is already waiting aborts the wait for the
 	// same reason: nothing is going to read the channel any more.
-	select {
-	case out <- ev:
+	switch out.sendUntil(envelope, turnDone, timer.C) {
+	case eventSent:
 		return true
-	case <-turnDone:
+	case eventTurnCanceled:
 		a.logDroppedEvent(ev, "turn_canceled")
 		return false
-	case <-timer.C:
+	default:
 		a.logDroppedEvent(ev, fmt.Sprintf("send_timeout_%s", timeout))
 		return false
 	}
@@ -2796,13 +2824,13 @@ func (t *turnBackpressure) chargeFloorSpent(d time.Duration) {
 // emitEvent can stop paying the critical-event floor once the turn is abandoned,
 // and gives the turn a fresh floor budget (see criticalEventFloorTurnBudget).
 // The returned function must be called when the turn ends.
-func (a *Agent) registerTurnCancellation(out chan Event, ctx context.Context) func() {
+func (a *Agent) registerTurnCancellation(out *eventOutput, ctx context.Context) func() {
 	if a == nil || out == nil || ctx == nil || ctx.Done() == nil {
 		return func() {}
 	}
 	a.turnCancelMu.Lock()
 	if a.turnCancelByOut == nil {
-		a.turnCancelByOut = make(map[chan Event]*turnBackpressure, 1)
+		a.turnCancelByOut = make(map[*eventOutput]*turnBackpressure, 1)
 	}
 	a.turnCancelByOut[out] = &turnBackpressure{done: ctx.Done()}
 	a.turnCancelMu.Unlock()
@@ -2816,7 +2844,7 @@ func (a *Agent) registerTurnCancellation(out chan Event, ctx context.Context) fu
 // turnBackpressureState returns the backpressure state of the turn that owns out,
 // or nil when the channel belongs to no registered turn (e.g. a direct unit-test
 // call or a library caller driving the loop itself).
-func (a *Agent) turnBackpressureState(out chan Event) *turnBackpressure {
+func (a *Agent) turnBackpressureState(out *eventOutput) *turnBackpressure {
 	if a == nil || out == nil {
 		return nil
 	}
@@ -2829,27 +2857,31 @@ func (a *Agent) turnBackpressureState(out chan Event) *turnBackpressure {
 // when the channel belongs to no registered turn (e.g. a direct unit-test call).
 // A nil channel blocks forever in a select, which is exactly the previous
 // behavior for unregistered channels.
-func (a *Agent) turnCancellation(out chan Event) <-chan struct{} {
+func (a *Agent) turnCancellation(out *eventOutput) <-chan struct{} {
 	if state := a.turnBackpressureState(out); state != nil {
 		return state.done
 	}
 	return nil
 }
 
-func (a *Agent) tryEnqueueTerminalEvent(out chan Event, ev Event) bool {
-	select {
-	case buffered := <-out:
-		if isTerminalAgentEvent(buffered) && terminalEventPriority(buffered) > terminalEventPriority(ev) {
-			out <- buffered
-			a.logDroppedEvent(ev, "terminal_priority_loss")
-			return false
-		}
-		a.logDroppedEvent(buffered, "evicted_for_terminal")
-		out <- ev
-		return true
-	default:
+func (a *Agent) tryEnqueueTerminalEvent(out *eventOutput, envelope EventEnvelope) bool {
+	buffered, ok := out.tryReceive()
+	if !ok {
 		return false
 	}
+	if isTerminalAgentEvent(buffered.Event) && terminalEventPriority(buffered.Event) > terminalEventPriority(envelope.Event) {
+		out.sendAfterReceive(buffered)
+		a.logDroppedEvent(envelope.Event, "terminal_priority_loss")
+		return false
+	}
+	a.logDroppedEvent(buffered.Event, "evicted_for_terminal")
+	if final, ok := envelope.Event.(FinalResponseEvent); ok {
+		final.DroppedEvents = dropsSince(a.eventDropCount.Load(), out.dropStart)
+		final.DroppedCriticalEvents = dropsSince(a.criticalEventDropCount.Load(), out.criticalDropStart)
+		envelope.Event = final
+	}
+	out.sendAfterReceive(envelope)
+	return true
 }
 
 func terminalEventPriority(ev Event) int {
@@ -2948,7 +2980,7 @@ func (a *Agent) logDroppedEvent(ev Event, reason string) {
 	}
 }
 
-func (a *Agent) emitAutoContinue(out chan Event, reason string, responseID string) {
+func (a *Agent) emitAutoContinue(out *eventOutput, reason string, responseID string) {
 	a.emitEvent(out, AutoContinueEvent{Reason: reason, ResponseID: strings.TrimSpace(responseID)})
 }
 
@@ -3109,7 +3141,7 @@ func (a *Agent) NotifyTodoCompletion() {
 	a.todoCompactionPending.Store(true)
 }
 
-func (a *Agent) checkAndCompact(ctx context.Context, last *llm.Completion, out chan Event, additionalTokens ...int) error {
+func (a *Agent) checkAndCompact(ctx context.Context, last *llm.Completion, out *eventOutput, additionalTokens ...int) error {
 	currentHistoryGrowth := 0
 	for _, value := range additionalTokens {
 		if value > 0 {
@@ -3119,7 +3151,7 @@ func (a *Agent) checkAndCompact(ctx context.Context, last *llm.Completion, out c
 	return a.checkAndCompactWithGrowth(ctx, last, out, currentHistoryGrowth, 0)
 }
 
-func (a *Agent) checkAndCompactWithGrowth(ctx context.Context, last *llm.Completion, out chan Event, currentHistoryGrowth, pendingHistoryGrowth int) error {
+func (a *Agent) checkAndCompactWithGrowth(ctx context.Context, last *llm.Completion, out *eventOutput, currentHistoryGrowth, pendingHistoryGrowth int) error {
 	if !a.hasCompactor || a.compactor == nil || last == nil {
 		return nil
 	}
@@ -3163,7 +3195,7 @@ func (a *Agent) checkAndCompactWithGrowth(ctx context.Context, last *llm.Complet
 // leaves the SDK: the pipeline result reports the raw trigger usage instead. So
 // without this event the estimator-versus-provider drift that moves every
 // watermark stays unobservable, which is what makes the mixed decision unsafe.
-func (a *Agent) emitCompactionDecisionProvenance(out chan Event, decisionUsage *llm.Usage) {
+func (a *Agent) emitCompactionDecisionProvenance(out *eventOutput, decisionUsage *llm.Usage) {
 	if a == nil || out == nil || decisionUsage == nil {
 		return
 	}
@@ -3254,7 +3286,7 @@ func asyncCompactionContext(parent context.Context) (context.Context, context.Ca
 	return ctx, cancel
 }
 
-func (a *Agent) compactSyncOverflow(ctx context.Context, last *llm.Completion, decisionUsage *llm.Usage, out chan Event) error {
+func (a *Agent) compactSyncOverflow(ctx context.Context, last *llm.Completion, decisionUsage *llm.Usage, out *eventOutput) error {
 	if !a.hasCompactor || a.compactor == nil || last == nil {
 		return nil
 	}
@@ -3337,7 +3369,7 @@ func (a *Agent) compactSyncOverflow(ctx context.Context, last *llm.Completion, d
 // applyEmergencyTrim publishes an emergency-trimmed history as a compaction
 // result. It reports false when the trim could not produce a legal sendable
 // history, in which case the caller must keep surfacing the original failure.
-func (a *Agent) applyEmergencyTrim(messages []llm.Message, snapshotLen int, triggerUsage *llm.Usage, cause error, out chan Event) bool {
+func (a *Agent) applyEmergencyTrim(messages []llm.Message, snapshotLen int, triggerUsage *llm.Usage, cause error, out *eventOutput) bool {
 	trimmed, trimmedOK := a.emergencyTrimHistory(messages)
 	if !trimmedOK {
 		return false
@@ -3849,7 +3881,7 @@ func (a *Agent) compactOverflowWithPlan(ctx context.Context, messages []llm.Mess
 // in-flight compaction that never completes must not hang the turn forever,
 // because its result is only published into pendingCompaction and is picked up
 // at the next boundary anyway.
-func (a *Agent) waitForCompactionIdle(ctx context.Context, out chan Event) error {
+func (a *Agent) waitForCompactionIdle(ctx context.Context, out *eventOutput) error {
 	if a == nil || !a.compactionInFlight.Load() {
 		return nil
 	}
@@ -3942,7 +3974,7 @@ func (a *Agent) hasPendingCompaction() bool {
 	return a.pendingCompaction != nil
 }
 
-func (a *Agent) applyPendingCompaction(out chan Event) {
+func (a *Agent) applyPendingCompaction(out *eventOutput) {
 	if !a.hasCompactor {
 		return
 	}
@@ -4733,7 +4765,7 @@ func (a *Agent) errEvent(err error) ErrorEvent {
 //
 // The function returns immediately if the channel is nil or empty.
 // Each received message triggers a SteeringReceivedEvent to notify the CLI layer.
-func (a *Agent) drainSteering(ch <-chan SteeringMsg, out chan Event) int {
+func (a *Agent) drainSteering(ch <-chan SteeringMsg, out *eventOutput) int {
 	messages := a.collectSteering(ch, out)
 	if len(messages) == 0 {
 		return 0
@@ -4747,7 +4779,7 @@ func (a *Agent) drainSteering(ch <-chan SteeringMsg, out chan Event) int {
 // assistant tool-call block must first complete the tool_result block and only
 // then append the returned messages: a provider rejects a tool_use block whose
 // tool results are interleaved with user text.
-func (a *Agent) collectSteering(ch <-chan SteeringMsg, out chan Event) []llm.Message {
+func (a *Agent) collectSteering(ch <-chan SteeringMsg, out *eventOutput) []llm.Message {
 	if ch == nil {
 		return nil
 	}

--- a/sdk/agent/agent.go
+++ b/sdk/agent/agent.go
@@ -2683,8 +2683,11 @@ func (a *Agent) emitEvent(out *eventOutput, ev Event) bool {
 	}
 	floored := false
 	if isTerminalAgentEvent(ev) {
-		if a.tryEnqueueTerminalEvent(out, envelope) {
+		switch a.tryEnqueueTerminalEvent(out, envelope) {
+		case terminalEnqueued:
 			return true
+		case terminalRejected:
+			return false
 		}
 		// Terminal events are not charged against the per-turn floor budget:
 		// there is at most one FinalResponseEvent/ErrorEvent per turn, so they
@@ -2864,15 +2867,23 @@ func (a *Agent) turnCancellation(out *eventOutput) <-chan struct{} {
 	return nil
 }
 
-func (a *Agent) tryEnqueueTerminalEvent(out *eventOutput, envelope EventEnvelope) bool {
+type terminalEnqueueOutcome uint8
+
+const (
+	terminalUnavailable terminalEnqueueOutcome = iota
+	terminalEnqueued
+	terminalRejected
+)
+
+func (a *Agent) tryEnqueueTerminalEvent(out *eventOutput, envelope EventEnvelope) terminalEnqueueOutcome {
 	buffered, ok := out.tryReceive()
 	if !ok {
-		return false
+		return terminalUnavailable
 	}
 	if isTerminalAgentEvent(buffered.Event) && terminalEventPriority(buffered.Event) > terminalEventPriority(envelope.Event) {
 		out.sendAfterReceive(buffered)
 		a.logDroppedEvent(envelope.Event, "terminal_priority_loss")
-		return false
+		return terminalRejected
 	}
 	a.logDroppedEvent(buffered.Event, "evicted_for_terminal")
 	if final, ok := envelope.Event.(FinalResponseEvent); ok {
@@ -2881,7 +2892,7 @@ func (a *Agent) tryEnqueueTerminalEvent(out *eventOutput, envelope EventEnvelope
 		envelope.Event = final
 	}
 	out.sendAfterReceive(envelope)
-	return true
+	return terminalEnqueued
 }
 
 func terminalEventPriority(ev Event) int {

--- a/sdk/agent/agent.go
+++ b/sdk/agent/agent.go
@@ -659,13 +659,19 @@ func (a *Agent) queryStreamWithSteering(ctx context.Context, input llm.Content, 
 				DroppedCriticalEvents: criticalDroppedThisTurn(),
 			})
 		}
-		emitErr := func(e ErrorEvent) {
+		emitErr := func(e ErrorEvent, origin EventOrigin) {
 			e.StallRecoveries = streamIdleRecoveryTotal
-			a.emitEvent(out, e)
+			a.emitEventFrom(out, e, origin)
 		}
 		emitSDKErr := func(e ErrorEvent) {
-			e.StallRecoveries = streamIdleRecoveryTotal
-			a.emitEventFrom(out, e, EventOriginSDKDriver)
+			emitErr(e, EventOriginSDKDriver)
+		}
+		emitCompactionErr := func(e ErrorEvent) {
+			origin := EventOriginCompaction
+			if ctx.Err() != nil {
+				origin = EventOriginSDKDriver
+			}
+			emitErr(e, origin)
 		}
 
 		// maxIterations < 0 means unlimited: the loop is then bounded only by
@@ -821,7 +827,11 @@ func (a *Agent) queryStreamWithSteering(ctx context.Context, input llm.Content, 
 				// before the terminal error or the tokens never reach the
 				// accounting journal, which silently under-counts the ledger.
 				a.emitPartialUsage(out, comp)
-				emitErr(a.errEvent(err))
+				origin := EventOriginProvider
+				if ctx.Err() != nil {
+					origin = EventOriginSDKDriver
+				}
+				emitErr(a.errEvent(err), origin)
 				return
 			}
 			streamIdleRecoveries = 0
@@ -875,7 +885,7 @@ func (a *Agent) queryStreamWithSteering(ctx context.Context, input llm.Content, 
 					Provider: a.llm.Provider(),
 					Kind:     "invalid_tool_call_block",
 					Message:  fmt.Sprintf("provider returned duplicate tool_call_id values at positions %d and %d; no tools were executed", first+1, second+1),
-				})
+				}, EventOriginSDKDriver)
 				return
 			}
 
@@ -939,7 +949,7 @@ func (a *Agent) queryStreamWithSteering(ctx context.Context, input llm.Content, 
 					reminder := messageorigin.NewInternalUserMessage(messageorigin.KindToolCallContinuation, messageorigin.ToolCallContinuationLimitText)
 					if a.hasCompactor {
 						if err := a.checkAndCompactWithGrowth(ctx, comp, out, additionalSinceCompletion(), pendingMessageTokens(reminder)); err != nil {
-							emitErr(a.errEvent(err))
+							emitCompactionErr(a.errEvent(err))
 							return
 						}
 					}
@@ -956,7 +966,7 @@ func (a *Agent) queryStreamWithSteering(ctx context.Context, input llm.Content, 
 				reminder := messageorigin.NewInternalUserMessage(messageorigin.KindToolCallContinuation, messageorigin.ResponseTruncatedContinuationText)
 				if a.hasCompactor {
 					if err := a.checkAndCompactWithGrowth(ctx, comp, out, additionalSinceCompletion(), pendingMessageTokens(reminder)); err != nil {
-						emitErr(a.errEvent(err))
+						emitCompactionErr(a.errEvent(err))
 						return
 					}
 				}
@@ -988,7 +998,7 @@ func (a *Agent) queryStreamWithSteering(ctx context.Context, input llm.Content, 
 						reminder := messageorigin.NewInternalUserMessage(messageorigin.KindToolCallContinuation, messageorigin.InvalidToolCallContinuationText)
 						if a.hasCompactor {
 							if err := a.checkAndCompactWithGrowth(ctx, comp, out, additionalSinceCompletion(), pendingMessageTokens(reminder)); err != nil {
-								emitErr(a.errEvent(err))
+								emitCompactionErr(a.errEvent(err))
 								return
 							}
 						}
@@ -1006,7 +1016,7 @@ func (a *Agent) queryStreamWithSteering(ctx context.Context, input llm.Content, 
 					reminder := messageorigin.NewInternalUserMessage(messageorigin.KindToolCallContinuation, messageorigin.ResponseTruncatedContinuationText)
 					if a.hasCompactor {
 						if err := a.checkAndCompactWithGrowth(ctx, comp, out, additionalSinceCompletion(), pendingMessageTokens(reminder)); err != nil {
-							emitErr(a.errEvent(err))
+							emitCompactionErr(a.errEvent(err))
 							return
 						}
 					}
@@ -1059,7 +1069,7 @@ func (a *Agent) queryStreamWithSteering(ctx context.Context, input llm.Content, 
 					reminder := messageorigin.NewInternalUserMessage(messageorigin.KindMaxTokensContinuation, messageorigin.ResponseTruncatedContinuationText)
 					if a.hasCompactor {
 						if err := a.checkAndCompactWithGrowth(ctx, comp, out, additionalSinceCompletion(), pendingMessageTokens(reminder)); err != nil {
-							emitErr(a.errEvent(err))
+							emitCompactionErr(a.errEvent(err))
 							return
 						}
 					}
@@ -1081,7 +1091,7 @@ func (a *Agent) queryStreamWithSteering(ctx context.Context, input llm.Content, 
 						reminder := messageorigin.NewInternalUserMessage(messageorigin.KindEarlyStop, earlyStopReminderText)
 						if a.hasCompactor {
 							if err := a.checkAndCompactWithGrowth(ctx, comp, out, additionalSinceCompletion(), pendingMessageTokens(reminder)); err != nil {
-								emitErr(a.errEvent(err))
+								emitCompactionErr(a.errEvent(err))
 								return
 							}
 						}
@@ -1155,7 +1165,7 @@ func (a *Agent) queryStreamWithSteering(ctx context.Context, input llm.Content, 
 					reminder := messageorigin.NewInternalUserMessage(messageorigin.KindRequireDone, requireDoneReminderText)
 					if a.hasCompactor {
 						if err := a.checkAndCompactWithGrowth(ctx, comp, out, additionalSinceCompletion(), pendingMessageTokens(reminder)); err != nil {
-							emitErr(a.errEvent(err))
+							emitCompactionErr(a.errEvent(err))
 							return
 						}
 					}
@@ -1475,7 +1485,7 @@ func (a *Agent) queryStreamWithSteering(ctx context.Context, input llm.Content, 
 			pendingBlockMessages = nil
 			if a.hasCompactor {
 				if err := a.checkAndCompact(ctx, comp, out, additionalSinceCompletion()); err != nil {
-					emitErr(a.errEvent(err))
+					emitCompactionErr(a.errEvent(err))
 					return
 				}
 			}
@@ -1484,7 +1494,7 @@ func (a *Agent) queryStreamWithSteering(ctx context.Context, input llm.Content, 
 		// Max iterations reached — emit both error and final events.
 		// Unreachable when maxIterations < 0 (unlimited).
 		msg := fmt.Sprintf("Max iterations reached (%d)", a.maxIterations)
-		emitErr(ErrorEvent{Provider: a.llm.Provider(), Message: msg, Kind: "max_iterations"})
+		emitErr(ErrorEvent{Provider: a.llm.Provider(), Message: msg, Kind: "max_iterations"}, EventOriginSDKDriver)
 		emitFinal(fmt.Sprintf("[Max iterations reached] %d", a.maxIterations), lastResponseID)
 	}(runtimeRelease, runtimeAcquired)
 	return out

--- a/sdk/agent/agent.go
+++ b/sdk/agent/agent.go
@@ -592,7 +592,7 @@ func (a *Agent) queryStreamWithSteering(ctx context.Context, input llm.Content, 
 			var err error
 			releaseCompactionRuntime, err = a.beginCompactionRuntimeUse(ctx)
 			if err != nil {
-				a.emitEvent(out, a.errEvent(err))
+				a.emitEventFrom(out, a.errEvent(err), EventOriginSDKDriver)
 				return
 			}
 		}
@@ -663,6 +663,10 @@ func (a *Agent) queryStreamWithSteering(ctx context.Context, input llm.Content, 
 			e.StallRecoveries = streamIdleRecoveryTotal
 			a.emitEvent(out, e)
 		}
+		emitSDKErr := func(e ErrorEvent) {
+			e.StallRecoveries = streamIdleRecoveryTotal
+			a.emitEventFrom(out, e, EventOriginSDKDriver)
+		}
 
 		// maxIterations < 0 means unlimited: the loop is then bounded only by
 		// tool-loop guards, idle detection, and context cancellation.
@@ -672,12 +676,12 @@ func (a *Agent) queryStreamWithSteering(ctx context.Context, input llm.Content, 
 			// result. Enforce cancellation at the provider-admission boundary so a
 			// context-ignoring model cannot receive one more stale request.
 			if err := ctx.Err(); err != nil {
-				emitErr(a.errEvent(err))
+				emitSDKErr(a.errEvent(err))
 				return
 			}
 			if a.compactionInFlight.Load() {
 				if err := a.waitForCompactionIdle(ctx, out); err != nil {
-					emitErr(a.errEvent(err))
+					emitSDKErr(a.errEvent(err))
 					return
 				}
 			}
@@ -715,7 +719,7 @@ func (a *Agent) queryStreamWithSteering(ctx context.Context, input llm.Content, 
 			// unblock a host that cancels the root turn. Recheck at the actual
 			// provider-admission boundary, not only at iteration entry.
 			if err := ctx.Err(); err != nil {
-				emitErr(a.errEvent(err))
+				emitSDKErr(a.errEvent(err))
 				return
 			}
 			comp, streamedText, err := a.invokeCompletionWithRetryAndSteering(ctx, llm.InvokeRequest{
@@ -1180,7 +1184,7 @@ func (a *Agent) queryStreamWithSteering(ctx context.Context, input llm.Content, 
 					a.appendCancellationSkippedToolResults(comp.ToolCalls[idx:])
 					a.appendMessages(pendingBlockMessages)
 					pendingBlockMessages = nil
-					emitErr(a.errEvent(err))
+					emitSDKErr(a.errEvent(err))
 					return
 				}
 				step := idx + 1
@@ -1393,7 +1397,7 @@ func (a *Agent) queryStreamWithSteering(ctx context.Context, input llm.Content, 
 						a.appendCancellationSkippedToolResults(comp.ToolCalls[idx+1:])
 						a.appendMessages(pendingBlockMessages)
 						pendingBlockMessages = nil
-						emitErr(a.errEvent(err))
+						emitSDKErr(a.errEvent(err))
 						return
 					}
 					// The turn ends here, but the assistant tool-call block must
@@ -1441,7 +1445,7 @@ func (a *Agent) queryStreamWithSteering(ctx context.Context, input llm.Content, 
 					a.appendCancellationSkippedToolResults(comp.ToolCalls[idx+1:])
 					a.appendMessages(pendingBlockMessages)
 					pendingBlockMessages = nil
-					emitErr(a.errEvent(rootCancelErr))
+					emitSDKErr(a.errEvent(rootCancelErr))
 					return
 				}
 				if strings.EqualFold(strings.TrimSpace(resolvedName), "done") {
@@ -2652,7 +2656,17 @@ func (a *Agent) emitEvent(out *eventOutput, ev Event) bool {
 	if out == nil {
 		return false
 	}
-	envelope := out.next(ev)
+	return a.emitEnvelope(out, ev, out.next(ev))
+}
+
+func (a *Agent) emitEventFrom(out *eventOutput, ev Event, origin EventOrigin) bool {
+	if out == nil {
+		return false
+	}
+	return a.emitEnvelope(out, ev, out.nextFrom(ev, origin))
+}
+
+func (a *Agent) emitEnvelope(out *eventOutput, ev Event, envelope EventEnvelope) bool {
 	if out.trySend(envelope) {
 		return true
 	}

--- a/sdk/agent/agent_backpressure_test.go
+++ b/sdk/agent/agent_backpressure_test.go
@@ -375,13 +375,14 @@ func TestCriticalEventFloorIsSkippedForCanceledTurn(t *testing.T) {
 	}
 
 	canceledOut := make(chan Event, 1)
+	canceledDelivery := wrapLegacyEventOutput(canceledOut)
 	canceledOut <- WarnEvent{Message: "filler"} // channel is now full
 	canceledCtx, cancel := context.WithCancel(context.Background())
-	defer ag.registerTurnCancellation(canceledOut, canceledCtx)()
+	defer ag.registerTurnCancellation(canceledDelivery, canceledCtx)()
 	cancel()
 
 	start := time.Now()
-	if ag.emitEvent(canceledOut, ToolResultEvent{Tool: "read"}) {
+	if ag.emitEvent(canceledDelivery, ToolResultEvent{Tool: "read"}) {
 		t.Fatal("expected the send into a full channel to fail")
 	}
 	if elapsed := time.Since(start); elapsed >= criticalEventSendTimeoutFloor {
@@ -390,7 +391,7 @@ func TestCriticalEventFloorIsSkippedForCanceledTurn(t *testing.T) {
 
 	start = time.Now()
 	for i := 0; i < 6; i++ {
-		ag.emitEvent(canceledOut, ToolResultEvent{Tool: "read"})
+		ag.emitEvent(canceledDelivery, ToolResultEvent{Tool: "read"})
 	}
 	if elapsed := time.Since(start); elapsed >= criticalEventSendTimeoutFloor {
 		t.Fatalf("6 critical events on a canceled turn cost %v; expected far below one %v floor",
@@ -398,12 +399,13 @@ func TestCriticalEventFloorIsSkippedForCanceledTurn(t *testing.T) {
 	}
 
 	liveOut := make(chan Event, 1)
+	liveDelivery := wrapLegacyEventOutput(liveOut)
 	liveOut <- WarnEvent{Message: "filler"}
 	liveCtx, liveCancel := context.WithCancel(context.Background())
 	defer liveCancel()
-	defer ag.registerTurnCancellation(liveOut, liveCtx)()
+	defer ag.registerTurnCancellation(liveDelivery, liveCtx)()
 	start = time.Now()
-	ag.emitEvent(liveOut, ToolResultEvent{Tool: "read"})
+	ag.emitEvent(liveDelivery, ToolResultEvent{Tool: "read"})
 	if elapsed := time.Since(start); elapsed < criticalEventSendTimeoutFloor {
 		t.Fatalf("live turn lost the deliberate critical-event floor: %v < %v", elapsed, criticalEventSendTimeoutFloor)
 	}
@@ -467,15 +469,16 @@ func TestCriticalEventFloorIsBoundedPerTurn(t *testing.T) {
 		t.Fatalf("new agent: %v", err)
 	}
 	out := make(chan Event, 1)
+	delivery := wrapLegacyEventOutput(out)
 	out <- WarnEvent{Message: "filler"} // full channel, and nothing drains it
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	defer ag.registerTurnCancellation(out, ctx)()
+	defer ag.registerTurnCancellation(delivery, ctx)()
 
 	const events = 700 // ~100 tool calls x ~7 critical events
 	start := time.Now()
 	for i := 0; i < events; i++ {
-		ag.emitEvent(out, ToolResultEvent{Tool: "read"})
+		ag.emitEvent(delivery, ToolResultEvent{Tool: "read"})
 	}
 	elapsed := time.Since(start)
 
@@ -510,13 +513,14 @@ func TestCriticalEventFloorBudgetStillPaysTheFirstEvents(t *testing.T) {
 		t.Fatalf("new agent: %v", err)
 	}
 	out := make(chan Event, 1)
+	delivery := wrapLegacyEventOutput(out)
 	out <- WarnEvent{Message: "filler"}
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	defer ag.registerTurnCancellation(out, ctx)()
+	defer ag.registerTurnCancellation(delivery, ctx)()
 
 	start := time.Now()
-	ag.emitEvent(out, ToolResultEvent{Tool: "read"})
+	ag.emitEvent(delivery, ToolResultEvent{Tool: "read"})
 	if elapsed := time.Since(start); elapsed < criticalEventSendTimeoutFloor {
 		t.Fatalf("the first critical event of a turn lost the deliberate floor: %v < %v",
 			elapsed, criticalEventSendTimeoutFloor)
@@ -526,25 +530,26 @@ func TestCriticalEventFloorBudgetStillPaysTheFirstEvents(t *testing.T) {
 	deadline := time.Now().Add(2 * criticalEventFloorTurnBudget)
 	for time.Now().Before(deadline) {
 		before := time.Now()
-		ag.emitEvent(out, ToolResultEvent{Tool: "read"})
+		ag.emitEvent(delivery, ToolResultEvent{Tool: "read"})
 		if time.Since(before) < criticalEventSendTimeoutFloor {
 			break // budget spent, critical events fell back to the ordinary budget
 		}
 	}
 	start = time.Now()
-	ag.emitEvent(out, ToolResultEvent{Tool: "read"})
+	ag.emitEvent(delivery, ToolResultEvent{Tool: "read"})
 	if elapsed := time.Since(start); elapsed >= criticalEventSendTimeoutFloor {
 		t.Fatalf("a critical event still paid the full floor after the turn budget was spent: %v", elapsed)
 	}
 
 	// A fresh turn gets a fresh budget.
 	freshOut := make(chan Event, 1)
+	freshDelivery := wrapLegacyEventOutput(freshOut)
 	freshOut <- WarnEvent{Message: "filler"}
 	freshCtx, freshCancel := context.WithCancel(context.Background())
 	defer freshCancel()
-	defer ag.registerTurnCancellation(freshOut, freshCtx)()
+	defer ag.registerTurnCancellation(freshDelivery, freshCtx)()
 	start = time.Now()
-	ag.emitEvent(freshOut, ToolResultEvent{Tool: "read"})
+	ag.emitEvent(freshDelivery, ToolResultEvent{Tool: "read"})
 	if elapsed := time.Since(start); elapsed < criticalEventSendTimeoutFloor {
 		t.Fatalf("a new turn did not get a fresh floor budget: %v < %v", elapsed, criticalEventSendTimeoutFloor)
 	}

--- a/sdk/agent/agent_compaction_checkpoint_test.go
+++ b/sdk/agent/agent_compaction_checkpoint_test.go
@@ -421,7 +421,7 @@ func TestAutomaticCompactionCheckpointFailurePreservesHistory(t *testing.T) {
 		},
 	}
 	out := make(chan Event, 1)
-	ag.applyPendingCompaction(out)
+	ag.applyPendingCompaction(wrapLegacyEventOutput(out))
 	if writes != 1 {
 		t.Fatalf("automatic checkpoint writes = %d, want 1", writes)
 	}

--- a/sdk/agent/agent_compaction_local_test.go
+++ b/sdk/agent/agent_compaction_local_test.go
@@ -331,7 +331,7 @@ func TestTodoCheckpointAtEligibleWatermarkUsesNormalPipeline(t *testing.T) {
 	}
 
 	out := make(chan Event, 1)
-	ag.applyPendingCompaction(out)
+	ag.applyPendingCompaction(wrapLegacyEventOutput(out))
 	close(out)
 	var got CompactionEvent
 	for event := range out {
@@ -374,7 +374,7 @@ func TestPlaceholderPressureUsesLocalDeterministicCleanup(t *testing.T) {
 	}
 
 	out := make(chan Event, 1)
-	ag.applyPendingCompaction(out)
+	ag.applyPendingCompaction(wrapLegacyEventOutput(out))
 	close(out)
 	var compacted CompactionEvent
 	for event := range out {

--- a/sdk/agent/agent_critical_floor_observability_test.go
+++ b/sdk/agent/agent_critical_floor_observability_test.go
@@ -34,13 +34,14 @@ func TestCriticalEventFloorOverrideOfHostConfigIsReported(t *testing.T) {
 			}
 
 			out := make(chan Event, 1)
+			delivery := wrapLegacyEventOutput(out)
 			out <- WarnEvent{Message: "filler"} // channel is now full
 			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()
-			defer ag.registerTurnCancellation(out, ctx)()
+			defer ag.registerTurnCancellation(delivery, ctx)()
 
 			start := time.Now()
-			if ag.emitEvent(out, ToolResultEvent{Tool: "read"}) {
+			if ag.emitEvent(delivery, ToolResultEvent{Tool: "read"}) {
 				t.Fatal("expected the send into a full channel to fail")
 			}
 			// The floor still wins over the configured value: ISS-129b.
@@ -63,7 +64,7 @@ func TestCriticalEventFloorOverrideOfHostConfigIsReported(t *testing.T) {
 			// One line per turn, not one per event: a tool-heavy turn must not
 			// flood the host's log with the same notice.
 			for i := 0; i < 5; i++ {
-				ag.emitEvent(out, ToolResultEvent{Tool: "read"})
+				ag.emitEvent(delivery, ToolResultEvent{Tool: "read"})
 			}
 			lines := 0
 			for _, line := range strings.Split(warnings.String(), "\n") {
@@ -94,12 +95,13 @@ func TestCriticalEventFloorDoesNotReportWhenHostConfigMeetsTheFloor(t *testing.T
 		t.Fatalf("new agent: %v", err)
 	}
 	out := make(chan Event, 1)
+	delivery := wrapLegacyEventOutput(out)
 	out <- WarnEvent{Message: "filler"}
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	defer ag.registerTurnCancellation(out, ctx)()
+	defer ag.registerTurnCancellation(delivery, ctx)()
 
-	ag.emitEvent(out, ToolResultEvent{Tool: "read"})
+	ag.emitEvent(delivery, ToolResultEvent{Tool: "read"})
 	if got := warnings.String(); strings.Contains(got, "critical-event floor instead of") {
 		t.Fatalf("warned about an override that did not happen; warnings = %q", got)
 	}
@@ -121,12 +123,13 @@ func TestCriticalEventFloorDoesNotReportForCanceledTurn(t *testing.T) {
 		t.Fatalf("new agent: %v", err)
 	}
 	out := make(chan Event, 1)
+	delivery := wrapLegacyEventOutput(out)
 	out <- WarnEvent{Message: "filler"}
 	ctx, cancel := context.WithCancel(context.Background())
-	defer ag.registerTurnCancellation(out, ctx)()
+	defer ag.registerTurnCancellation(delivery, ctx)()
 	cancel()
 
-	ag.emitEvent(out, ToolResultEvent{Tool: "read"})
+	ag.emitEvent(delivery, ToolResultEvent{Tool: "read"})
 	if got := warnings.String(); strings.Contains(got, "critical-event floor instead of") {
 		t.Fatalf("a canceled turn reported a floor override it never paid; warnings = %q", got)
 	}

--- a/sdk/agent/agent_emergency_trim_iteration_test.go
+++ b/sdk/agent/agent_emergency_trim_iteration_test.go
@@ -343,7 +343,7 @@ func TestCompactSyncOverflowPropagatesFailedEmergencyTrim(t *testing.T) {
 
 	out := make(chan Event, 64)
 	completion := &llm.Completion{Usage: &llm.Usage{TotalTokens: 4000, PromptTokens: 4000}}
-	compactErr := ag.compactSyncOverflow(context.Background(), completion, completion.Usage, out)
+	compactErr := ag.compactSyncOverflow(context.Background(), completion, completion.Usage, wrapLegacyEventOutput(out))
 	budget := ag.compactor.ThresholdTokens()
 	estimate := ag.compactor.EstimateMessages(ag.Messages())
 	if estimate <= budget {

--- a/sdk/agent/agent_request_ownership_test.go
+++ b/sdk/agent/agent_request_ownership_test.go
@@ -80,7 +80,7 @@ func TestInvokeRetryUsesFreshRequestClone(t *testing.T) {
 			OutputSchema: map[string]any{"type": "object"},
 		},
 	}
-	if _, _, err := agent.invokeCompletionWithRetry(context.Background(), request, make(chan Event, 8)); err != nil {
+	if _, _, err := agent.invokeCompletionWithRetry(context.Background(), request, wrapLegacyEventOutput(make(chan Event, 8))); err != nil {
 		t.Fatal(err)
 	}
 	if model.calls != 2 {

--- a/sdk/agent/agent_stream_terminal_contract_test.go
+++ b/sdk/agent/agent_stream_terminal_contract_test.go
@@ -33,7 +33,7 @@ func invokeTerminalContract(t *testing.T, events ...llm.StreamEvent) (*llm.Compl
 		t.Fatal(err)
 	}
 	out := make(chan Event, 32)
-	completion, _, err := agent.invokeCompletion(context.Background(), llm.InvokeRequest{}, out)
+	completion, _, err := agent.invokeCompletion(context.Background(), llm.InvokeRequest{}, wrapLegacyEventOutput(out))
 	return completion, err
 }
 

--- a/sdk/agent/event_envelope.go
+++ b/sdk/agent/event_envelope.go
@@ -89,7 +89,14 @@ func newEventOutput(bufferSize int, enveloped bool, queryID string, clock func()
 }
 
 func (o *eventOutput) next(ev Event) EventEnvelope {
-	kind, origin := classifyEvent(ev)
+	return o.nextFrom(ev, "")
+}
+
+func (o *eventOutput) nextFrom(ev Event, origin EventOrigin) EventEnvelope {
+	kind, classifiedOrigin := classifyEvent(ev)
+	if origin == "" {
+		origin = classifiedOrigin
+	}
 	now := time.Now()
 	if o != nil && o.clock != nil {
 		now = o.clock()

--- a/sdk/agent/event_envelope.go
+++ b/sdk/agent/event_envelope.go
@@ -1,0 +1,242 @@
+package agent
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"fmt"
+	"strings"
+	"sync/atomic"
+	"time"
+)
+
+const EventEnvelopeSchemaVersion = 1
+
+type EventKind string
+
+const (
+	EventKindText              EventKind = "text"
+	EventKindTextDelta         EventKind = "text_delta"
+	EventKindThinking          EventKind = "thinking"
+	EventKindThinkingDelta     EventKind = "thinking_delta"
+	EventKindError             EventKind = "error"
+	EventKindWarning           EventKind = "warning"
+	EventKindHiddenUserMessage EventKind = "hidden_user_message"
+	EventKindStepStart         EventKind = "step_start"
+	EventKindStepComplete      EventKind = "step_complete"
+	EventKindToolCall          EventKind = "tool_call"
+	EventKindToolResult        EventKind = "tool_result"
+	EventKindFinalResponse     EventKind = "final_response"
+	EventKindUsage             EventKind = "usage"
+	EventKindCompaction        EventKind = "compaction"
+	EventKindAccounting        EventKind = "accounting"
+	EventKindSteeringReceived  EventKind = "steering_received"
+	EventKindAutoContinue      EventKind = "auto_continue"
+)
+
+type EventOrigin string
+
+const (
+	EventOriginModel       EventOrigin = "model"
+	EventOriginProvider    EventOrigin = "provider"
+	EventOriginSDKDriver   EventOrigin = "sdk_driver"
+	EventOriginToolRuntime EventOrigin = "tool_runtime"
+	EventOriginCompaction  EventOrigin = "compaction"
+	EventOriginHost        EventOrigin = "host"
+)
+
+// EventEnvelope adds query-wide ordering metadata without replacing the typed
+// Event payload. Sequence, not Timestamp, defines logical order.
+type EventEnvelope struct {
+	SchemaVersion int
+	QueryID       string
+	Sequence      uint64
+	Origin        EventOrigin
+	Kind          EventKind
+	Timestamp     time.Time
+	Event         Event
+}
+
+type eventOutput struct {
+	legacy            chan Event
+	enveloped         chan EventEnvelope
+	queryID           string
+	clock             func() time.Time
+	sequence          atomic.Uint64
+	dropStart         uint64
+	criticalDropStart uint64
+}
+
+func (o *eventOutput) setDropBaseline(dropped, critical uint64) {
+	o.dropStart = dropped
+	o.criticalDropStart = critical
+}
+
+func dropsSince(current, baseline uint64) uint64 {
+	if current <= baseline {
+		return 0
+	}
+	return current - baseline
+}
+
+func newEventOutput(bufferSize int, enveloped bool, queryID string, clock func() time.Time) *eventOutput {
+	out := &eventOutput{queryID: queryID, clock: clock}
+	if enveloped {
+		out.enveloped = make(chan EventEnvelope, bufferSize)
+	} else {
+		out.legacy = make(chan Event, bufferSize)
+	}
+	return out
+}
+
+func (o *eventOutput) next(ev Event) EventEnvelope {
+	kind, origin := classifyEvent(ev)
+	now := time.Now()
+	if o != nil && o.clock != nil {
+		now = o.clock()
+	}
+	return EventEnvelope{
+		SchemaVersion: EventEnvelopeSchemaVersion,
+		QueryID:       o.queryID,
+		Sequence:      o.sequence.Add(1),
+		Origin:        origin,
+		Kind:          kind,
+		Timestamp:     now,
+		Event:         ev,
+	}
+}
+
+func (o *eventOutput) trySend(envelope EventEnvelope) bool {
+	if o == nil {
+		return false
+	}
+	if o.enveloped != nil {
+		select {
+		case o.enveloped <- envelope:
+			return true
+		default:
+			return false
+		}
+	}
+	select {
+	case o.legacy <- envelope.Event:
+		return true
+	default:
+		return false
+	}
+}
+
+type eventSendOutcome uint8
+
+const (
+	eventSent eventSendOutcome = iota
+	eventTurnCanceled
+	eventSendTimedOut
+)
+
+func (o *eventOutput) sendUntil(envelope EventEnvelope, done <-chan struct{}, timeout <-chan time.Time) eventSendOutcome {
+	if o.enveloped != nil {
+		select {
+		case o.enveloped <- envelope:
+			return eventSent
+		case <-done:
+			return eventTurnCanceled
+		case <-timeout:
+			return eventSendTimedOut
+		}
+	}
+	select {
+	case o.legacy <- envelope.Event:
+		return eventSent
+	case <-done:
+		return eventTurnCanceled
+	case <-timeout:
+		return eventSendTimedOut
+	}
+}
+
+func (o *eventOutput) tryReceive() (EventEnvelope, bool) {
+	if o.enveloped != nil {
+		select {
+		case envelope := <-o.enveloped:
+			return envelope, true
+		default:
+			return EventEnvelope{}, false
+		}
+	}
+	select {
+	case event := <-o.legacy:
+		return EventEnvelope{Event: event}, true
+	default:
+		return EventEnvelope{}, false
+	}
+}
+
+func (o *eventOutput) sendAfterReceive(envelope EventEnvelope) {
+	if o.enveloped != nil {
+		o.enveloped <- envelope
+		return
+	}
+	o.legacy <- envelope.Event
+}
+
+func (o *eventOutput) close() {
+	if o.enveloped != nil {
+		close(o.enveloped)
+		return
+	}
+	close(o.legacy)
+}
+
+func classifyEvent(event Event) (EventKind, EventOrigin) {
+	switch event := event.(type) {
+	case TextEvent:
+		return EventKindText, EventOriginModel
+	case TextDeltaEvent:
+		return EventKindTextDelta, EventOriginModel
+	case ThinkingEvent:
+		return EventKindThinking, EventOriginModel
+	case ThinkingDeltaEvent:
+		return EventKindThinkingDelta, EventOriginModel
+	case ErrorEvent:
+		if strings.TrimSpace(event.Provider) != "" {
+			return EventKindError, EventOriginProvider
+		}
+		return EventKindError, EventOriginSDKDriver
+	case WarnEvent:
+		return EventKindWarning, EventOriginSDKDriver
+	case HiddenUserMessageEvent:
+		return EventKindHiddenUserMessage, EventOriginSDKDriver
+	case StepStartEvent:
+		return EventKindStepStart, EventOriginToolRuntime
+	case StepCompleteEvent:
+		return EventKindStepComplete, EventOriginToolRuntime
+	case ToolCallEvent:
+		return EventKindToolCall, EventOriginToolRuntime
+	case ToolResultEvent:
+		return EventKindToolResult, EventOriginToolRuntime
+	case FinalResponseEvent:
+		return EventKindFinalResponse, EventOriginSDKDriver
+	case UsageEvent:
+		return EventKindUsage, EventOriginProvider
+	case CompactionEvent:
+		return EventKindCompaction, EventOriginCompaction
+	case AccountingEvent:
+		return EventKindAccounting, EventOriginSDKDriver
+	case SteeringReceivedEvent:
+		return EventKindSteeringReceived, EventOriginHost
+	case AutoContinueEvent:
+		return EventKindAutoContinue, EventOriginSDKDriver
+	default:
+		panic(fmt.Sprintf("agent: unclassified event type %T", event))
+	}
+}
+
+var fallbackQueryID atomic.Uint64
+
+func newDefaultQueryID() string {
+	var random [16]byte
+	if _, err := rand.Read(random[:]); err == nil {
+		return "query_" + hex.EncodeToString(random[:])
+	}
+	return fmt.Sprintf("query_fallback_%d_%d", time.Now().UnixNano(), fallbackQueryID.Add(1))
+}

--- a/sdk/agent/event_envelope.go
+++ b/sdk/agent/event_envelope.go
@@ -198,10 +198,7 @@ func classifyEvent(event Event) (EventKind, EventOrigin) {
 	case ThinkingDeltaEvent:
 		return EventKindThinkingDelta, EventOriginModel
 	case ErrorEvent:
-		if strings.TrimSpace(event.Provider) != "" {
-			return EventKindError, EventOriginProvider
-		}
-		return EventKindError, EventOriginSDKDriver
+		return EventKindError, classifyErrorOrigin(event)
 	case WarnEvent:
 		return EventKindWarning, EventOriginSDKDriver
 	case HiddenUserMessageEvent:
@@ -229,6 +226,17 @@ func classifyEvent(event Event) (EventKind, EventOrigin) {
 	default:
 		panic(fmt.Sprintf("agent: unclassified event type %T", event))
 	}
+}
+
+func classifyErrorOrigin(event ErrorEvent) EventOrigin {
+	switch strings.TrimSpace(event.Kind) {
+	case "agent_busy", "canceled", "invalid_tool_call_block", "max_iterations", "loop_guard", "doom_loop":
+		return EventOriginSDKDriver
+	}
+	if strings.TrimSpace(event.Provider) != "" {
+		return EventOriginProvider
+	}
+	return EventOriginSDKDriver
 }
 
 var fallbackQueryID atomic.Uint64

--- a/sdk/agent/event_envelope.go
+++ b/sdk/agent/event_envelope.go
@@ -237,7 +237,7 @@ func classifyEvent(event Event) (EventKind, EventOrigin) {
 
 func classifyErrorOrigin(event ErrorEvent) EventOrigin {
 	switch strings.TrimSpace(event.Kind) {
-	case "agent_busy", "canceled", "invalid_tool_call_block", "max_iterations", "loop_guard", "doom_loop":
+	case "agent_busy", "invalid_tool_call_block", "max_iterations", "loop_guard", "doom_loop":
 		return EventOriginSDKDriver
 	}
 	if strings.TrimSpace(event.Provider) != "" {

--- a/sdk/agent/event_envelope_test.go
+++ b/sdk/agent/event_envelope_test.go
@@ -14,6 +14,14 @@ import (
 
 type envelopeFinalModel struct{}
 
+type envelopeToolLoopModel struct{}
+
+func (envelopeToolLoopModel) Provider() string { return "fixture" }
+func (envelopeToolLoopModel) Model() string    { return "fixture" }
+func (envelopeToolLoopModel) Invoke(context.Context, llm.InvokeRequest) (*llm.Completion, error) {
+	return &llm.Completion{ToolCalls: []llm.ToolCall{{ID: "call-loop", Type: "function", Function: llm.FunctionCall{Name: "missing", Arguments: `{}`}}}, StopReason: "tool_calls"}, nil
+}
+
 func wrapLegacyEventOutput(ch chan Event) *eventOutput {
 	return &eventOutput{legacy: ch, queryID: "test-query", clock: time.Now}
 }
@@ -73,6 +81,8 @@ func TestEventEnvelopeClassifiesAllTypedEvents(t *testing.T) {
 		{ThinkingDeltaEvent{}, EventKindThinkingDelta, EventOriginModel},
 		{ErrorEvent{}, EventKindError, EventOriginSDKDriver},
 		{ErrorEvent{Provider: "fixture"}, EventKindError, EventOriginProvider},
+		{ErrorEvent{Provider: "fixture", Kind: "canceled"}, EventKindError, EventOriginSDKDriver},
+		{ErrorEvent{Provider: "fixture", Kind: "max_iterations"}, EventKindError, EventOriginSDKDriver},
 		{WarnEvent{}, EventKindWarning, EventOriginSDKDriver},
 		{HiddenUserMessageEvent{}, EventKindHiddenUserMessage, EventOriginSDKDriver},
 		{StepStartEvent{}, EventKindStepStart, EventOriginToolRuntime},
@@ -92,6 +102,63 @@ func TestEventEnvelopeClassifiesAllTypedEvents(t *testing.T) {
 			t.Fatalf("%T classified as %q/%q want %q/%q", test.event, kind, origin, test.kind, test.origin)
 		}
 	}
+}
+
+func TestEventEnvelopeTerminalPriorityRejectsOnce(t *testing.T) {
+	agent := &Agent{eventSendTimeout: time.Millisecond}
+	out := newEventOutput(1, true, "query-test", time.Now)
+	errorEnvelope := out.next(ErrorEvent{Provider: "fixture", Kind: "provider", Message: "failed"})
+	if !out.trySend(errorEnvelope) {
+		t.Fatal("failed to fill envelope channel")
+	}
+
+	if agent.emitEvent(out, FinalResponseEvent{Content: "must not follow error"}) {
+		t.Fatal("lower-priority final was delivered after terminal error")
+	}
+	if got := agent.eventDropCount.Load(); got != 1 {
+		t.Fatalf("drop count=%d want exactly 1", got)
+	}
+	buffered := <-out.enveloped
+	if buffered.Sequence != 1 || buffered.Kind != EventKindError {
+		t.Fatalf("buffered terminal changed: %#v", buffered)
+	}
+	select {
+	case extra := <-out.enveloped:
+		t.Fatalf("lower-priority terminal remained deliverable: %#v", extra)
+	default:
+	}
+}
+
+func TestEventEnvelopeSDKTerminalErrorsKeepSDKOrigin(t *testing.T) {
+	canceledAgent, err := New(Config{LLM: envelopeFinalModel{}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	canceled := collectEnvelopes(canceledAgent.QueryStreamEnveloped(ctx, llm.TextContent("run")))
+	assertEnvelopeErrorOrigin(t, canceled, "canceled", EventOriginSDKDriver)
+
+	maxAgent, err := New(Config{LLM: envelopeToolLoopModel{}, MaxIterations: 1})
+	if err != nil {
+		t.Fatal(err)
+	}
+	maximum := collectEnvelopes(maxAgent.QueryStreamEnveloped(context.Background(), llm.TextContent("run")))
+	assertEnvelopeErrorOrigin(t, maximum, "max_iterations", EventOriginSDKDriver)
+}
+
+func assertEnvelopeErrorOrigin(t *testing.T, envelopes []EventEnvelope, kind string, want EventOrigin) {
+	t.Helper()
+	for _, envelope := range envelopes {
+		event, ok := envelope.Event.(ErrorEvent)
+		if ok && event.Kind == kind {
+			if envelope.Origin != want {
+				t.Fatalf("%s origin=%q want %q: %#v", kind, envelope.Origin, want, envelope)
+			}
+			return
+		}
+	}
+	t.Fatalf("missing %s error envelope: %#v", kind, envelopes)
 }
 
 func TestEventEnvelopeLegacyProjectionPreservesPayloadOrder(t *testing.T) {

--- a/sdk/agent/event_envelope_test.go
+++ b/sdk/agent/event_envelope_test.go
@@ -16,6 +16,18 @@ type envelopeFinalModel struct{}
 
 type envelopeToolLoopModel struct{}
 
+type envelopeErrorModel struct {
+	calls atomic.Int64
+	err   error
+}
+
+func (m *envelopeErrorModel) Provider() string { return "fixture" }
+func (m *envelopeErrorModel) Model() string    { return "fixture" }
+func (m *envelopeErrorModel) Invoke(context.Context, llm.InvokeRequest) (*llm.Completion, error) {
+	m.calls.Add(1)
+	return nil, m.err
+}
+
 func (envelopeToolLoopModel) Provider() string { return "fixture" }
 func (envelopeToolLoopModel) Model() string    { return "fixture" }
 func (envelopeToolLoopModel) Invoke(context.Context, llm.InvokeRequest) (*llm.Completion, error) {
@@ -145,6 +157,32 @@ func TestEventEnvelopeSDKTerminalErrorsKeepSDKOrigin(t *testing.T) {
 	}
 	maximum := collectEnvelopes(maxAgent.QueryStreamEnveloped(context.Background(), llm.TextContent("run")))
 	assertEnvelopeErrorOrigin(t, maximum, "max_iterations", EventOriginSDKDriver)
+}
+
+func TestEventEnvelopeTimeoutOriginUsesEmissionBoundary(t *testing.T) {
+	rootModel := &envelopeErrorModel{err: context.DeadlineExceeded}
+	rootAgent, err := New(Config{LLM: rootModel})
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(-time.Second))
+	defer cancel()
+	rootTimeout := collectEnvelopes(rootAgent.QueryStreamEnveloped(ctx, llm.TextContent("run")))
+	assertEnvelopeErrorOrigin(t, rootTimeout, "timeout", EventOriginSDKDriver)
+	if calls := rootModel.calls.Load(); calls != 0 {
+		t.Fatalf("expired root deadline invoked provider %d times", calls)
+	}
+
+	providerModel := &envelopeErrorModel{err: context.DeadlineExceeded}
+	providerAgent, err := New(Config{LLM: providerModel})
+	if err != nil {
+		t.Fatal(err)
+	}
+	providerTimeout := collectEnvelopes(providerAgent.QueryStreamEnveloped(context.Background(), llm.TextContent("run")))
+	assertEnvelopeErrorOrigin(t, providerTimeout, "timeout", EventOriginProvider)
+	if calls := providerModel.calls.Load(); calls == 0 {
+		t.Fatal("provider timeout did not invoke provider")
+	}
 }
 
 func assertEnvelopeErrorOrigin(t *testing.T, envelopes []EventEnvelope, kind string, want EventOrigin) {

--- a/sdk/agent/event_envelope_test.go
+++ b/sdk/agent/event_envelope_test.go
@@ -1,0 +1,222 @@
+package agent
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/timwhitez/agent-sdk-golang/sdk/llm"
+)
+
+type envelopeFinalModel struct{}
+
+func wrapLegacyEventOutput(ch chan Event) *eventOutput {
+	return &eventOutput{legacy: ch, queryID: "test-query", clock: time.Now}
+}
+
+func (envelopeFinalModel) Provider() string { return "fixture" }
+func (envelopeFinalModel) Model() string    { return "fixture" }
+func (envelopeFinalModel) Invoke(context.Context, llm.InvokeRequest) (*llm.Completion, error) {
+	return &llm.Completion{Content: llm.TextContent("done"), StopReason: "stop"}, nil
+}
+
+func collectEnvelopes(ch <-chan EventEnvelope) []EventEnvelope {
+	var envelopes []EventEnvelope
+	for envelope := range ch {
+		envelopes = append(envelopes, envelope)
+	}
+	return envelopes
+}
+
+func TestEventEnvelopeQuerySequenceAndMetadata(t *testing.T) {
+	fixed := time.Date(2026, 9, 1, 12, 0, 0, 0, time.UTC)
+	agent, err := New(Config{
+		LLM:              envelopeFinalModel{},
+		QueryIDGenerator: func() string { return "query-test" },
+		EventClock:       func() time.Time { return fixed },
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	envelopes := collectEnvelopes(agent.QueryStreamEnveloped(context.Background(), llm.TextContent("secret prompt")))
+	if len(envelopes) != 2 {
+		t.Fatalf("envelope count=%d want 2: %#v", len(envelopes), envelopes)
+	}
+	wantKinds := []EventKind{EventKindText, EventKindFinalResponse}
+	for i, envelope := range envelopes {
+		if envelope.SchemaVersion != EventEnvelopeSchemaVersion || envelope.QueryID != "query-test" {
+			t.Fatalf("envelope[%d] identity=%#v", i, envelope)
+		}
+		if envelope.Sequence != uint64(i+1) || envelope.Kind != wantKinds[i] || !envelope.Timestamp.Equal(fixed) {
+			t.Fatalf("envelope[%d] ordering metadata=%#v", i, envelope)
+		}
+	}
+	if envelopes[0].Origin != EventOriginModel || envelopes[1].Origin != EventOriginSDKDriver {
+		t.Fatalf("origins=%q/%q", envelopes[0].Origin, envelopes[1].Origin)
+	}
+}
+
+func TestEventEnvelopeClassifiesAllTypedEvents(t *testing.T) {
+	tests := []struct {
+		event  Event
+		kind   EventKind
+		origin EventOrigin
+	}{
+		{TextEvent{}, EventKindText, EventOriginModel},
+		{TextDeltaEvent{}, EventKindTextDelta, EventOriginModel},
+		{ThinkingEvent{}, EventKindThinking, EventOriginModel},
+		{ThinkingDeltaEvent{}, EventKindThinkingDelta, EventOriginModel},
+		{ErrorEvent{}, EventKindError, EventOriginSDKDriver},
+		{ErrorEvent{Provider: "fixture"}, EventKindError, EventOriginProvider},
+		{WarnEvent{}, EventKindWarning, EventOriginSDKDriver},
+		{HiddenUserMessageEvent{}, EventKindHiddenUserMessage, EventOriginSDKDriver},
+		{StepStartEvent{}, EventKindStepStart, EventOriginToolRuntime},
+		{StepCompleteEvent{}, EventKindStepComplete, EventOriginToolRuntime},
+		{ToolCallEvent{}, EventKindToolCall, EventOriginToolRuntime},
+		{ToolResultEvent{}, EventKindToolResult, EventOriginToolRuntime},
+		{FinalResponseEvent{}, EventKindFinalResponse, EventOriginSDKDriver},
+		{UsageEvent{}, EventKindUsage, EventOriginProvider},
+		{CompactionEvent{}, EventKindCompaction, EventOriginCompaction},
+		{AccountingEvent{}, EventKindAccounting, EventOriginSDKDriver},
+		{SteeringReceivedEvent{}, EventKindSteeringReceived, EventOriginHost},
+		{AutoContinueEvent{}, EventKindAutoContinue, EventOriginSDKDriver},
+	}
+	for _, test := range tests {
+		kind, origin := classifyEvent(test.event)
+		if kind != test.kind || origin != test.origin {
+			t.Fatalf("%T classified as %q/%q want %q/%q", test.event, kind, origin, test.kind, test.origin)
+		}
+	}
+}
+
+func TestEventEnvelopeLegacyProjectionPreservesPayloadOrder(t *testing.T) {
+	legacyAgent, err := New(Config{LLM: envelopeFinalModel{}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	envelopedAgent, err := New(Config{LLM: envelopeFinalModel{}})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	legacy := collectEvents(legacyAgent.QueryStream(context.Background(), llm.TextContent("run")))
+	envelopes := collectEnvelopes(envelopedAgent.QueryStreamEnveloped(context.Background(), llm.TextContent("run")))
+	payloads := make([]Event, len(envelopes))
+	for i, envelope := range envelopes {
+		payloads[i] = envelope.Event
+	}
+	if !reflect.DeepEqual(payloads, legacy) {
+		t.Fatalf("legacy payloads changed\nlegacy=%#v\nenveloped=%#v", legacy, payloads)
+	}
+}
+
+func TestEventEnvelopeAllocatesSequenceBeforeDrop(t *testing.T) {
+	agent, err := New(Config{LLM: envelopeFinalModel{}, EventBufferSize: 1, EventSendTimeout: time.Millisecond})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	events := agent.QueryStreamEnveloped(context.Background(), llm.TextContent("run"))
+	time.Sleep(25 * time.Millisecond)
+	envelopes := collectEnvelopes(events)
+	if len(envelopes) != 1 {
+		t.Fatalf("delivered envelopes=%d want terminal only: %#v", len(envelopes), envelopes)
+	}
+	final, ok := envelopes[0].Event.(FinalResponseEvent)
+	if !ok || envelopes[0].Kind != EventKindFinalResponse {
+		t.Fatalf("terminal envelope=%#v", envelopes[0])
+	}
+	if envelopes[0].Sequence != 2 {
+		t.Fatalf("terminal sequence=%d want 2 to expose dropped sequence 1", envelopes[0].Sequence)
+	}
+	if final.DroppedEvents != 1 {
+		t.Fatalf("terminal dropped events=%d want 1", final.DroppedEvents)
+	}
+
+	legacyAgent, err := New(Config{LLM: envelopeFinalModel{}, EventBufferSize: 1, EventSendTimeout: time.Millisecond})
+	if err != nil {
+		t.Fatal(err)
+	}
+	legacyStream := legacyAgent.QueryStream(context.Background(), llm.TextContent("run"))
+	time.Sleep(25 * time.Millisecond)
+	legacy := collectEvents(legacyStream)
+	if len(legacy) != 1 {
+		t.Fatalf("legacy delivered events=%d want terminal only: %#v", len(legacy), legacy)
+	}
+	legacyFinal, ok := legacy[0].(FinalResponseEvent)
+	if !ok || legacyFinal.DroppedEvents != final.DroppedEvents {
+		t.Fatalf("legacy/enveloped drop parity failed: legacy=%#v envelope=%#v", legacy, envelopes)
+	}
+}
+
+func TestEventEnvelopeEmptyGeneratedQueryIDFallsBack(t *testing.T) {
+	agent, err := New(Config{LLM: envelopeFinalModel{}, QueryIDGenerator: func() string { return "  " }})
+	if err != nil {
+		t.Fatal(err)
+	}
+	envelopes := collectEnvelopes(agent.QueryStreamEnveloped(context.Background(), llm.TextContent("secret prompt")))
+	if len(envelopes) == 0 || envelopes[0].QueryID == "" || envelopes[0].QueryID == "secret prompt" {
+		t.Fatalf("fallback query ID=%q", envelopes[0].QueryID)
+	}
+}
+
+func TestEventEnvelopeQueryIDsArePerTurn(t *testing.T) {
+	var ids atomic.Uint64
+	agent, err := New(Config{
+		LLM: envelopeFinalModel{},
+		QueryIDGenerator: func() string {
+			return fmt.Sprintf("query-%d", ids.Add(1))
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	first := collectEnvelopes(agent.QueryStreamEnveloped(context.Background(), llm.TextContent("first")))
+	second := collectEnvelopes(agent.QueryStreamEnveloped(context.Background(), llm.TextContent("second")))
+	if len(first) == 0 || len(second) == 0 || first[0].QueryID != "query-1" || second[0].QueryID != "query-2" {
+		t.Fatalf("query IDs=%#v/%#v", first, second)
+	}
+	if first[0].Sequence != 1 || second[0].Sequence != 1 {
+		t.Fatalf("per-query sequences did not restart: %d/%d", first[0].Sequence, second[0].Sequence)
+	}
+}
+
+func TestEventEnvelopeBusyAdmissionIsEnveloped(t *testing.T) {
+	model := &singleActiveTurnModel{firstStart: make(chan struct{}), firstFinish: make(chan struct{})}
+	var idMu sync.Mutex
+	nextID := 0
+	agent, err := New(Config{
+		LLM: model,
+		QueryIDGenerator: func() string {
+			idMu.Lock()
+			defer idMu.Unlock()
+			nextID++
+			return fmt.Sprintf("query-%d", nextID)
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	first := agent.QueryStreamEnveloped(context.Background(), llm.TextContent("first"))
+	select {
+	case <-model.firstStart:
+	case <-time.After(5 * time.Second):
+		t.Fatal("first provider invocation did not start")
+	}
+	busy := collectEnvelopes(agent.QueryStreamEnveloped(context.Background(), llm.TextContent("second")))
+	if len(busy) != 1 || busy[0].Sequence != 1 || busy[0].QueryID == "" || busy[0].Kind != EventKindError {
+		t.Fatalf("busy envelope=%#v", busy)
+	}
+	if event, ok := busy[0].Event.(ErrorEvent); !ok || event.Kind != "agent_busy" {
+		t.Fatalf("busy payload=%#v", busy[0].Event)
+	}
+	close(model.firstFinish)
+	collectEnvelopes(first)
+}

--- a/sdk/agent/event_envelope_test.go
+++ b/sdk/agent/event_envelope_test.go
@@ -93,7 +93,7 @@ func TestEventEnvelopeClassifiesAllTypedEvents(t *testing.T) {
 		{ThinkingDeltaEvent{}, EventKindThinkingDelta, EventOriginModel},
 		{ErrorEvent{}, EventKindError, EventOriginSDKDriver},
 		{ErrorEvent{Provider: "fixture"}, EventKindError, EventOriginProvider},
-		{ErrorEvent{Provider: "fixture", Kind: "canceled"}, EventKindError, EventOriginSDKDriver},
+		{ErrorEvent{Provider: "fixture", Kind: "canceled"}, EventKindError, EventOriginProvider},
 		{ErrorEvent{Provider: "fixture", Kind: "max_iterations"}, EventKindError, EventOriginSDKDriver},
 		{WarnEvent{}, EventKindWarning, EventOriginSDKDriver},
 		{HiddenUserMessageEvent{}, EventKindHiddenUserMessage, EventOriginSDKDriver},
@@ -159,7 +159,7 @@ func TestEventEnvelopeSDKTerminalErrorsKeepSDKOrigin(t *testing.T) {
 	assertEnvelopeErrorOrigin(t, maximum, "max_iterations", EventOriginSDKDriver)
 }
 
-func TestEventEnvelopeTimeoutOriginUsesEmissionBoundary(t *testing.T) {
+func TestEventEnvelopeCancellationOriginUsesEmissionBoundary(t *testing.T) {
 	rootModel := &envelopeErrorModel{err: context.DeadlineExceeded}
 	rootAgent, err := New(Config{LLM: rootModel})
 	if err != nil {
@@ -173,15 +173,26 @@ func TestEventEnvelopeTimeoutOriginUsesEmissionBoundary(t *testing.T) {
 		t.Fatalf("expired root deadline invoked provider %d times", calls)
 	}
 
-	providerModel := &envelopeErrorModel{err: context.DeadlineExceeded}
-	providerAgent, err := New(Config{LLM: providerModel})
-	if err != nil {
-		t.Fatal(err)
-	}
-	providerTimeout := collectEnvelopes(providerAgent.QueryStreamEnveloped(context.Background(), llm.TextContent("run")))
-	assertEnvelopeErrorOrigin(t, providerTimeout, "timeout", EventOriginProvider)
-	if calls := providerModel.calls.Load(); calls == 0 {
-		t.Fatal("provider timeout did not invoke provider")
+	for _, test := range []struct {
+		name string
+		err  error
+		kind string
+	}{
+		{name: "deadline", err: context.DeadlineExceeded, kind: "timeout"},
+		{name: "canceled", err: context.Canceled, kind: "canceled"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			providerModel := &envelopeErrorModel{err: test.err}
+			providerAgent, err := New(Config{LLM: providerModel})
+			if err != nil {
+				t.Fatal(err)
+			}
+			providerError := collectEnvelopes(providerAgent.QueryStreamEnveloped(context.Background(), llm.TextContent("run")))
+			assertEnvelopeErrorOrigin(t, providerError, test.kind, EventOriginProvider)
+			if calls := providerModel.calls.Load(); calls == 0 {
+				t.Fatalf("provider %s did not invoke provider", test.name)
+			}
+		})
 	}
 }
 

--- a/sdk/agent/events.go
+++ b/sdk/agent/events.go
@@ -151,8 +151,10 @@ type AccountingEvent struct {
 	CorrelationKind string
 	ToolCallID      string
 	ResponseID      string
-	Sequence        uint64
-	DurationMS      int64
+	// Sequence is the legacy accounting-only counter. EventEnvelope.Sequence is
+	// the query-wide ordering authority shared by every event kind.
+	Sequence   uint64
+	DurationMS int64
 }
 
 func (AccountingEvent) isEvent() {}


### PR DESCRIPTION
First zero-Provider-behavior foundation for #88.

## Behavior

- adds versioned `EventEnvelope`, stable `EventKind`/`EventOrigin`, SDK `QueryID`, per-query monotonic `Sequence`, and observational `Timestamp`;
- adds `QueryStreamEnveloped` and steering equivalent while preserving typed `Event` payloads;
- routes legacy and enveloped APIs through one direct `eventOutput` delivery path, with exactly one public channel and no projection buffer/goroutine;
- allocates sequence before bounded delivery/drop, so gaps expose missing events;
- preserves terminal priority, cancellation, critical-event floor, and drop accounting;
- corrects terminal eviction reporting so the delivered `FinalResponseEvent` includes the event evicted to make room for it;
- classifies SDK, Provider, and Compaction terminal errors by their emission boundary instead of ambiguous cancellation strings;
- makes terminal priority rejection definitive, preventing a rejected lower-priority terminal from being delivered later or counted twice;
- documents the legacy Accounting sequence as payload-local; envelope sequence is the query-wide authority.

## Compatibility and safety

- legacy payload order equals enveloped payload order;
- configured channel capacity/backpressure semantics remain on the same channel;
- busy admission is also enveloped with sequence 1;
- empty injected ID generation falls back to a non-empty SDK ID;
- metadata contains identity/classification/time only and does not duplicate Prompt, Tool Result, headers, or secret content.

## Non-goals

No Provider payload, Prompt, tool execution, persistence, JSON schema, Host Run/Session ID, ExecutionFrame/attempt/tool correlation, ParentSequence, scheduler, compaction lifecycle expansion, or intervention event changes. This does not close #88.

## Local validation at 631d704

Using Go 1.22.12:

- focused envelope tests, including root-vs-Provider cancellation/deadline provenance, x50
- backpressure/critical-floor/turn-admission regression x5
- `go test ./... -count=1`
- `go vet ./...`
- `go test -race ./sdk/agent -count=1`
- `git diff --check`

All passed.
