### PR TITLE
agent: shadow automatic compaction decisions

### DIFF
--- a/sdk/agent/agent.go
+++ b/sdk/agent/agent.go
@@ -135,37 +135,39 @@ type Config struct {
 }
 
 type Agent struct {
-	llm                        llm.ChatModel
-	systemPrompt               string
-	maxIterations              int
-	invokeRetryMax             int
-	invokeRetryBackoff         time.Duration
-	repeatSigThreshold         int
-	repeatSigWindow            int
-	loopGuardStrikeMax         int
-	loopGuardUserMsg           string
-	maxToolResultBytes         int
-	maxToolResultTokens        int
-	toolResultTokenEstimator   func(string) int
-	accountingEstimator        sdkaccounting.Estimator
-	artifactOwner              artifact.Owner
-	artifactOwnerProvider      ArtifactOwnerProvider
-	artifactSink               artifact.Sink
-	artifactResolver           artifact.Resolver
-	artifactResolverCapability artifact.ResolverCapability
-	artifactEnvelopeCodec      artifact.EnvelopeCodec
-	toolResultDumpTTL          time.Duration
-	eventBufferSize            int
-	eventSendTimeout           time.Duration
-	eventDropLogEvery          uint64
-	queryIDGenerator           func() string
-	eventClock                 func() time.Time
-	streamIdleTimeout          time.Duration
-	streamIdleMaxRecov         int
-	toolChoice                 llm.ToolChoice
-	requireDone                bool
-	warningf                   func(format string, args ...any)
-	hasCompactor               bool
+	llm                         llm.ChatModel
+	systemPrompt                string
+	maxIterations               int
+	invokeRetryMax              int
+	invokeRetryBackoff          time.Duration
+	repeatSigThreshold          int
+	repeatSigWindow             int
+	loopGuardStrikeMax          int
+	loopGuardUserMsg            string
+	maxToolResultBytes          int
+	maxToolResultTokens         int
+	toolResultTokenEstimator    func(string) int
+	accountingEstimator         sdkaccounting.Estimator
+	artifactOwner               artifact.Owner
+	artifactOwnerProvider       ArtifactOwnerProvider
+	artifactSink                artifact.Sink
+	artifactResolver            artifact.Resolver
+	artifactResolverCapability  artifact.ResolverCapability
+	artifactEnvelopeCodec       artifact.EnvelopeCodec
+	toolResultDumpTTL           time.Duration
+	eventBufferSize             int
+	eventSendTimeout            time.Duration
+	eventDropLogEvery           uint64
+	queryIDGenerator            func() string
+	eventClock                  func() time.Time
+	streamIdleTimeout           time.Duration
+	streamIdleMaxRecov          int
+	toolChoice                  llm.ToolChoice
+	requireDone                 bool
+	warningf                    func(format string, args ...any)
+	hasCompactor                bool
+	compactionAdmissionObserved func()
+	compactionShadowObserved    func()
 
 	tools             []tools.Tool
 	toolMap           map[string]tools.Tool
@@ -4301,6 +4303,9 @@ func (a *Agent) shouldAttemptCompaction(ctx context.Context, last *llm.Completio
 func (a *Agent) shouldAttemptCompactionUsage(ctx context.Context, usage *llm.Usage) bool {
 	if !a.hasCompactor || a.compactor == nil {
 		return false
+	}
+	if a.compactionAdmissionObserved != nil {
+		a.compactionAdmissionObserved()
 	}
 	if ctx != nil && ctx.Err() != nil {
 		return false

--- a/sdk/agent/agent.go
+++ b/sdk/agent/agent.go
@@ -135,37 +135,38 @@ type Config struct {
 }
 
 type Agent struct {
-	llm                         llm.ChatModel
-	systemPrompt                string
-	maxIterations               int
-	invokeRetryMax              int
-	invokeRetryBackoff          time.Duration
-	repeatSigThreshold          int
-	repeatSigWindow             int
-	loopGuardStrikeMax          int
-	loopGuardUserMsg            string
-	maxToolResultBytes          int
-	maxToolResultTokens         int
-	toolResultTokenEstimator    func(string) int
-	accountingEstimator         sdkaccounting.Estimator
-	artifactOwner               artifact.Owner
-	artifactOwnerProvider       ArtifactOwnerProvider
-	artifactSink                artifact.Sink
-	artifactResolver            artifact.Resolver
-	artifactResolverCapability  artifact.ResolverCapability
-	artifactEnvelopeCodec       artifact.EnvelopeCodec
-	toolResultDumpTTL           time.Duration
-	eventBufferSize             int
-	eventSendTimeout            time.Duration
-	eventDropLogEvery           uint64
-	queryIDGenerator            func() string
-	eventClock                  func() time.Time
-	streamIdleTimeout           time.Duration
-	streamIdleMaxRecov          int
-	toolChoice                  llm.ToolChoice
-	requireDone                 bool
-	warningf                    func(format string, args ...any)
-	hasCompactor                bool
+	llm                        llm.ChatModel
+	systemPrompt               string
+	maxIterations              int
+	invokeRetryMax             int
+	invokeRetryBackoff         time.Duration
+	repeatSigThreshold         int
+	repeatSigWindow            int
+	loopGuardStrikeMax         int
+	loopGuardUserMsg           string
+	maxToolResultBytes         int
+	maxToolResultTokens        int
+	toolResultTokenEstimator   func(string) int
+	accountingEstimator        sdkaccounting.Estimator
+	artifactOwner              artifact.Owner
+	artifactOwnerProvider      ArtifactOwnerProvider
+	artifactSink               artifact.Sink
+	artifactResolver           artifact.Resolver
+	artifactResolverCapability artifact.ResolverCapability
+	artifactEnvelopeCodec      artifact.EnvelopeCodec
+	toolResultDumpTTL          time.Duration
+	eventBufferSize            int
+	eventSendTimeout           time.Duration
+	eventDropLogEvery          uint64
+	queryIDGenerator           func() string
+	eventClock                 func() time.Time
+	streamIdleTimeout          time.Duration
+	streamIdleMaxRecov         int
+	toolChoice                 llm.ToolChoice
+	requireDone                bool
+	warningf                   func(format string, args ...any)
+	hasCompactor               bool
+
 	compactionAdmissionObserved func()
 	compactionShadowObserved    func()
 

--- a/sdk/agent/agent.go
+++ b/sdk/agent/agent.go
@@ -3218,10 +3218,26 @@ func (a *Agent) checkAndCompactWithGrowth(ctx context.Context, last *llm.Complet
 	a.applyPendingCompaction(out)
 	decisionUsage := a.effectiveCompactionUsageWithGrowth(last.Usage, currentHistoryGrowth, pendingHistoryGrowth)
 	trigger, watermark := a.compactionTriggerAndWatermarkForUsage(decisionUsage)
-	if watermark == "overflow" {
+	overflow := watermark == "overflow"
+	ordinaryAdmission := false
+	if !overflow {
+		ordinaryAdmission = a.shouldAttemptCompactionUsage(ctx, decisionUsage)
+	}
+	legacyDecision := compactionDecision{
+		run:             overflow || ordinaryAdmission,
+		trigger:         trigger,
+		targetWatermark: watermark,
+	}
+	a.observeAutomaticCompactionDecision(legacyDecision, shadowAutomaticCompactionDecision(automaticCompactionObservation{
+		overflow:          overflow,
+		ordinaryAdmission: ordinaryAdmission,
+		trigger:           trigger,
+		targetWatermark:   watermark,
+	}))
+	if legacyDecision.targetWatermark == "overflow" {
 		return a.compactSyncOverflow(ctx, last, decisionUsage, out)
 	}
-	if !a.shouldAttemptCompactionUsage(ctx, decisionUsage) {
+	if !legacyDecision.run {
 		return nil
 	}
 	if !a.compactionInFlight.CompareAndSwap(false, true) {

--- a/sdk/agent/compaction_decision.go
+++ b/sdk/agent/compaction_decision.go
@@ -1,0 +1,56 @@
+package agent
+
+type compactionDecision struct {
+	run             bool
+	trigger         string
+	targetWatermark string
+}
+
+type automaticCompactionObservation struct {
+	overflow          bool
+	ordinaryAdmission bool
+	trigger           string
+	targetWatermark   string
+}
+
+func shadowAutomaticCompactionDecision(observation automaticCompactionObservation) compactionDecision {
+	return compactionDecision{
+		run:             observation.overflow || observation.ordinaryAdmission,
+		trigger:         observation.trigger,
+		targetWatermark: observation.targetWatermark,
+	}
+}
+
+func (a *Agent) observeAutomaticCompactionDecision(legacy, shadow compactionDecision) {
+	if legacy != shadow {
+		a.warnf(
+			"agent: automatic compaction decision shadow mismatch: legacy_run=%t shadow_run=%t legacy_trigger=%s shadow_trigger=%s legacy_watermark=%s shadow_watermark=%s",
+			legacy.run,
+			shadow.run,
+			safeCompactionTrigger(legacy.trigger),
+			safeCompactionTrigger(shadow.trigger),
+			safeCompactionWatermark(legacy.targetWatermark),
+			safeCompactionWatermark(shadow.targetWatermark),
+		)
+	}
+}
+
+func safeCompactionTrigger(trigger string) string {
+	switch trigger {
+	case "usage", "overflow", "todo_checkpoint", "retry_checkpoint", "placeholder_pressure":
+		return trigger
+	default:
+		return "unknown"
+	}
+}
+
+func safeCompactionWatermark(watermark string) string {
+	switch watermark {
+	case "":
+		return "none"
+	case "snip", "prune", "summarize", "overflow", "placeholder_cleanup":
+		return watermark
+	default:
+		return "unknown"
+	}
+}

--- a/sdk/agent/compaction_decision.go
+++ b/sdk/agent/compaction_decision.go
@@ -22,6 +22,9 @@ func shadowAutomaticCompactionDecision(observation automaticCompactionObservatio
 }
 
 func (a *Agent) observeAutomaticCompactionDecision(legacy, shadow compactionDecision) {
+	if a.compactionShadowObserved != nil {
+		a.compactionShadowObserved()
+	}
 	if legacy != shadow {
 		a.warnf(
 			"agent: automatic compaction decision shadow mismatch: legacy_run=%t shadow_run=%t legacy_trigger=%s shadow_trigger=%s legacy_watermark=%s shadow_watermark=%s",

--- a/sdk/agent/compaction_decision_test.go
+++ b/sdk/agent/compaction_decision_test.go
@@ -1,9 +1,13 @@
 package agent
 
 import (
+	"context"
 	"fmt"
 	"strings"
 	"testing"
+
+	"github.com/timwhitez/agent-sdk-golang/sdk/agent/compaction"
+	"github.com/timwhitez/agent-sdk-golang/sdk/llm"
 )
 
 func TestShadowAutomaticCompactionDecision(t *testing.T) {
@@ -66,6 +70,34 @@ func TestObserveAutomaticCompactionDecisionKeepsLegacyAuthorityAndSafeWarning(t 
 	)
 	if !strings.Contains(warning, "legacy_run=true shadow_run=false legacy_trigger=unknown shadow_trigger=usage legacy_watermark=unknown shadow_watermark=snip") || strings.Contains(warning, "secret") {
 		t.Fatalf("unsafe mismatch warning: %q", warning)
+	}
+}
+
+func TestAutomaticCompactionDecisionRuntimeObservesOnce(t *testing.T) {
+	agent, err := New(Config{
+		LLM: &countingCompactionModel{},
+		Compaction: &compaction.Config{
+			Enabled:             true,
+			ContextWindow:       100,
+			ReserveOutputTokens: 0,
+			SnipThresholdRatio:  0.70,
+			PruneThresholdRatio: 0.80,
+			ThresholdRatio:      0.85,
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	admissions, shadows := 0, 0
+	agent.compactionAdmissionObserved = func() { admissions++ }
+	agent.compactionShadowObserved = func() { shadows++ }
+
+	err = agent.checkAndCompactWithGrowth(context.Background(), &llm.Completion{Usage: llm.WithPromptEstimate(nil, 69)}, nil, 0, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if admissions != 1 || shadows != 1 {
+		t.Fatalf("observations admission=%d shadow=%d want 1/1", admissions, shadows)
 	}
 }
 

--- a/sdk/agent/compaction_decision_test.go
+++ b/sdk/agent/compaction_decision_test.go
@@ -1,0 +1,89 @@
+package agent
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+)
+
+func TestShadowAutomaticCompactionDecision(t *testing.T) {
+	for _, test := range []struct {
+		name        string
+		observation automaticCompactionObservation
+		want        compactionDecision
+	}{
+		{
+			name:        "below watermark",
+			observation: automaticCompactionObservation{trigger: "usage"},
+			want:        compactionDecision{trigger: "usage"},
+		},
+		{
+			name:        "ordinary admission",
+			observation: automaticCompactionObservation{ordinaryAdmission: true, trigger: "usage", targetWatermark: "snip"},
+			want:        compactionDecision{run: true, trigger: "usage", targetWatermark: "snip"},
+		},
+		{
+			name:        "hard overflow bypass",
+			observation: automaticCompactionObservation{overflow: true, trigger: "overflow", targetWatermark: "overflow"},
+			want:        compactionDecision{run: true, trigger: "overflow", targetWatermark: "overflow"},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			if got := shadowAutomaticCompactionDecision(test.observation); got != test.want {
+				t.Fatalf("decision=%#v want %#v", got, test.want)
+			}
+		})
+	}
+}
+
+func TestObserveAutomaticCompactionDecisionKeepsLegacyAuthorityAndSafeWarning(t *testing.T) {
+	legacy := compactionDecision{run: true, trigger: "usage", targetWatermark: "snip"}
+	for _, test := range []struct {
+		name         string
+		shadow       compactionDecision
+		wantWarnings int
+	}{
+		{name: "equal", shadow: legacy},
+		{name: "run", shadow: compactionDecision{trigger: "usage", targetWatermark: "snip"}, wantWarnings: 1},
+		{name: "trigger", shadow: compactionDecision{run: true, trigger: "todo_checkpoint", targetWatermark: "snip"}, wantWarnings: 1},
+		{name: "watermark", shadow: compactionDecision{run: true, trigger: "usage", targetWatermark: "prune"}, wantWarnings: 1},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			warnings := 0
+			agent := &Agent{warningf: func(string, ...any) { warnings++ }}
+			agent.observeAutomaticCompactionDecision(legacy, test.shadow)
+			if got := warnings; got != test.wantWarnings {
+				t.Fatalf("warnings=%d want %d", got, test.wantWarnings)
+			}
+		})
+	}
+
+	var warning string
+	agent := &Agent{warningf: func(format string, args ...any) { warning = fmt.Sprintf(format, args...) }}
+	agent.observeAutomaticCompactionDecision(
+		compactionDecision{run: true, trigger: "secret-trigger", targetWatermark: "secret-watermark"},
+		compactionDecision{trigger: "usage", targetWatermark: "snip"},
+	)
+	if !strings.Contains(warning, "legacy_run=true shadow_run=false legacy_trigger=unknown shadow_trigger=usage legacy_watermark=unknown shadow_watermark=snip") || strings.Contains(warning, "secret") {
+		t.Fatalf("unsafe mismatch warning: %q", warning)
+	}
+}
+
+var benchmarkCompactionDecision compactionDecision
+
+func BenchmarkShadowAutomaticCompactionDecision(b *testing.B) {
+	observation := automaticCompactionObservation{
+		ordinaryAdmission: true,
+		trigger:           "todo_checkpoint",
+		targetWatermark:   "prune",
+	}
+	legacy := compactionDecision{run: true, trigger: "todo_checkpoint", targetWatermark: "prune"}
+	agent := &Agent{warningf: func(string, ...any) {}}
+	b.ReportAllocs()
+	var decision compactionDecision
+	for i := 0; i < b.N; i++ {
+		decision = shadowAutomaticCompactionDecision(observation)
+		agent.observeAutomaticCompactionDecision(legacy, decision)
+	}
+	benchmarkCompactionDecision = decision
+}


### PR DESCRIPTION
Progresses #86.

## Scope

- add a package-private automatic compaction Decision shadow for `run`, `trigger`, and `targetWatermark`;
- observe the existing automatic admission path exactly once, without re-reading cooldown or other mutable state;
- keep the legacy decision as the direct authority for synchronous overflow and ordinary admission;
- emit only closed-enum/boolean diagnostics on a shadow mismatch;
- freeze the runtime wiring and single admission observation with package-private test counters.

## Non-goals

No Prompt, Provider payload, threshold, cooldown, retry, compaction execution, persistence, public API, manual/preflight, or Provider-overflow behavior changes. This does not add a unified Controller or enable enforcement.

## Local verification

Exact base: `dc69de5b04e6b48bc3dd3ede1f394018cbe69746`
Exact head: `4ed01e26ebeec92a0c314499de5398c0cb8598bc`

- `go test ./sdk/agent -run 'Test(AutomaticCompactionDecisionRuntimeObservesOnce|ShadowAutomaticCompactionDecision|ObserveAutomaticCompactionDecisionKeepsLegacyAuthorityAndSafeWarning|CompactionLegacyDecisionParity|ProviderRejectedContextOverflowIsTerminal)$' -count=100`\n- `go test ./... -count=1`\n- `go vet ./...`\n- `go test -race ./sdk/agent -count=1`\n- `go test ./sdk/agent -run ^ -bench ^BenchmarkShadowAutomaticCompactionDecision -benchmem -count=10` (median 10.06 ns/op, 0 B/op, 0 allocs/op)
- `git diff --check`

Independent exact-head review is required before merge.