### PR TITLE
agent: observe indeterminate running-tool cancellation

### DIFF
--- a/sdk/agent/agent.go
+++ b/sdk/agent/agent.go
@@ -169,6 +169,7 @@ type Agent struct {
 
 	compactionAdmissionObserved func()
 	compactionShadowObserved    func()
+	toolBlockStateObserved      func(*toolBlockState)
 
 	tools             []tools.Tool
 	toolMap           map[string]tools.Tool
@@ -680,8 +681,14 @@ func (a *Agent) queryStreamWithSteering(ctx context.Context, input llm.Content, 
 		finishToolBlock := func() {
 			block := activeToolBlock
 			activeToolBlock = nil
+			if block == nil {
+				return
+			}
 			if err := block.validateClosed(); err != nil {
 				a.warnf("warning: tool block shadow invariant mismatch: %v", err)
+			}
+			if a.toolBlockStateObserved != nil {
+				a.toolBlockStateObserved(block)
 			}
 		}
 		defer finishToolBlock()
@@ -1380,6 +1387,7 @@ func (a *Agent) queryStreamWithSteering(ctx context.Context, input llm.Content, 
 				content, toolErr := a.executeToolSafely(ctxTool, tool, execArgs)
 				stageInterruptedForSteering := finishToolStage()
 				rootCancelErr := ctx.Err()
+				activeToolBlock.markAttemptReturned(idx, rootCancelErr != nil)
 				if rootCancelErr != nil {
 					// Root cancellation outranks a tool's ordinary or task-complete
 					// return. Keep a contiguous result for this call, then terminate.

--- a/sdk/agent/agent_cancel_boundary_test.go
+++ b/sdk/agent/agent_cancel_boundary_test.go
@@ -407,6 +407,7 @@ func BenchmarkToolBlockShadowLifecycle(b *testing.B) {
 		state := newToolBlockState(calls)
 		for ordinal := range calls {
 			state.markRunning(ordinal)
+			state.markAttemptReturned(ordinal, false)
 			state.markTerminal(ordinal, toolCallRunning, "handler_return")
 		}
 		if err := state.validateClosed(); err != nil {

--- a/sdk/agent/tool_block_state.go
+++ b/sdk/agent/tool_block_state.go
@@ -9,16 +9,40 @@ import (
 
 type toolCallPhase string
 
+type toolExecutionKnowledge uint8
+
 const (
 	toolCallAccepted toolCallPhase = "accepted"
 	toolCallRunning  toolCallPhase = "running"
 	toolCallTerminal toolCallPhase = "terminal"
+
+	toolExecutionUnknown toolExecutionKnowledge = iota
+	toolExecutionNotStarted
+	toolExecutionAttemptStarted
+	toolExecutionOutcomeObserved
+	toolExecutionIndeterminate
 )
 
 type toolCallState struct {
-	phase         toolCallPhase
-	terminalCount int
-	closure       string
+	phase              toolCallPhase
+	executionKnowledge toolExecutionKnowledge
+	terminalCount      int
+	closure            string
+}
+
+func (k toolExecutionKnowledge) String() string {
+	switch k {
+	case toolExecutionNotStarted:
+		return "not_started"
+	case toolExecutionAttemptStarted:
+		return "attempt_started"
+	case toolExecutionOutcomeObserved:
+		return "outcome_observed"
+	case toolExecutionIndeterminate:
+		return "indeterminate"
+	default:
+		return "unknown"
+	}
 }
 
 // toolBlockState is an observe-only mirror of the sequential Tool Loop. It is
@@ -33,7 +57,7 @@ func newToolBlockState(calls []llm.ToolCall) *toolBlockState {
 	seen := make(map[string]int, len(calls))
 	for i, call := range calls {
 		id := strings.TrimSpace(call.ID)
-		block.calls[i] = toolCallState{phase: toolCallAccepted}
+		block.calls[i] = toolCallState{phase: toolCallAccepted, executionKnowledge: toolExecutionNotStarted}
 		if id == "" {
 			block.addViolation("call[%d] has empty id", i)
 			continue
@@ -56,7 +80,27 @@ func (b *toolBlockState) markRunning(index int) {
 		b.addViolation("call[%d] cannot start from phase %q", index, call.phase)
 		return
 	}
+	if call.executionKnowledge != toolExecutionNotStarted {
+		b.addViolation("call[%d] cannot start from execution %q", index, call.executionKnowledge)
+		return
+	}
 	call.phase = toolCallRunning
+	call.executionKnowledge = toolExecutionAttemptStarted
+}
+
+func (b *toolBlockState) markAttemptReturned(index int, rootCanceled bool) {
+	call, ok := b.call(index)
+	if !ok {
+		return
+	}
+	if call.phase != toolCallRunning || call.executionKnowledge != toolExecutionAttemptStarted {
+		b.addViolation("call[%d] cannot observe attempt return from phase %q execution %q", index, call.phase, call.executionKnowledge)
+		return
+	}
+	call.executionKnowledge = toolExecutionOutcomeObserved
+	if rootCanceled {
+		call.executionKnowledge = toolExecutionIndeterminate
+	}
 }
 
 func (b *toolBlockState) markTerminal(index int, expected toolCallPhase, closure string) {
@@ -72,6 +116,12 @@ func (b *toolBlockState) markTerminal(index int, expected toolCallPhase, closure
 	if call.phase != expected {
 		b.addViolation("call[%d] closed by %q from phase %q, want %q", index, closure, call.phase, expected)
 		return
+	}
+	if expected == toolCallAccepted && call.executionKnowledge != toolExecutionNotStarted {
+		b.addViolation("call[%d] closed by %q from execution %q, want %q", index, closure, call.executionKnowledge, toolExecutionNotStarted)
+	}
+	if expected == toolCallRunning && call.executionKnowledge != toolExecutionOutcomeObserved && call.executionKnowledge != toolExecutionIndeterminate {
+		b.addViolation("call[%d] closed by %q from execution %q, want terminal execution knowledge", index, closure, call.executionKnowledge)
 	}
 	call.phase = toolCallTerminal
 	call.closure = closure
@@ -96,8 +146,8 @@ func (b *toolBlockState) validateClosed() error {
 	}
 	violations := append([]string(nil), b.violations...)
 	for i, call := range b.calls {
-		if call.phase != toolCallTerminal || call.terminalCount != 1 {
-			violations = append(violations, fmt.Sprintf("call[%d] remains phase=%q terminal_count=%d", i, call.phase, call.terminalCount))
+		if call.phase != toolCallTerminal || call.terminalCount != 1 || call.executionKnowledge == toolExecutionUnknown || call.executionKnowledge == toolExecutionAttemptStarted {
+			violations = append(violations, fmt.Sprintf("call[%d] remains phase=%q execution=%q terminal_count=%d", i, call.phase, call.executionKnowledge, call.terminalCount))
 		}
 	}
 	if len(violations) == 0 {

--- a/sdk/agent/tool_block_state_test.go
+++ b/sdk/agent/tool_block_state_test.go
@@ -2,6 +2,7 @@ package agent
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"slices"
 	"strings"
@@ -81,6 +82,38 @@ func TestToolBlockStateObservesRunningCancellationAsIndeterminate(t *testing.T) 
 	}
 }
 
+func TestToolBlockStateObservesOrdinaryAttemptOutcomes(t *testing.T) {
+	for _, test := range []struct {
+		name    string
+		handler func() (any, error)
+	}{
+		{name: "success", handler: func() (any, error) { return "ok", nil }},
+		{name: "error", handler: func() (any, error) { return nil, errors.New("failed") }},
+		{name: "panic", handler: func() (any, error) { panic("failed") }},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			model := &cancelBoundaryScriptModel{toolCalls: []llm.ToolCall{cancelBoundaryCall("ordinary-1", "ordinary")}}
+			tool := tools.Func[struct{}]("ordinary", "ordinary", func(context.Context, struct{}, *tools.Container) (any, error) {
+				return test.handler()
+			})
+			agent, err := New(Config{LLM: model, Tools: []tools.Tool{tool}, MaxIterations: 4, Warningf: failOnToolBlockShadowWarning(t)})
+			if err != nil {
+				t.Fatal(err)
+			}
+			var observed []toolExecutionKnowledge
+			agent.toolBlockStateObserved = func(block *toolBlockState) {
+				for _, call := range block.calls {
+					observed = append(observed, call.executionKnowledge)
+				}
+			}
+			collectEvents(agent.QueryStream(context.Background(), llm.TextContent("run")))
+			if want := []toolExecutionKnowledge{toolExecutionOutcomeObserved}; !slices.Equal(observed, want) {
+				t.Fatalf("execution knowledge=%v want %v", observed, want)
+			}
+		})
+	}
+}
+
 func TestToolBlockStateReportsInvariantViolations(t *testing.T) {
 	tests := []struct {
 		name string
@@ -99,6 +132,10 @@ func TestToolBlockStateReportsInvariantViolations(t *testing.T) {
 			block.markRunning(0)
 			block.markTerminal(0, toolCallRunning, "handler_return")
 		}, want: "want terminal execution knowledge"},
+		{name: "terminal unknown execution", run: func(block *toolBlockState) {
+			block.markTerminal(0, toolCallAccepted, "turn_end")
+			block.calls[0].executionKnowledge = toolExecutionUnknown
+		}, want: "execution=\"unknown\""},
 		{name: "out of range", run: func(block *toolBlockState) {
 			block.markRunning(1)
 			block.markTerminal(0, toolCallAccepted, "turn_end")

--- a/sdk/agent/tool_block_state_test.go
+++ b/sdk/agent/tool_block_state_test.go
@@ -1,20 +1,83 @@
 package agent
 
 import (
+	"context"
 	"fmt"
+	"slices"
 	"strings"
 	"testing"
 
 	"github.com/timwhitez/agent-sdk-golang/sdk/llm"
+	"github.com/timwhitez/agent-sdk-golang/sdk/tools"
 )
 
 func TestToolBlockStateTracksExecutedAndUnstartedClosure(t *testing.T) {
 	block := newToolBlockState([]llm.ToolCall{{ID: "run"}, {ID: "skip"}})
 	block.markRunning(0)
+	block.markAttemptReturned(0, false)
 	block.markTerminal(0, toolCallRunning, "handler_return")
 	block.markTerminal(1, toolCallAccepted, "turn_end")
 	if err := block.validateClosed(); err != nil {
 		t.Fatal(err)
+	}
+}
+
+func TestToolBlockStateExecutionKnowledgeTransitions(t *testing.T) {
+	block := newToolBlockState([]llm.ToolCall{{ID: "observed"}, {ID: "indeterminate"}, {ID: "unstarted"}})
+	if got := block.calls[0].executionKnowledge; got != toolExecutionNotStarted {
+		t.Fatalf("accepted execution=%q want %q", got, toolExecutionNotStarted)
+	}
+	block.markRunning(0)
+	if got := block.calls[0].executionKnowledge; got != toolExecutionAttemptStarted {
+		t.Fatalf("running execution=%q want %q", got, toolExecutionAttemptStarted)
+	}
+	block.markAttemptReturned(0, false)
+	block.markTerminal(0, toolCallRunning, "handler_return")
+	block.markRunning(1)
+	block.markAttemptReturned(1, true)
+	block.markTerminal(1, toolCallRunning, "handler_return")
+	block.markTerminal(2, toolCallAccepted, "root_cancel_after_handler")
+
+	if got := block.calls[0].executionKnowledge; got != toolExecutionOutcomeObserved {
+		t.Fatalf("observed execution=%q want %q", got, toolExecutionOutcomeObserved)
+	}
+	if got := block.calls[1].executionKnowledge; got != toolExecutionIndeterminate {
+		t.Fatalf("canceled running execution=%q want %q", got, toolExecutionIndeterminate)
+	}
+	if got := block.calls[2].executionKnowledge; got != toolExecutionNotStarted {
+		t.Fatalf("unstarted execution=%q want %q", got, toolExecutionNotStarted)
+	}
+	if err := block.validateClosed(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestToolBlockStateObservesRunningCancellationAsIndeterminate(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	model := &runningCancelOutcomeModel{}
+	running := tools.Func[struct{}]("running", "running", func(context.Context, struct{}, *tools.Container) (any, error) {
+		cancel()
+		return "side effect may have happened", nil
+	})
+	tail := tools.Func[struct{}]("tail", "tail", func(context.Context, struct{}, *tools.Container) (any, error) {
+		return "must not run", nil
+	})
+	agent, err := New(Config{LLM: model, Tools: []tools.Tool{running, tail}, MaxIterations: 4, Warningf: failOnToolBlockShadowWarning(t)})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var observed []toolExecutionKnowledge
+	agent.toolBlockStateObserved = func(block *toolBlockState) {
+		for _, call := range block.calls {
+			observed = append(observed, call.executionKnowledge)
+		}
+	}
+	collectEvents(agent.QueryStream(ctx, llm.TextContent("run")))
+
+	want := []toolExecutionKnowledge{toolExecutionIndeterminate, toolExecutionNotStarted}
+	if !slices.Equal(observed, want) {
+		t.Fatalf("execution knowledge=%v want %v", observed, want)
 	}
 }
 
@@ -32,6 +95,10 @@ func TestToolBlockStateReportsInvariantViolations(t *testing.T) {
 		{name: "wrong phase", run: func(block *toolBlockState) {
 			block.markTerminal(0, toolCallRunning, "handler_return")
 		}, want: "want \"running\""},
+		{name: "running without returned outcome", run: func(block *toolBlockState) {
+			block.markRunning(0)
+			block.markTerminal(0, toolCallRunning, "handler_return")
+		}, want: "want terminal execution knowledge"},
 		{name: "out of range", run: func(block *toolBlockState) {
 			block.markRunning(1)
 			block.markTerminal(0, toolCallAccepted, "turn_end")


### PR DESCRIPTION
Progresses #84.

## Scope

- extend the existing query-local `toolBlockState` with private execution knowledge: unknown, not-started, attempt-started, outcome-observed, and indeterminate;
- mark a returned running attempt indeterminate only when root cancellation causes the legacy handler outcome to be overwritten;
- keep unstarted accepted siblings explicitly not-started;
- validate that terminal running calls have observed or indeterminate knowledge;
- expose the final private shadow state only to a package-private test observer so runtime wiring is mutation-tested.

`outcome_observed` means only that the SDK retained a return/error/panic outcome. It does not claim an external side effect was applied or not applied.

## Non-goals

No Tool Result/history/event/accounting/provider payload changes; no public API or persistence; no single writer; no scheduler/concurrency; no Frame/EventEnvelope projection. A context-ignoring handler that never returns remains outside this slice.

## Local verification

Exact base: `bee696f7113e0f58102985dfabe17bf9cb08c587`
Exact head: `72d46333b9c44c3635b34e08209fa96e944ccc86`

- focused state/cancellation tests x100
- focused state/cancellation race x20
- `go test ./... -count=1`
- `go vet ./...`
- `go test -race ./sdk/agent -count=1`
- `BenchmarkToolBlockShadowLifecycle` x10: 2 allocs/op, 432 B/op (baseline 368 B/op; +64 B for eight ordinal knowledge fields)
- `git diff --check`

Independent exact-head review is required before merge.