### PR TITLE
Define request-local CachePlan and capability types

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,6 +14,10 @@ and progressive disclosure through `agent_docs/`.
 - Agent orchestration and runtime state: `Config`, `Agent` (`sdk/agent/agent.go:20`, `sdk/agent/agent.go:39`)
 - Provider abstraction: `ChatModel`, `StreamingChatModel`, `InvokeRequest`, `StreamEvent` (`sdk/llm/model.go:8`, `sdk/llm/model.go:17`, `sdk/llm/model.go:82`, `sdk/llm/model.go:24`)
 - Message and tool-call model: `ToolChoice`, `ToolDefinition`, `ToolCall`, `Content`, `Message`, `Completion` (`sdk/llm/types.go:17`, `sdk/llm/types.go:25`, `sdk/llm/types.go:37`, `sdk/llm/types.go:68`, `sdk/llm/types.go:100`, `sdk/llm/types.go:133`)
+- Request-local prompt-cache intent and concrete-client capability types:
+  `CachePlan`, `CacheDirective`, `CacheTarget`, `PromptCacheCapabilities`, and
+  `PromptCacheCapabilityProvider` (`sdk/llm/cache_plan.go`). These types are not
+  yet attached to `InvokeRequest` or consumed by Provider serializers.
 - Tool system primitives: `Tool`, `Func`, `SchemaFor`, `SerializeResult` (`sdk/tools/tool.go:15`, `sdk/tools/tool.go:701`, `sdk/tools/schema.go:8`, `sdk/tools/result.go:10`)
 - Tool dependency context and metadata: `Container`, `WithToolCallID`, `WithToolResultMetadata` (`sdk/tools/deps.go:156`, `sdk/tools/deps.go:27`, `sdk/tools/deps.go:56`)
 - Compaction service: `compaction.Service` (`sdk/agent/compaction/service.go:10`)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,6 +14,10 @@ and progressive disclosure through `agent_docs/`.
 - Agent orchestration and runtime state: `Config`, `Agent` (`sdk/agent/agent.go:20`, `sdk/agent/agent.go:39`)
 - Provider abstraction: `ChatModel`, `StreamingChatModel`, `InvokeRequest`, `StreamEvent` (`sdk/llm/model.go:8`, `sdk/llm/model.go:17`, `sdk/llm/model.go:82`, `sdk/llm/model.go:24`)
 - Message and tool-call model: `ToolChoice`, `ToolDefinition`, `ToolCall`, `Content`, `Message`, `Completion` (`sdk/llm/types.go:17`, `sdk/llm/types.go:25`, `sdk/llm/types.go:37`, `sdk/llm/types.go:68`, `sdk/llm/types.go:100`, `sdk/llm/types.go:133`)
+- Request-local prompt-cache intent and concrete-client capability types:
+  `CachePlan`, `CacheDirective`, `CacheTarget`, `PromptCacheCapabilities`, and
+  `PromptCacheCapabilityProvider` (`sdk/llm/cache_plan.go`). These types are not
+  yet attached to `InvokeRequest` or consumed by Provider serializers.
 - Tool system primitives: `Tool`, `Func`, `SchemaFor`, `SerializeResult` (`sdk/tools/tool.go:15`, `sdk/tools/tool.go:701`, `sdk/tools/schema.go:8`, `sdk/tools/result.go:10`)
 - Tool dependency context and metadata: `Container`, `WithToolCallID`, `WithToolResultMetadata` (`sdk/tools/deps.go:156`, `sdk/tools/deps.go:27`, `sdk/tools/deps.go:56`)
 - Compaction service: `compaction.Service` (`sdk/agent/compaction/service.go:10`)

--- a/sdk/llm/cache_plan.go
+++ b/sdk/llm/cache_plan.go
@@ -1,0 +1,98 @@
+package llm
+
+// CachePlanSchemaVersion identifies the in-memory request-local plan model.
+// It is not a persistence or Provider wire schema.
+const CachePlanSchemaVersion = 1
+
+type CacheTargetKind string
+
+const (
+	CacheAfterMessageBlock   CacheTargetKind = "after_message_block"
+	CacheAfterMessage        CacheTargetKind = "after_message"
+	CacheAfterToolDefinition CacheTargetKind = "after_tool_definition"
+)
+
+type CacheDirectivePolicy string
+
+const (
+	CacheBestEffort CacheDirectivePolicy = "best_effort"
+	CacheRequired   CacheDirectivePolicy = "required"
+)
+
+type CacheTTL string
+
+const (
+	CacheTTLProviderDefault CacheTTL = ""
+	CacheTTL5Minutes        CacheTTL = "5m"
+	CacheTTL1Hour           CacheTTL = "1h"
+)
+
+// CacheTarget identifies an object in a normalized, already-materialized
+// request. Only fields selected by Kind are meaningful. Fingerprints bind the
+// intent without retaining Prompt, Tool Result, or Tool Definition text.
+type CacheTarget struct {
+	Kind CacheTargetKind
+
+	MessageIndex int
+	BlockOrdinal int
+	ToolIndex    int
+
+	ExpectedObjectFingerprint string
+}
+
+type CacheDirective struct {
+	Target CacheTarget
+	Policy CacheDirectivePolicy
+	TTL    CacheTTL
+}
+
+// CachePlan is request-local optimization intent. It must not be written into
+// conversation history or treated as proof that a Provider cache was hit.
+// Provider adapters do not consume this type until explicit validation and
+// capability-gated mapping are added.
+type CachePlan struct {
+	SchemaVersion      int
+	RequestFingerprint string
+	Directives         []CacheDirective
+}
+
+// CloneCachePlan returns an owned copy while preserving nil versus non-nil
+// empty directive slices.
+func CloneCachePlan(plan *CachePlan) *CachePlan {
+	if plan == nil {
+		return nil
+	}
+	cloned := *plan
+	if plan.Directives != nil {
+		cloned.Directives = make([]CacheDirective, len(plan.Directives))
+		copy(cloned.Directives, plan.Directives)
+	}
+	return &cloned
+}
+
+// PromptCacheCapabilities describes explicit request controls implemented by
+// one concrete Provider client. Callers must not infer it from a provider name.
+type PromptCacheCapabilities struct {
+	ExplicitMessageBoundary bool
+	ExplicitContentBlock    bool
+	ExplicitToolDefinition  bool
+	SupportedTTLs           []CacheTTL
+	MaxBreakpoints          int
+	UsageTelemetry          bool
+}
+
+// Clone returns an owned capability snapshot.
+func (capabilities PromptCacheCapabilities) Clone() PromptCacheCapabilities {
+	cloned := capabilities
+	if capabilities.SupportedTTLs != nil {
+		cloned.SupportedTTLs = make([]CacheTTL, len(capabilities.SupportedTTLs))
+		copy(cloned.SupportedTTLs, capabilities.SupportedTTLs)
+	}
+	return cloned
+}
+
+// PromptCacheCapabilityProvider is an optional interface implemented by a
+// concrete client only when it can report explicit cache controls accurately.
+type PromptCacheCapabilityProvider interface {
+	PromptCacheCapabilities() PromptCacheCapabilities
+}

--- a/sdk/llm/cache_plan_test.go
+++ b/sdk/llm/cache_plan_test.go
@@ -1,0 +1,64 @@
+package llm
+
+import "testing"
+
+type cacheCapabilityFixture struct {
+	capabilities PromptCacheCapabilities
+}
+
+var _ PromptCacheCapabilityProvider = cacheCapabilityFixture{}
+
+func (fixture cacheCapabilityFixture) PromptCacheCapabilities() PromptCacheCapabilities {
+	return fixture.capabilities.Clone()
+}
+
+func TestCloneCachePlanOwnsDirectives(t *testing.T) {
+	plan := &CachePlan{
+		SchemaVersion:      CachePlanSchemaVersion,
+		RequestFingerprint: "request:v1:abc",
+		Directives: []CacheDirective{{
+			Target: CacheTarget{
+				Kind:                      CacheAfterMessageBlock,
+				MessageIndex:              2,
+				BlockOrdinal:              1,
+				ExpectedObjectFingerprint: "object:v1:def",
+			},
+			Policy: CacheRequired,
+			TTL:    CacheTTL5Minutes,
+		}},
+	}
+	cloned := CloneCachePlan(plan)
+	plan.Directives[0].Target.MessageIndex = 9
+	plan.Directives[0].Target.ExpectedObjectFingerprint = "mutated"
+	if cloned == plan || cloned.Directives[0].Target.MessageIndex != 2 || cloned.Directives[0].Target.ExpectedObjectFingerprint != "object:v1:def" {
+		t.Fatalf("clone shared mutable plan state: %#v", cloned)
+	}
+}
+
+func TestCloneCachePlanPreservesNilAndEmpty(t *testing.T) {
+	if CloneCachePlan(nil) != nil {
+		t.Fatal("nil plan became non-nil")
+	}
+	cloned := CloneCachePlan(&CachePlan{Directives: []CacheDirective{}})
+	if cloned.Directives == nil {
+		t.Fatal("non-nil empty directives became nil")
+	}
+}
+
+func TestPromptCacheCapabilitiesCloneOwnsTTLs(t *testing.T) {
+	capabilities := PromptCacheCapabilities{
+		ExplicitMessageBoundary: true,
+		SupportedTTLs:           []CacheTTL{CacheTTL5Minutes, CacheTTL1Hour},
+		MaxBreakpoints:          4,
+		UsageTelemetry:          true,
+	}
+	cloned := capabilities.Clone()
+	capabilities.SupportedTTLs[0] = "mutated"
+	if cloned.SupportedTTLs[0] != CacheTTL5Minutes {
+		t.Fatalf("capability clone shared TTL slice: %#v", cloned)
+	}
+	empty := (PromptCacheCapabilities{SupportedTTLs: []CacheTTL{}}).Clone()
+	if empty.SupportedTTLs == nil {
+		t.Fatal("non-nil empty SupportedTTLs became nil")
+	}
+}


### PR DESCRIPTION
First zero-wire foundation for #89.

## Behavior

- defines request-local `CachePlan`, `CacheDirective`, normalized target kinds, required/best-effort policy, and provider-neutral TTL intent;
- defines concrete-client `PromptCacheCapabilities` and optional `PromptCacheCapabilityProvider`;
- provides owned clone helpers that preserve nil versus non-nil empty slices;
- keeps fingerprints as metadata fields without storing Prompt, Tool Result, or Tool Definition text.

## Safety boundary

These types are deliberately inert in this phase: `CachePlan` is not attached to `InvokeRequest`, and no Provider adapter consumes it. This prevents `CacheRequired` from being silently ignored before preflight validation and capability-gated mapping exist.

## Non-goals

No InvokeRequest, Agent, Provider serializer, Anthropic `cache_control`, legacy `Message.Cache`, payload, session/history, diagnostic, validation, fingerprint generation, breakpoint selection, or SDK pin change. This does not close #89.

## Local validation at 360ec7a

Using Go 1.22.12:

- focused clone/capability tests x50
- `go test ./... -count=1`
- `go vet ./...`
- `go test -race ./sdk/llm ./sdk/llm/anthropic ./sdk/llm/openai -count=1`
- `git diff --check`

All passed.
