### PR TITLE
Characterize provider admission identity boundaries

### DIFF
--- a/sdk/agent/agent_request_ownership_test.go
+++ b/sdk/agent/agent_request_ownership_test.go
@@ -119,6 +119,7 @@ func (m *providerAdmissionModel) Invoke(_ context.Context, request llm.InvokeReq
 	if call == 1 && m.retryFirst {
 		request.Messages[0].Content.Blocks[0].Text = "mutated"
 		request.Tools[1].Parameters["limit"] = int64(99)
+		request.Tools[1].Parameters["items"].([]any)[0] = "mutated"
 		*request.Temperature = 9
 		*request.Responses.UseResponseItems = false
 		*request.Responses.UseInstructions = true
@@ -128,7 +129,7 @@ func (m *providerAdmissionModel) Invoke(_ context.Context, request llm.InvokeReq
 		*request.Responses.Store = true
 		request.Responses.Text.Verbosity = "mutated"
 		request.Responses.Text.Format.Name = "mutated"
-		request.Responses.Text.Format.Schema["required"] = []any{"mutated"}
+		request.Responses.Text.Format.Schema["required"].([]any)[0] = "mutated"
 		request.Responses.Reasoning.Effort = "mutated"
 		request.Responses.Reasoning.Summary = "mutated"
 		request.Responses.OutputSchema["type"] = "mutated"
@@ -182,7 +183,7 @@ func TestFrameworkRetryCapturesOuterModelInterface(t *testing.T) {
 	if err != nil || completion == nil || completion.PlainText() != "captured" {
 		t.Fatalf("completion=%#v err=%v", completion, err)
 	}
-	assertProviderAdmissionRequests(t, primary.snapshots(), request, 2)
+	assertProviderAdmissionRequests(t, primary.snapshots(), providerAdmissionRequest(), 2)
 	if got := len(replacement.snapshots()); got != 0 {
 		t.Fatalf("replacement calls during retry=%d want 0", got)
 	}
@@ -190,7 +191,7 @@ func TestFrameworkRetryCapturesOuterModelInterface(t *testing.T) {
 	if err != nil || next == nil || next.PlainText() != "replacement" {
 		t.Fatalf("next admission completion=%#v err=%v", next, err)
 	}
-	assertProviderAdmissionRequests(t, replacement.snapshots(), request, 1)
+	assertProviderAdmissionRequests(t, replacement.snapshots(), providerAdmissionRequest(), 1)
 }
 
 func TestFrameworkRetryDoesNotSnapshotDynamicModelTarget(t *testing.T) {
@@ -207,8 +208,8 @@ func TestFrameworkRetryDoesNotSnapshotDynamicModelTarget(t *testing.T) {
 	if err != nil || completion == nil || completion.PlainText() != "new" {
 		t.Fatalf("completion=%#v err=%v want new", completion, err)
 	}
-	assertProviderAdmissionRequests(t, oldModel.snapshots(), request, 1)
-	assertProviderAdmissionRequests(t, newModel.snapshots(), request, 1)
+	assertProviderAdmissionRequests(t, oldModel.snapshots(), providerAdmissionRequest(), 1)
+	assertProviderAdmissionRequests(t, newModel.snapshots(), providerAdmissionRequest(), 1)
 	if got := dynamic.callCount(); got != 2 {
 		t.Fatalf("outer model calls=%d want 2", got)
 	}
@@ -226,7 +227,7 @@ func providerAdmissionRequest() llm.InvokeRequest {
 		}},
 		Tools: []llm.ToolDefinition{
 			{Name: "nil-schema", Parameters: nil},
-			{Name: "typed-schema", Strict: true, Parameters: map[string]any{"type": "object", "limit": int64(7), "empty": []any{}}},
+			{Name: "typed-schema", Strict: true, Parameters: map[string]any{"type": "object", "limit": int64(7), "items": []any{"stable"}, "empty": []any{}}},
 		},
 		ToolChoice:      llm.ToolChoice("required"),
 		Temperature:     &temperature,

--- a/sdk/agent/agent_request_ownership_test.go
+++ b/sdk/agent/agent_request_ownership_test.go
@@ -5,6 +5,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"net"
+	"reflect"
+	"sync"
 	"testing"
 
 	"github.com/timwhitez/agent-sdk-golang/sdk/llm"
@@ -88,5 +90,193 @@ func TestInvokeRetryUsesFreshRequestClone(t *testing.T) {
 	}
 	if model.err != nil {
 		t.Fatal(model.err)
+	}
+}
+
+type providerAdmissionModel struct {
+	name       string
+	retryFirst bool
+	onFirst    func()
+
+	mu       sync.Mutex
+	requests []llm.InvokeRequest
+}
+
+func (m *providerAdmissionModel) Provider() string { return "fixture" }
+func (m *providerAdmissionModel) Model() string    { return m.name }
+func (m *providerAdmissionModel) Invoke(_ context.Context, request llm.InvokeRequest) (*llm.Completion, error) {
+	snapshot, err := llm.CloneInvokeRequest(request)
+	if err != nil {
+		return nil, err
+	}
+	m.mu.Lock()
+	m.requests = append(m.requests, snapshot)
+	call := len(m.requests)
+	m.mu.Unlock()
+	if call == 1 && m.onFirst != nil {
+		m.onFirst()
+	}
+	if call == 1 && m.retryFirst {
+		request.Messages[0].Content.Blocks[0].Text = "mutated"
+		request.Tools[1].Parameters["limit"] = int64(99)
+		request.Responses.Text.Format.Schema["required"] = []any{"mutated"}
+		return nil, &net.DNSError{Err: "i/o timeout", IsTimeout: true}
+	}
+	return &llm.Completion{Content: llm.TextContent(m.name), StopReason: "stop"}, nil
+}
+
+func (m *providerAdmissionModel) snapshots() []llm.InvokeRequest {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return append([]llm.InvokeRequest(nil), m.requests...)
+}
+
+type dynamicProviderAdmissionModel struct {
+	mu      sync.RWMutex
+	current llm.ChatModel
+	calls   int
+}
+
+func (m *dynamicProviderAdmissionModel) Provider() string { return "fixture" }
+func (m *dynamicProviderAdmissionModel) Model() string    { return "dynamic" }
+func (m *dynamicProviderAdmissionModel) Invoke(ctx context.Context, request llm.InvokeRequest) (*llm.Completion, error) {
+	m.mu.Lock()
+	current := m.current
+	m.calls++
+	m.mu.Unlock()
+	return current.Invoke(ctx, request)
+}
+func (m *dynamicProviderAdmissionModel) swap(next llm.ChatModel) {
+	m.mu.Lock()
+	m.current = next
+	m.mu.Unlock()
+}
+func (m *dynamicProviderAdmissionModel) callCount() int {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	return m.calls
+}
+
+func TestFrameworkRetryCapturesOuterModelInterface(t *testing.T) {
+	request := providerAdmissionRequest()
+	primary := &providerAdmissionModel{name: "captured", retryFirst: true}
+	replacement := &providerAdmissionModel{name: "replacement"}
+	agent, err := New(Config{LLM: primary, InvokeRetryMaxAttempts: 2})
+	if err != nil {
+		t.Fatal(err)
+	}
+	primary.onFirst = func() { agent.llm = replacement }
+	completion, _, err := agent.invokeCompletionWithRetry(context.Background(), request, wrapLegacyEventOutput(make(chan Event, 8)))
+	if err != nil || completion == nil || completion.PlainText() != "captured" {
+		t.Fatalf("completion=%#v err=%v", completion, err)
+	}
+	assertProviderAdmissionRequests(t, primary.snapshots(), request, 2)
+	if got := len(replacement.snapshots()); got != 0 {
+		t.Fatalf("replacement calls during retry=%d want 0", got)
+	}
+	next, _, err := agent.invokeCompletionWithRetry(context.Background(), request, wrapLegacyEventOutput(make(chan Event, 8)))
+	if err != nil || next == nil || next.PlainText() != "replacement" {
+		t.Fatalf("next admission completion=%#v err=%v", next, err)
+	}
+	assertProviderAdmissionRequests(t, replacement.snapshots(), request, 1)
+}
+
+func TestFrameworkRetryDoesNotSnapshotDynamicModelTarget(t *testing.T) {
+	request := providerAdmissionRequest()
+	oldModel := &providerAdmissionModel{name: "old", retryFirst: true}
+	newModel := &providerAdmissionModel{name: "new"}
+	dynamic := &dynamicProviderAdmissionModel{current: oldModel}
+	oldModel.onFirst = func() { dynamic.swap(newModel) }
+	agent, err := New(Config{LLM: dynamic, InvokeRetryMaxAttempts: 2})
+	if err != nil {
+		t.Fatal(err)
+	}
+	completion, _, err := agent.invokeCompletionWithRetry(context.Background(), request, wrapLegacyEventOutput(make(chan Event, 8)))
+	if err != nil || completion == nil || completion.PlainText() != "new" {
+		t.Fatalf("completion=%#v err=%v want new", completion, err)
+	}
+	assertProviderAdmissionRequests(t, oldModel.snapshots(), request, 1)
+	assertProviderAdmissionRequests(t, newModel.snapshots(), request, 1)
+	if got := dynamic.callCount(); got != 2 {
+		t.Fatalf("outer model calls=%d want 2", got)
+	}
+}
+
+func providerAdmissionRequest() llm.InvokeRequest {
+	temperature := 0.25
+	yes, no := true, false
+	return llm.InvokeRequest{
+		Messages: []llm.Message{{
+			Role:    llm.RoleUser,
+			Name:    "fixture",
+			Cache:   true,
+			Content: llm.Content{Blocks: []llm.ContentBlock{{Type: "text", Text: "original"}}},
+		}},
+		Tools: []llm.ToolDefinition{
+			{Name: "nil-schema", Parameters: nil},
+			{Name: "typed-schema", Strict: true, Parameters: map[string]any{"type": "object", "limit": int64(7), "empty": []any{}}},
+		},
+		ToolChoice:      llm.ToolChoice("required"),
+		Temperature:     &temperature,
+		DisableThinking: true,
+		Responses: &llm.ResponsesOptions{
+			UseResponseItems:  &yes,
+			UseInstructions:   &no,
+			Instructions:      "stable",
+			ConversationID:    "conversation",
+			PromptCacheKey:    "cache",
+			Include:           []string{},
+			ParallelToolCalls: &no,
+			Store:             &no,
+			Text: &llm.ResponsesTextControls{
+				Verbosity: "low",
+				Format: &llm.ResponsesTextFormat{
+					Type:   "json_schema",
+					Strict: true,
+					Name:   "answer",
+					Schema: map[string]any{"type": "object", "required": []any{"answer"}},
+				},
+			},
+			Reasoning:    &llm.ResponsesReasoning{Effort: "low", Summary: "auto"},
+			Verbosity:    "medium",
+			OutputSchema: map[string]any{},
+		},
+	}
+}
+
+func assertProviderAdmissionRequests(t *testing.T, got []llm.InvokeRequest, want llm.InvokeRequest, count int) {
+	t.Helper()
+	if len(got) != count {
+		t.Fatalf("provider requests=%d want %d", len(got), count)
+	}
+	for i, request := range got {
+		if !reflect.DeepEqual(request, want) {
+			t.Fatalf("request[%d]\n got: %#v\nwant: %#v", i, request, want)
+		}
+	}
+}
+
+type providerAdmissionNoopModel struct{}
+
+func (providerAdmissionNoopModel) Provider() string { return "fixture" }
+func (providerAdmissionNoopModel) Model() string    { return "noop" }
+func (providerAdmissionNoopModel) Invoke(context.Context, llm.InvokeRequest) (*llm.Completion, error) {
+	return &llm.Completion{StopReason: "stop"}, nil
+}
+
+func BenchmarkProviderAdmissionSnapshot(b *testing.B) {
+	model := providerAdmissionNoopModel{}
+	agent, err := New(Config{LLM: model, InvokeRetryMaxAttempts: 1})
+	if err != nil {
+		b.Fatal(err)
+	}
+	request := providerAdmissionRequest()
+	out := wrapLegacyEventOutput(make(chan Event, 1))
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, _, err := agent.invokeModelCompletionWithSteering(context.Background(), model, request, out, nil); err != nil {
+			b.Fatal(err)
+		}
 	}
 }

--- a/sdk/agent/agent_request_ownership_test.go
+++ b/sdk/agent/agent_request_ownership_test.go
@@ -119,7 +119,19 @@ func (m *providerAdmissionModel) Invoke(_ context.Context, request llm.InvokeReq
 	if call == 1 && m.retryFirst {
 		request.Messages[0].Content.Blocks[0].Text = "mutated"
 		request.Tools[1].Parameters["limit"] = int64(99)
+		*request.Temperature = 9
+		*request.Responses.UseResponseItems = false
+		*request.Responses.UseInstructions = true
+		request.Responses.Instructions = "mutated"
+		request.Responses.Include[0] = "mutated"
+		*request.Responses.ParallelToolCalls = true
+		*request.Responses.Store = true
+		request.Responses.Text.Verbosity = "mutated"
+		request.Responses.Text.Format.Name = "mutated"
 		request.Responses.Text.Format.Schema["required"] = []any{"mutated"}
+		request.Responses.Reasoning.Effort = "mutated"
+		request.Responses.Reasoning.Summary = "mutated"
+		request.Responses.OutputSchema["type"] = "mutated"
 		return nil, &net.DNSError{Err: "i/o timeout", IsTimeout: true}
 	}
 	return &llm.Completion{Content: llm.TextContent(m.name), StopReason: "stop"}, nil
@@ -225,7 +237,7 @@ func providerAdmissionRequest() llm.InvokeRequest {
 			Instructions:      "stable",
 			ConversationID:    "conversation",
 			PromptCacheKey:    "cache",
-			Include:           []string{},
+			Include:           []string{"trace"},
 			ParallelToolCalls: &no,
 			Store:             &no,
 			Text: &llm.ResponsesTextControls{


### PR DESCRIPTION
Characterization phase for #83. Relative to current main this PR changes only `agent_request_ownership_test.go`; production code is untouched.

## Frozen current behavior

- one framework retry loop captures the same outer `llm.ChatModel` interface across attempts;
- the next independent admission captures the newly installed outer model;
- a dynamic outer wrapper may still change its concrete target between attempts, explicitly recording the remaining snapshot gap;
- every attempt receives an independently cloned, provider-neutral request that remains exactly equivalent across messages, nil/empty schemas, concrete JSON number types, ToolChoice, Temperature, thinking flag, and all mutable Responses pointer/slice/map options;
- the first Provider attempt mutates nested request and Responses state, proving the next attempt does not inherit those mutations;
- `BenchmarkProviderAdmissionSnapshot` records the current clone + no-op Provider admission baseline.

## Non-goals

No production ExecutionFrame, FrameID/lineage, fingerprint, observer, public API, concrete-model snapshot, tool resolver refactor, Prompt/Provider payload, Tool execution, persistence, compaction behavior, or Goode pin update. #83 remains open.

## Local validation at 631fbe9

Go 1.22.12:

- focused admission/ownership tests x100
- `go test ./...`
- `go vet ./...`
- `go test -race ./sdk/agent`
- `git diff --check`
- outer-model re-read mutation killed 20/20
- Store + Reasoning shallow-clone mutations killed 20/20
- benchmark x10: median `4694 ns/op`, `2240 B/op`, `50 allocs/op`

Benchmark command:

`go test ./sdk/agent -run ^$ -bench ^BenchmarkProviderAdmissionSnapshot$ -benchmem -count=10`

No performance claim is made; this is the baseline for later shadow/refactor comparison.