### PR TITLE
Observe sequential tool block closure state

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,6 +37,10 @@ and progressive disclosure through `agent_docs/`.
   kind/origin, and observational timestamp. Legacy `QueryStream` uses the same
   direct delivery/backpressure path without metadata; sequence gaps expose
   dropped events (`sdk/agent/event_envelope.go`, `sdk/agent/agent.go`).
+- The sequential Tool Loop mirrors accepted/running/terminal transitions into
+  a query-local, observe-only `toolBlockState`. Mismatches use `Warningf`; the
+  shadow does not construct history, events, Tool Results, or Provider payloads
+  (`sdk/agent/tool_block_state.go`, `sdk/agent/agent.go`).
 - Auto-continue on `max_tokens` (including partial tool-call merge) now emits metadata-only `AutoContinueEvent` instead of text markers (`sdk/agent/agent.go:259`, `sdk/agent/agent.go:275`, `sdk/agent/agent.go:298`, `sdk/agent/events.go:113`)
 - Tool resolution via exact + normalized + alias matching (`sdk/agent/tool_resolve.go:107`, `sdk/agent/tool_resolve.go:30`)
 - Argument normalization with conservative loose-object repair + schema-key retry, including schema-derived single-string wrapping for custom tools and tool-specific alias handling for ambiguous keys like `line`/`offset` (`sdk/tools/args_normalize.go:21`, `sdk/tools/args_normalize.go:247`, `sdk/tools/tool.go:363`)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,6 +30,10 @@ and progressive disclosure through `agent_docs/`.
   kind/origin, and observational timestamp. Legacy `QueryStream` uses the same
   direct delivery/backpressure path without metadata; sequence gaps expose
   dropped events (`sdk/agent/event_envelope.go`, `sdk/agent/agent.go`).
+- The sequential Tool Loop mirrors accepted/running/terminal transitions into
+  a query-local, observe-only `toolBlockState`. Mismatches use `Warningf`; the
+  shadow does not construct history, events, Tool Results, or Provider payloads
+  (`sdk/agent/tool_block_state.go`, `sdk/agent/agent.go`).
 - Auto-continue on `max_tokens` (including partial tool-call merge) now emits metadata-only `AutoContinueEvent` instead of text markers (`sdk/agent/agent.go:259`, `sdk/agent/agent.go:275`, `sdk/agent/agent.go:298`, `sdk/agent/events.go:113`)
 - Tool resolution via exact + normalized + alias matching (`sdk/agent/tool_resolve.go:107`, `sdk/agent/tool_resolve.go:30`)
 - Argument normalization with conservative loose-object repair + schema-key retry, including schema-derived single-string wrapping for custom tools and tool-specific alias handling for ambiguous keys like `line`/`offset` (`sdk/tools/args_normalize.go:21`, `sdk/tools/args_normalize.go:247`, `sdk/tools/tool.go:363`)

--- a/sdk/agent/agent.go
+++ b/sdk/agent/agent.go
@@ -673,6 +673,15 @@ func (a *Agent) queryStreamWithSteering(ctx context.Context, input llm.Content, 
 			}
 			emitErr(e, origin)
 		}
+		var activeToolBlock *toolBlockState
+		finishToolBlock := func() {
+			block := activeToolBlock
+			activeToolBlock = nil
+			if err := block.validateClosed(); err != nil {
+				a.warnf("warning: tool block shadow invariant mismatch: %v", err)
+			}
+		}
+		defer finishToolBlock()
 
 		// maxIterations < 0 means unlimited: the loop is then bounded only by
 		// tool-loop guards, idle detection, and context cancellation.
@@ -1186,12 +1195,14 @@ func (a *Agent) queryStreamWithSteering(ctx context.Context, input llm.Content, 
 			// interleaved with user text, and the malformed history would stay
 			// in place and fail every later turn — so these are only appended
 			// once every tool_use in the block has a matching tool_result.
+			activeToolBlock = newToolBlockState(comp.ToolCalls)
 			var pendingBlockMessages []llm.Message
 			for idx, tc := range comp.ToolCalls {
 				if err := ctx.Err(); err != nil {
 					// Close every unstarted tool call before terminating so a later
 					// turn never inherits an unpaired assistant tool-call block.
 					a.appendCancellationSkippedToolResults(comp.ToolCalls[idx:])
+					activeToolBlock.markTerminalRange(idx, toolCallAccepted, "root_cancel_before_start")
 					a.appendMessages(pendingBlockMessages)
 					pendingBlockMessages = nil
 					emitSDKErr(a.errEvent(err))
@@ -1242,6 +1253,7 @@ func (a *Agent) queryStreamWithSteering(ctx context.Context, input llm.Content, 
 					if blocked {
 						loopGuardStrikes++
 						a.appendLoopGuardSkippedToolResult(tc, resolvedName)
+						activeToolBlock.markTerminal(idx, toolCallAccepted, "loop_guard")
 						reminder := strings.TrimSpace(a.loopGuardUserMsg)
 						if repeatGuard.exhausted {
 							// The default reminder can mislead here ("reuse prior
@@ -1328,6 +1340,7 @@ func (a *Agent) queryStreamWithSteering(ctx context.Context, input llm.Content, 
 							Content: content, IsError: false, Ephemeral: tool.EphemeralKeep > 0,
 						})
 						a.mu.Unlock()
+						activeToolBlock.markTerminal(idx, toolCallAccepted, "evidence_suppressed")
 						suppressedResult := ToolResultEvent{
 							Tool: resolvedName, Result: content.PlainText(), ToolCallID: tc.ID,
 							IsError: false, Metadata: decision.metadata,
@@ -1360,6 +1373,7 @@ func (a *Agent) queryStreamWithSteering(ctx context.Context, input llm.Content, 
 				ctxToolBase := tools.WithToolCallID(ctx, tc.ID)
 				ctxToolBase = tools.WithToolResultMetadata(ctxToolBase)
 				ctxTool, finishToolStage := a.beginSteeringInterruptibleStage(ctxToolBase)
+				activeToolBlock.markRunning(idx)
 				content, toolErr := a.executeToolSafely(ctxTool, tool, execArgs)
 				stageInterruptedForSteering := finishToolStage()
 				rootCancelErr := ctx.Err()
@@ -1401,10 +1415,12 @@ func (a *Agent) queryStreamWithSteering(ctx context.Context, input llm.Content, 
 					a.mu.Lock()
 					a.messages = append(a.messages, llm.Message{Role: llm.RoleTool, ToolCallID: tc.ID, ToolName: resolvedName, Content: content, IsError: false, Ephemeral: ephemeral})
 					a.mu.Unlock()
+					activeToolBlock.markTerminal(idx, toolCallRunning, "task_complete")
 					a.emitToolResultWithAccounting(out, ToolResultEvent{Tool: resolvedName, Result: content.PlainText(), ToolCallID: tc.ID, IsError: false, Metadata: meta}, originalResult, time.Since(start))
 					a.emitEvent(out, StepCompleteEvent{StepID: tc.ID, Status: status, DurationMS: time.Since(start).Milliseconds()})
 					if err := ctx.Err(); err != nil {
 						a.appendCancellationSkippedToolResults(comp.ToolCalls[idx+1:])
+						activeToolBlock.markTerminalRange(idx+1, toolCallAccepted, "root_cancel_after_task_complete")
 						a.appendMessages(pendingBlockMessages)
 						pendingBlockMessages = nil
 						emitSDKErr(a.errEvent(err))
@@ -1415,6 +1431,7 @@ func (a *Agent) queryStreamWithSteering(ctx context.Context, input llm.Content, 
 					// call would otherwise leave tool_use blocks with no result,
 					// making the *next* turn's first provider request invalid.
 					a.appendTurnEndSkippedToolResults(comp.ToolCalls[idx+1:])
+					activeToolBlock.markTerminalRange(idx+1, toolCallAccepted, "task_complete_tail")
 					a.appendMessages(pendingBlockMessages)
 					pendingBlockMessages = nil
 					if a.hasCompactor {
@@ -1429,6 +1446,7 @@ func (a *Agent) queryStreamWithSteering(ctx context.Context, input llm.Content, 
 						}
 					}
 					requireDoneRecoveryDisableThinkingActive = false
+					finishToolBlock()
 					emitFinal(finalContent, finalResponseID)
 					return
 				}
@@ -1445,6 +1463,7 @@ func (a *Agent) queryStreamWithSteering(ctx context.Context, input llm.Content, 
 				a.mu.Lock()
 				a.messages = append(a.messages, llm.Message{Role: llm.RoleTool, ToolCallID: tc.ID, ToolName: resolvedName, Content: content, IsError: isError, Ephemeral: ephemeral})
 				a.mu.Unlock()
+				activeToolBlock.markTerminal(idx, toolCallRunning, "handler_return")
 
 				a.emitToolResultWithAccounting(out, ToolResultEvent{Tool: resolvedName, Result: content.PlainText(), ToolCallID: tc.ID, IsError: isError, Metadata: meta}, originalResult, time.Since(start))
 				a.emitEvent(out, StepCompleteEvent{StepID: tc.ID, Status: status, DurationMS: time.Since(start).Milliseconds()})
@@ -1453,6 +1472,7 @@ func (a *Agent) queryStreamWithSteering(ctx context.Context, input llm.Content, 
 				}
 				if rootCancelErr != nil {
 					a.appendCancellationSkippedToolResults(comp.ToolCalls[idx+1:])
+					activeToolBlock.markTerminalRange(idx+1, toolCallAccepted, "root_cancel_after_handler")
 					a.appendMessages(pendingBlockMessages)
 					pendingBlockMessages = nil
 					emitSDKErr(a.errEvent(rootCancelErr))
@@ -1475,12 +1495,14 @@ func (a *Agent) queryStreamWithSteering(ctx context.Context, input llm.Content, 
 					// between two tool results of the same assistant block makes
 					// the whole conversation permanently unsendable.
 					a.appendSteeringSkippedToolResults(comp.ToolCalls[idx+1:])
+					activeToolBlock.markTerminalRange(idx+1, toolCallAccepted, "steering")
 					pendingBlockMessages = append(pendingBlockMessages, steeringMessages...)
 					break
 				}
 			}
 			// The assistant tool-call block is now closed: every tool_use has a
 			// tool_result. Only here may user-role messages enter history.
+			finishToolBlock()
 			a.appendMessages(pendingBlockMessages)
 			pendingBlockMessages = nil
 			if a.hasCompactor {

--- a/sdk/agent/agent_cancel_boundary_test.go
+++ b/sdk/agent/agent_cancel_boundary_test.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/timwhitez/agent-sdk-golang/sdk/llm"
 	"github.com/timwhitez/agent-sdk-golang/sdk/tools"
@@ -23,6 +24,34 @@ type cancelBoundaryScriptModel struct {
 type cancelOnInvokeBoundaryModel struct {
 	cancel context.CancelFunc
 	calls  atomic.Int32
+}
+
+type cancelBeforeToolStartModel struct{}
+
+func (cancelBeforeToolStartModel) Provider() string { return "fake" }
+func (cancelBeforeToolStartModel) Model() string    { return "cancel-before-tool-start" }
+func (cancelBeforeToolStartModel) Invoke(context.Context, llm.InvokeRequest) (*llm.Completion, error) {
+	return &llm.Completion{
+		Thinking:   "fill-buffer",
+		Content:    llm.TextContent("force-drop"),
+		StopReason: "tool_calls",
+		ToolCalls:  []llm.ToolCall{cancelBoundaryCall("never-start", "mutate")},
+	}, nil
+}
+
+type cancelAsTaskComplete struct {
+	cancel context.CancelFunc
+}
+
+func (e cancelAsTaskComplete) Error() string { return "task complete" }
+func (e cancelAsTaskComplete) As(target any) bool {
+	taskComplete, ok := target.(**tools.TaskCompleteError)
+	if !ok {
+		return false
+	}
+	e.cancel()
+	*taskComplete = &tools.TaskCompleteError{Message: "done"}
+	return true
 }
 
 func (m *cancelOnInvokeBoundaryModel) Provider() string { return "fake" }
@@ -173,6 +202,79 @@ func TestRootCancellationSkipsUnstartedSiblingTools(t *testing.T) {
 	if !foundSkipped {
 		t.Fatalf("canceled sibling tool topology was not closed: %#v", ag.Messages())
 	}
+}
+
+func TestRootCancellationBeforeFirstToolClosesAcceptedBlock(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	var runs atomic.Int32
+	dropped := make(chan struct{})
+	var sawDrop atomic.Bool
+	failShadow := failOnToolBlockShadowWarning(t)
+	ag, err := New(Config{
+		LLM:               cancelBeforeToolStartModel{},
+		Tools:             []tools.Tool{tools.Func[struct{}]("mutate", "must not run", func(context.Context, struct{}, *tools.Container) (any, error) { runs.Add(1); return "mutated", nil })},
+		EventBufferSize:   1,
+		EventSendTimeout:  time.Millisecond,
+		EventDropLogEvery: 1,
+		Warningf: func(format string, args ...any) {
+			failShadow(format, args...)
+			if strings.Contains(format, "dropping agent event") && sawDrop.CompareAndSwap(false, true) {
+				cancel()
+				close(dropped)
+			}
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	events := ag.QueryStream(ctx, llm.TextContent("run"))
+	select {
+	case <-dropped:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timeout waiting for controlled event drop")
+	}
+	got := collectCancelBoundaryTerminals(events)
+	if runs.Load() != 0 || got.canceled != 1 || got.finals != 0 {
+		t.Fatalf("runs=%d canceled=%d finals=%d; want 0/1/0", runs.Load(), got.canceled, got.finals)
+	}
+	assertCanceledToolResult(t, ag.Messages(), "never-start")
+}
+
+func TestRootCancellationAfterTaskCompleteClosesUnstartedTail(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	model := &cancelBoundaryScriptModel{toolCalls: []llm.ToolCall{
+		cancelBoundaryCall("done-1", "done"),
+		cancelBoundaryCall("tail-2", "tail"),
+	}}
+	var tailRuns atomic.Int32
+	done := tools.Func[struct{}]("done", "done", func(context.Context, struct{}, *tools.Container) (any, error) {
+		return nil, cancelAsTaskComplete{cancel: cancel}
+	})
+	tail := tools.Func[struct{}]("tail", "must not run", func(context.Context, struct{}, *tools.Container) (any, error) {
+		tailRuns.Add(1)
+		return "mutated", nil
+	})
+	ag, err := New(Config{LLM: model, Tools: []tools.Tool{done, tail}, Warningf: failOnToolBlockShadowWarning(t)})
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := collectCancelBoundaryTerminals(ag.QueryStream(ctx, llm.TextContent("run")))
+	if tailRuns.Load() != 0 || got.canceled != 1 || got.finals != 0 {
+		t.Fatalf("tail_runs=%d canceled=%d finals=%d; want 0/1/0", tailRuns.Load(), got.canceled, got.finals)
+	}
+	assertCanceledToolResult(t, ag.Messages(), "tail-2")
+}
+
+func assertCanceledToolResult(t *testing.T, messages []llm.Message, callID string) {
+	t.Helper()
+	for _, message := range messages {
+		if message.Role == llm.RoleTool && message.ToolCallID == callID && message.IsError && strings.Contains(strings.ToLower(message.Content.PlainText()), "cancel") {
+			return
+		}
+	}
+	t.Fatalf("missing cancellation Tool Result for %q: %#v", callID, messages)
 }
 
 func TestCancellationDuringPreProviderSteeringDrainPreventsAdmission(t *testing.T) {

--- a/sdk/agent/agent_cancel_boundary_test.go
+++ b/sdk/agent/agent_cancel_boundary_test.go
@@ -149,7 +149,7 @@ func TestRootCancellationSkipsUnstartedSiblingTools(t *testing.T) {
 		secondRuns.Add(1)
 		return "mutated", nil
 	})
-	ag, err := New(Config{LLM: model, Tools: []tools.Tool{cancelTool, secondTool}, MaxIterations: 4})
+	ag, err := New(Config{LLM: model, Tools: []tools.Tool{cancelTool, secondTool}, MaxIterations: 4, Warningf: failOnToolBlockShadowWarning(t)})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/sdk/agent/agent_duplicate_tool_call_id_test.go
+++ b/sdk/agent/agent_duplicate_tool_call_id_test.go
@@ -112,7 +112,8 @@ func TestDuplicateToolCallIDsFailBeforeAnyHandler(t *testing.T) {
 	var executions atomic.Int32
 	model := &duplicateToolCallIDModel{}
 	agent, err := New(Config{
-		LLM: model,
+		LLM:      model,
+		Warningf: failOnToolBlockShadowWarning(t),
 		Tools: []tools.Tool{{
 			Name: "mutate",
 			Handler: func(context.Context, json.RawMessage, *tools.Container) (llm.Content, error) {
@@ -164,7 +165,8 @@ func TestDuplicateAfterContinuationKeepsOlderSyntheticIDBlock(t *testing.T) {
 	var executions atomic.Int32
 	model := &repeatedSyntheticIDContinuationModel{}
 	agent, err := New(Config{
-		LLM: model,
+		LLM:      model,
+		Warningf: failOnToolBlockShadowWarning(t),
 		Tools: []tools.Tool{{
 			Name: "mutate",
 			Handler: func(context.Context, json.RawMessage, *tools.Container) (llm.Content, error) {
@@ -235,7 +237,7 @@ func TestDuplicateAfterRotatingContinuationIDsClearsWholeEpisode(t *testing.T) {
 		mustProviderStateContent(t, llm.Content{}, []llm.ProviderState{{Provider: "openai-responses", Kind: "response.output_item.v1", Data: json.RawMessage(`{"type":"function_call","call_id":"old-partial"}`)}}),
 		mustProviderStateContent(t, llm.Content{}, []llm.ProviderState{{Provider: "openai-responses", Kind: "response.output_item.v1", Data: json.RawMessage(`{"type":"function_call","call_id":"new-partial"}`)}}),
 	}}
-	agent, err := New(Config{LLM: model})
+	agent, err := New(Config{LLM: model, Warningf: failOnToolBlockShadowWarning(t)})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/sdk/agent/agent_evidence_progress_test.go
+++ b/sdk/agent/agent_evidence_progress_test.go
@@ -70,7 +70,7 @@ func TestEvidenceProgressSuppressesCoveredReadAndPreservesMixedBatch(t *testing.
 	})
 	ag, err := New(Config{
 		LLM: model, Tools: []tools.Tool{readTool, readAlias, doneTool},
-		MaxIterations: -1, RequireDoneTool: true,
+		MaxIterations: -1, RequireDoneTool: true, Warningf: failOnToolBlockShadowWarning(t),
 	})
 	if err != nil {
 		t.Fatal(err)

--- a/sdk/agent/agent_retry_loop_guard_test.go
+++ b/sdk/agent/agent_retry_loop_guard_test.go
@@ -493,6 +493,7 @@ func TestRepeatToolSignatureGuardRetreatsAfterStrikeThreshold(t *testing.T) {
 		RepeatToolSignatureWindow:    6,
 		LoopGuardStrikeThreshold:     1,
 		LoopGuardUserMessage:         "stop repeating",
+		Warningf:                     failOnToolBlockShadowWarning(t),
 	})
 	if err != nil {
 		t.Fatalf("new agent: %v", err)

--- a/sdk/agent/agent_steering_interrupt_test.go
+++ b/sdk/agent/agent_steering_interrupt_test.go
@@ -553,6 +553,7 @@ func TestSteeringCanCancelActiveToolWithoutCancelingQuery(t *testing.T) {
 		LLM:             model,
 		Tools:           []tools.Tool{waitTool, skippedTool, doneTool},
 		RequireDoneTool: true,
+		Warningf:        failOnToolBlockShadowWarning(t),
 	})
 	if err != nil {
 		t.Fatalf("new agent: %v", err)

--- a/sdk/agent/agent_tool_block_closure_characterization_test.go
+++ b/sdk/agent/agent_tool_block_closure_characterization_test.go
@@ -63,8 +63,9 @@ func TestToolBlockSequentialClosureCharacterization(t *testing.T) {
 	})
 
 	agent, err := New(Config{
-		LLM:   mixedToolBlockModel{},
-		Tools: []tools.Tool{invalid, panicTool, errorTool, done, tail},
+		LLM:      mixedToolBlockModel{},
+		Tools:    []tools.Tool{invalid, panicTool, errorTool, done, tail},
+		Warningf: failOnToolBlockShadowWarning(t),
 	})
 	if err != nil {
 		t.Fatal(err)

--- a/sdk/agent/agent_tool_block_closure_characterization_test.go
+++ b/sdk/agent/agent_tool_block_closure_characterization_test.go
@@ -12,6 +12,24 @@ import (
 
 type mixedToolBlockModel struct{}
 
+type reusedToolCallIDAcrossBlocksModel struct {
+	calls int
+}
+
+func (m *reusedToolCallIDAcrossBlocksModel) Provider() string { return "fixture" }
+func (m *reusedToolCallIDAcrossBlocksModel) Model() string    { return "reused-id-blocks" }
+func (m *reusedToolCallIDAcrossBlocksModel) Invoke(context.Context, llm.InvokeRequest) (*llm.Completion, error) {
+	m.calls++
+	name := "echo"
+	if m.calls == 2 {
+		name = "done"
+	}
+	return &llm.Completion{
+		ToolCalls:  []llm.ToolCall{{ID: "reused", Type: "function", Function: llm.FunctionCall{Name: name, Arguments: `{}`}}},
+		StopReason: "tool_calls",
+	}, nil
+}
+
 func (mixedToolBlockModel) Provider() string { return "fixture" }
 func (mixedToolBlockModel) Model() string    { return "mixed-tool-block" }
 func (mixedToolBlockModel) Invoke(context.Context, llm.InvokeRequest) (*llm.Completion, error) {
@@ -120,6 +138,59 @@ func TestToolBlockSequentialClosureCharacterization(t *testing.T) {
 
 	if _, changed, unexpected := repairToolCallPairsDetailed(messages); changed || unexpected {
 		t.Fatalf("closed block required outbound repair: changed=%v unexpected=%v", changed, unexpected)
+	}
+	var final FinalResponseEvent
+	for _, event := range events {
+		if candidate, ok := event.(FinalResponseEvent); ok {
+			final = candidate
+		}
+	}
+	if final.Content != "finished" {
+		t.Fatalf("final=%#v want finished", final)
+	}
+}
+
+func TestToolBlockShadowAllowsIDsReusedAcrossBlocks(t *testing.T) {
+	model := &reusedToolCallIDAcrossBlocksModel{}
+	echoStarts := 0
+	doneStarts := 0
+	echo := tools.Func[struct{}]("echo", "echo", func(context.Context, struct{}, *tools.Container) (any, error) {
+		echoStarts++
+		return "echoed", nil
+	})
+	done := tools.Func[struct{}]("done", "done", func(context.Context, struct{}, *tools.Container) (any, error) {
+		doneStarts++
+		return nil, &tools.TaskCompleteError{Message: "finished"}
+	})
+	agent, err := New(Config{
+		LLM:      model,
+		Tools:    []tools.Tool{echo, done},
+		Warningf: failOnToolBlockShadowWarning(t),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	events := collectEvents(agent.QueryStream(context.Background(), llm.TextContent("run")))
+	if echoStarts != 1 || doneStarts != 1 || model.calls != 2 {
+		t.Fatalf("echo_starts=%d done_starts=%d provider_calls=%d; want 1/1/2", echoStarts, doneStarts, model.calls)
+	}
+
+	messages := agent.Messages()
+	blocks := 0
+	for i, message := range messages {
+		if message.Role != llm.RoleAssistant || len(message.ToolCalls) != 1 || message.ToolCalls[0].ID != "reused" {
+			continue
+		}
+		blocks++
+		if i+1 >= len(messages) || messages[i+1].Role != llm.RoleTool || messages[i+1].ToolCallID != "reused" {
+			t.Fatalf("block %d is not immediately closed: %#v", blocks, messages)
+		}
+	}
+	if blocks != 2 {
+		t.Fatalf("reused-id blocks=%d want 2: %#v", blocks, messages)
+	}
+	if _, changed, unexpected := repairToolCallPairsDetailed(messages); changed || unexpected {
+		t.Fatalf("reused IDs across blocks required repair: changed=%v unexpected=%v", changed, unexpected)
 	}
 	var final FinalResponseEvent
 	for _, event := range events {

--- a/sdk/agent/tool_block_state.go
+++ b/sdk/agent/tool_block_state.go
@@ -1,0 +1,125 @@
+package agent
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/timwhitez/agent-sdk-golang/sdk/llm"
+)
+
+type toolCallPhase string
+
+const (
+	toolCallAccepted toolCallPhase = "accepted"
+	toolCallRunning  toolCallPhase = "running"
+	toolCallTerminal toolCallPhase = "terminal"
+)
+
+type toolCallState struct {
+	phase         toolCallPhase
+	terminalCount int
+	closure       string
+}
+
+// toolBlockState is an observe-only mirror of the sequential Tool Loop. It is
+// deliberately query-local and does not construct history, events, or results.
+type toolBlockState struct {
+	calls      []toolCallState
+	violations []string
+}
+
+func newToolBlockState(calls []llm.ToolCall) *toolBlockState {
+	block := &toolBlockState{calls: make([]toolCallState, len(calls))}
+	seen := make(map[string]int, len(calls))
+	for i, call := range calls {
+		id := strings.TrimSpace(call.ID)
+		block.calls[i] = toolCallState{phase: toolCallAccepted}
+		if id == "" {
+			block.addViolation("call[%d] has empty id", i)
+			continue
+		}
+		if first, ok := seen[id]; ok {
+			block.addViolation("call[%d] duplicates the id from call[%d]", i, first)
+			continue
+		}
+		seen[id] = i
+	}
+	return block
+}
+
+func (b *toolBlockState) markRunning(index int) {
+	call, ok := b.call(index)
+	if !ok {
+		return
+	}
+	if call.phase != toolCallAccepted {
+		b.addViolation("call[%d] cannot start from phase %q", index, call.phase)
+		return
+	}
+	call.phase = toolCallRunning
+}
+
+func (b *toolBlockState) markTerminal(index int, expected toolCallPhase, closure string) {
+	call, ok := b.call(index)
+	if !ok {
+		return
+	}
+	call.terminalCount++
+	if call.terminalCount != 1 {
+		b.addViolation("call[%d] has %d terminal transitions", index, call.terminalCount)
+		return
+	}
+	if call.phase != expected {
+		b.addViolation("call[%d] closed by %q from phase %q, want %q", index, closure, call.phase, expected)
+		return
+	}
+	call.phase = toolCallTerminal
+	call.closure = closure
+}
+
+func (b *toolBlockState) markTerminalRange(start int, expected toolCallPhase, closure string) {
+	if b == nil {
+		return
+	}
+	if start < 0 || start > len(b.calls) {
+		b.addViolation("terminal range start %d outside block length %d", start, len(b.calls))
+		return
+	}
+	for i := start; i < len(b.calls); i++ {
+		b.markTerminal(i, expected, closure)
+	}
+}
+
+func (b *toolBlockState) validateClosed() error {
+	if b == nil {
+		return nil
+	}
+	violations := append([]string(nil), b.violations...)
+	for i, call := range b.calls {
+		if call.phase != toolCallTerminal || call.terminalCount != 1 {
+			violations = append(violations, fmt.Sprintf("call[%d] remains phase=%q terminal_count=%d", i, call.phase, call.terminalCount))
+		}
+	}
+	if len(violations) == 0 {
+		return nil
+	}
+	return fmt.Errorf("%s", strings.Join(violations, "; "))
+}
+
+func (b *toolBlockState) call(index int) (*toolCallState, bool) {
+	if b == nil {
+		return nil, false
+	}
+	if index < 0 || index >= len(b.calls) {
+		b.addViolation("call index %d outside block length %d", index, len(b.calls))
+		return nil, false
+	}
+	return &b.calls[index], true
+}
+
+func (b *toolBlockState) addViolation(format string, args ...any) {
+	if b == nil {
+		return
+	}
+	b.violations = append(b.violations, fmt.Sprintf(format, args...))
+}

--- a/sdk/agent/tool_block_state_test.go
+++ b/sdk/agent/tool_block_state_test.go
@@ -1,0 +1,69 @@
+package agent
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/timwhitez/agent-sdk-golang/sdk/llm"
+)
+
+func TestToolBlockStateTracksExecutedAndUnstartedClosure(t *testing.T) {
+	block := newToolBlockState([]llm.ToolCall{{ID: "run"}, {ID: "skip"}})
+	block.markRunning(0)
+	block.markTerminal(0, toolCallRunning, "handler_return")
+	block.markTerminal(1, toolCallAccepted, "turn_end")
+	if err := block.validateClosed(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestToolBlockStateReportsInvariantViolations(t *testing.T) {
+	tests := []struct {
+		name string
+		run  func(*toolBlockState)
+		want string
+	}{
+		{name: "missing terminal", run: func(*toolBlockState) {}, want: "remains phase=\"accepted\""},
+		{name: "duplicate terminal", run: func(block *toolBlockState) {
+			block.markTerminal(0, toolCallAccepted, "first")
+			block.markTerminal(0, toolCallTerminal, "second")
+		}, want: "2 terminal transitions"},
+		{name: "wrong phase", run: func(block *toolBlockState) {
+			block.markTerminal(0, toolCallRunning, "handler_return")
+		}, want: "want \"running\""},
+		{name: "out of range", run: func(block *toolBlockState) {
+			block.markRunning(1)
+			block.markTerminal(0, toolCallAccepted, "turn_end")
+		}, want: "outside block length"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			block := newToolBlockState([]llm.ToolCall{{ID: "call-1"}})
+			test.run(block)
+			err := block.validateClosed()
+			if err == nil || !strings.Contains(err.Error(), test.want) {
+				t.Fatalf("error=%v want substring %q", err, test.want)
+			}
+		})
+	}
+}
+
+func TestToolBlockStateRejectsAmbiguousAcceptedIDs(t *testing.T) {
+	block := newToolBlockState([]llm.ToolCall{{ID: ""}, {ID: "same"}, {ID: "same"}})
+	block.markTerminalRange(0, toolCallAccepted, "closed")
+	err := block.validateClosed()
+	if err == nil || !strings.Contains(err.Error(), "empty id") || !strings.Contains(err.Error(), "duplicates the id") || strings.Contains(err.Error(), "same") {
+		t.Fatalf("error=%v", err)
+	}
+}
+
+func failOnToolBlockShadowWarning(t *testing.T) func(string, ...any) {
+	t.Helper()
+	return func(format string, args ...any) {
+		message := fmt.Sprintf(format, args...)
+		if strings.Contains(message, "tool block shadow invariant mismatch") {
+			t.Errorf("unexpected shadow warning: %s", message)
+		}
+	}
+}


### PR DESCRIPTION
Observe-only Shadow phase for #84, built on the merged characterization PR #96.

## Scope

- adds a package-private, query-local `toolBlockState` with accepted/running/terminal phases;
- identifies Calls only by block ordinal; IDs are validated at admission but are neither retained in diagnostics nor used across blocks;
- mirrors current sequential closure paths: pre-start cancellation, loop guard, evidence suppression, Handler execution, TaskComplete, post-Handler cancellation, steering, and unstarted tail closure;
- validates at the common block exit and again through a query-level defer for future forgotten early returns;
- reports mismatch only through existing `Warningf` and does not add/change typed Events.

## Compatibility and security

The shadow does not construct or mutate history, Tool Results, events, accounting, artifacts, Provider requests, Prompt text, scheduling, or execution order. It stores no arguments, results, Prompt/source text, history index, artifact payload, secret, or cross-block/global ID. Existing mixed-block result text/order/IsError and outbound-repair=0 characterization remain exact.

## Non-goals

No enforcement, unified closure writer, `indeterminate` semantics, durable ledger, FrameID, Scheduler, concurrency, EventEnvelope projection, Prompt/Provider/persistence change, or Goode consumer. #84 remains open.

## Local validation at e8c7286

Go 1.22.12:

- focused state + mixed/cancellation/steering/loop-guard/evidence/continuation tests x50
- legacy/enveloped payload parity x50
- `go test ./... -count=1`
- `go vet ./...`
- `go test -race ./sdk/agent -count=1`
- `git diff --check`

All passed. Benchmark does not apply to an observe-only constant-work mirror.