### PR TITLE
agent: shadow repeated-signature interventions

### DIFF
--- a/sdk/agent/agent.go
+++ b/sdk/agent/agent.go
@@ -171,6 +171,8 @@ type Agent struct {
 	compactionShadowObserved    func()
 	toolBlockStateObserved      func(*toolBlockState)
 
+	repeatInterventionShadowObserved func(interventionDecision, interventionDecision)
+
 	tools             []tools.Tool
 	toolMap           map[string]tools.Tool
 	toolMapNormalized map[string]tools.Tool
@@ -1252,7 +1254,12 @@ func (a *Agent) queryStreamWithSteering(ctx context.Context, input llm.Content, 
 				if repeatGuard != nil && !evidenceTool {
 					signature := normalizeToolSignature(resolvedName, norm.Normalized, execArgs)
 					seen, blocked := repeatGuard.observe(signature)
-					if blocked && repeatGuard.exhausted && !a.lastResultForSignatureIsRecycled(signature) {
+					detected := blocked
+					lastResultRecycled := false
+					if blocked && repeatGuard.exhausted {
+						lastResultRecycled = a.lastResultForSignatureIsRecycled(signature)
+					}
+					if blocked && repeatGuard.exhausted && !lastResultRecycled {
 						// In downgraded mode the guard only keeps intercepting the
 						// pathological subclass (re-issuing a call whose previous
 						// result is a known recycled placeholder — which can never
@@ -1260,6 +1267,26 @@ func (a *Agent) queryStreamWithSteering(ctx context.Context, input llm.Content, 
 						// re-reads after compaction, are allowed through.
 						blocked = false
 					}
+					reminderConfigured := blocked && strings.TrimSpace(a.loopGuardUserMsg) != ""
+					legacyAction := interventionActionProceed
+					if blocked {
+						legacyAction = interventionActionSuppressTool
+					}
+					legacyDecision := interventionDecision{
+						detection:      interventionDetection{kind: interventionKindRepeatedSignature, active: detected},
+						action:         legacyAction,
+						queueReminder:  blocked && (repeatGuard.exhausted || reminderConfigured),
+						downgradeGuard: blocked && !repeatGuard.exhausted && a.loopGuardStrikeMax > 0 && loopGuardStrikes+1 >= a.loopGuardStrikeMax,
+					}
+					a.observeRepeatedSignatureIntervention(legacyDecision, shadowRepeatedSignatureIntervention(repeatedSignatureObservation{
+						count:              seen,
+						threshold:          repeatGuard.threshold,
+						exhausted:          repeatGuard.exhausted,
+						lastResultRecycled: lastResultRecycled,
+						reminderConfigured: reminderConfigured,
+						nextStrike:         loopGuardStrikes + 1,
+						strikeLimit:        a.loopGuardStrikeMax,
+					}))
 					if blocked {
 						loopGuardStrikes++
 						a.appendLoopGuardSkippedToolResult(tc, resolvedName)

--- a/sdk/agent/agent.go
+++ b/sdk/agent/agent.go
@@ -171,7 +171,9 @@ type Agent struct {
 	compactionShadowObserved    func()
 	toolBlockStateObserved      func(*toolBlockState)
 
-	repeatInterventionShadowObserved func(interventionDecision, interventionDecision)
+	repeatInterventionShadowObserved  func(interventionDecision, interventionDecision)
+	repeatInterventionShadowEvaluator func(repeatedSignatureObservation) interventionDecision
+	repeatResultRecycled              func(string) bool
 
 	tools             []tools.Tool
 	toolMap           map[string]tools.Tool
@@ -1257,7 +1259,11 @@ func (a *Agent) queryStreamWithSteering(ctx context.Context, input llm.Content, 
 					detected := blocked
 					lastResultRecycled := false
 					if blocked && repeatGuard.exhausted {
-						lastResultRecycled = a.lastResultForSignatureIsRecycled(signature)
+						if a.repeatResultRecycled != nil {
+							lastResultRecycled = a.repeatResultRecycled(signature)
+						} else {
+							lastResultRecycled = a.lastResultForSignatureIsRecycled(signature)
+						}
 					}
 					if blocked && repeatGuard.exhausted && !lastResultRecycled {
 						// In downgraded mode the guard only keeps intercepting the
@@ -1278,7 +1284,7 @@ func (a *Agent) queryStreamWithSteering(ctx context.Context, input llm.Content, 
 						queueReminder:  blocked && (repeatGuard.exhausted || reminderConfigured),
 						downgradeGuard: blocked && !repeatGuard.exhausted && a.loopGuardStrikeMax > 0 && loopGuardStrikes+1 >= a.loopGuardStrikeMax,
 					}
-					a.observeRepeatedSignatureIntervention(legacyDecision, shadowRepeatedSignatureIntervention(repeatedSignatureObservation{
+					observation := repeatedSignatureObservation{
 						count:              seen,
 						threshold:          repeatGuard.threshold,
 						exhausted:          repeatGuard.exhausted,
@@ -1286,7 +1292,12 @@ func (a *Agent) queryStreamWithSteering(ctx context.Context, input llm.Content, 
 						reminderConfigured: reminderConfigured,
 						nextStrike:         loopGuardStrikes + 1,
 						strikeLimit:        a.loopGuardStrikeMax,
-					}))
+					}
+					shadowDecision := shadowRepeatedSignatureIntervention(observation)
+					if a.repeatInterventionShadowEvaluator != nil {
+						shadowDecision = a.repeatInterventionShadowEvaluator(observation)
+					}
+					a.observeRepeatedSignatureIntervention(legacyDecision, shadowDecision)
 					if blocked {
 						loopGuardStrikes++
 						a.appendLoopGuardSkippedToolResult(tc, resolvedName)

--- a/sdk/agent/intervention_shadow.go
+++ b/sdk/agent/intervention_shadow.go
@@ -1,0 +1,88 @@
+package agent
+
+type interventionKind uint8
+type interventionAction uint8
+
+const (
+	interventionKindUnknown interventionKind = iota
+	interventionKindRepeatedSignature
+
+	interventionActionProceed interventionAction = iota
+	interventionActionSuppressTool
+)
+
+type interventionDetection struct {
+	kind   interventionKind
+	active bool
+}
+
+type interventionDecision struct {
+	detection      interventionDetection
+	action         interventionAction
+	queueReminder  bool
+	downgradeGuard bool
+}
+
+type repeatedSignatureObservation struct {
+	count              int
+	threshold          int
+	exhausted          bool
+	lastResultRecycled bool
+	reminderConfigured bool
+	nextStrike         int
+	strikeLimit        int
+}
+
+func shadowRepeatedSignatureIntervention(observation repeatedSignatureObservation) interventionDecision {
+	detected := observation.threshold > 0 && observation.count >= observation.threshold
+	suppress := detected && (!observation.exhausted || observation.lastResultRecycled)
+	action := interventionActionProceed
+	if suppress {
+		action = interventionActionSuppressTool
+	}
+	return interventionDecision{
+		detection:      interventionDetection{kind: interventionKindRepeatedSignature, active: detected},
+		action:         action,
+		queueReminder:  suppress && (observation.exhausted || observation.reminderConfigured),
+		downgradeGuard: suppress && !observation.exhausted && observation.strikeLimit > 0 && observation.nextStrike >= observation.strikeLimit,
+	}
+}
+
+func (a *Agent) observeRepeatedSignatureIntervention(legacy, shadow interventionDecision) {
+	if a.repeatInterventionShadowObserved != nil {
+		a.repeatInterventionShadowObserved(legacy, shadow)
+	}
+	if legacy == shadow {
+		return
+	}
+	a.warnf(
+		"agent: repeated-signature intervention shadow mismatch: legacy_kind=%s shadow_kind=%s legacy_detected=%t shadow_detected=%t legacy_action=%s shadow_action=%s legacy_reminder=%t shadow_reminder=%t legacy_downgrade=%t shadow_downgrade=%t",
+		safeInterventionKind(legacy.detection.kind),
+		safeInterventionKind(shadow.detection.kind),
+		legacy.detection.active,
+		shadow.detection.active,
+		safeInterventionAction(legacy.action),
+		safeInterventionAction(shadow.action),
+		legacy.queueReminder,
+		shadow.queueReminder,
+		legacy.downgradeGuard,
+		shadow.downgradeGuard,
+	)
+}
+
+func safeInterventionKind(kind interventionKind) string {
+	if kind == interventionKindRepeatedSignature {
+		return "repeated_signature"
+	}
+	return "unknown"
+}
+
+func safeInterventionAction(action interventionAction) string {
+	if action == interventionActionSuppressTool {
+		return "suppress_tool"
+	}
+	if action == interventionActionProceed {
+		return "proceed"
+	}
+	return "unknown"
+}

--- a/sdk/agent/intervention_shadow_test.go
+++ b/sdk/agent/intervention_shadow_test.go
@@ -3,12 +3,35 @@ package agent
 import (
 	"context"
 	"fmt"
+	"slices"
 	"strings"
 	"testing"
 
 	"github.com/timwhitez/agent-sdk-golang/sdk/llm"
 	"github.com/timwhitez/agent-sdk-golang/sdk/tools"
 )
+
+type repeatedInterventionBoundaryModel struct {
+	calls int
+}
+
+func (m *repeatedInterventionBoundaryModel) Provider() string { return "fixture" }
+func (m *repeatedInterventionBoundaryModel) Model() string    { return "repeat-boundary" }
+func (m *repeatedInterventionBoundaryModel) Invoke(context.Context, llm.InvokeRequest) (*llm.Completion, error) {
+	m.calls++
+	if m.calls <= 4 {
+		return &llm.Completion{StopReason: "tool_calls", ToolCalls: []llm.ToolCall{{
+			ID:       fmt.Sprintf("echo-%d", m.calls),
+			Type:     "function",
+			Function: llm.FunctionCall{Name: "echo", Arguments: `{"text":"repeat"}`},
+		}}}, nil
+	}
+	return &llm.Completion{StopReason: "tool_calls", ToolCalls: []llm.ToolCall{{
+		ID:       "done-5",
+		Type:     "function",
+		Function: llm.FunctionCall{Name: "done", Arguments: `{"message":"finished"}`},
+	}}}, nil
+}
 
 func TestShadowRepeatedSignatureIntervention(t *testing.T) {
 	for _, test := range []struct {
@@ -137,6 +160,110 @@ func TestRepeatedSignatureInterventionSkipsEvidenceTools(t *testing.T) {
 		t.Fatal("evidence tool entered repeated-signature intervention shadow")
 	}
 	collectEvents(agent.QueryStream(context.Background(), llm.TextContent("read")))
+}
+
+func TestRepeatedSignatureInterventionRuntimeBoundaries(t *testing.T) {
+	for _, test := range []struct {
+		name               string
+		recycled           bool
+		wantFourthAction   interventionAction
+		wantFourthReminder bool
+		wantEchoCalls      int
+	}{
+		{name: "exhausted normal proceeds", wantFourthAction: interventionActionProceed, wantEchoCalls: 3},
+		{name: "exhausted recycled suppresses", recycled: true, wantFourthAction: interventionActionSuppressTool, wantFourthReminder: true, wantEchoCalls: 2},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			model := &repeatedInterventionBoundaryModel{}
+			echoCalls := 0
+			echo := tools.Func[struct {
+				Text string `json:"text"`
+			}]("echo", "echo", func(context.Context, struct {
+				Text string `json:"text"`
+			}, *tools.Container) (any, error) {
+				echoCalls++
+				return "ok", nil
+			})
+			done := tools.Func[struct {
+				Message string `json:"message"`
+			}]("done", "done", func(_ context.Context, args struct {
+				Message string `json:"message"`
+			}, _ *tools.Container) (any, error) {
+				return nil, tools.TaskComplete(args.Message)
+			})
+			agent, err := New(Config{
+				LLM:                          model,
+				Tools:                        []tools.Tool{echo, done},
+				MaxIterations:                10,
+				RepeatToolSignatureThreshold: 2,
+				RepeatToolSignatureWindow:    4,
+				LoopGuardStrikeThreshold:     1,
+				LoopGuardUserMessage:         "stop repeating",
+				Warningf:                     failOnToolBlockShadowWarning(t),
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			lookups := 0
+			agent.repeatResultRecycled = func(string) bool {
+				lookups++
+				return test.recycled
+			}
+			var decisions []interventionDecision
+			agent.repeatInterventionShadowObserved = func(legacy, shadow interventionDecision) {
+				if legacy != shadow {
+					t.Errorf("legacy=%#v shadow=%#v", legacy, shadow)
+				}
+				decisions = append(decisions, legacy)
+			}
+			collectEvents(agent.QueryStream(context.Background(), llm.TextContent("loop")))
+			if len(decisions) != 5 || lookups != 1 || echoCalls != test.wantEchoCalls {
+				t.Fatalf("decisions=%d lookups=%d echo_calls=%d want 5/1/%d", len(decisions), lookups, echoCalls, test.wantEchoCalls)
+			}
+			if !decisions[1].downgradeGuard || decisions[1].action != interventionActionSuppressTool {
+				t.Fatalf("strike-boundary decision=%#v", decisions[1])
+			}
+			if decisions[3].action != test.wantFourthAction || decisions[3].queueReminder != test.wantFourthReminder {
+				t.Fatalf("exhausted decision=%#v want action=%v reminder=%t", decisions[3], test.wantFourthAction, test.wantFourthReminder)
+			}
+		})
+	}
+}
+
+func TestRepeatedSignatureInterventionShadowMismatchDoesNotChangeLegacyApplication(t *testing.T) {
+	model := &repeatedInterventionRecordingModel{}
+	agent, echoCalls := newRepeatedInterventionCharacterizationAgent(t, model, 3)
+	agent.repeatInterventionShadowEvaluator = func(observation repeatedSignatureObservation) interventionDecision {
+		decision := shadowRepeatedSignatureIntervention(observation)
+		if decision.action == interventionActionSuppressTool {
+			decision.action = interventionActionProceed
+		}
+		return decision
+	}
+	warnings := 0
+	previousWarningf := agent.warningf
+	agent.warningf = func(format string, args ...any) {
+		if strings.Contains(format, "repeated-signature intervention shadow mismatch") {
+			warnings++
+			return
+		}
+		previousWarningf(format, args...)
+	}
+	events := collectEvents(agent.QueryStream(context.Background(), llm.TextContent("loop")))
+
+	if *echoCalls != 2 || warnings != 1 || len(model.requests) != 4 {
+		t.Fatalf("echo_calls=%d warnings=%d requests=%d want 2/1/4", *echoCalls, warnings, len(model.requests))
+	}
+	want := repeatedInterventionExpectedRequests(true)
+	for i, request := range model.requests {
+		if got := interventionRequestTranscript(request); !slices.Equal(got, want[i]) {
+			t.Fatalf("request[%d] transcript=%#v want %#v", i, got, want[i])
+		}
+	}
+	wantOrder := []string{"hidden", "warn", "step_start", "tool_call", "tool_result", "accounting", "step_complete"}
+	if got := repeatedInterventionEventOrder(events, "call-3"); !slices.Equal(got, wantOrder) {
+		t.Fatalf("event order=%v want %v", got, wantOrder)
+	}
 }
 
 var benchmarkInterventionDecision interventionDecision

--- a/sdk/agent/intervention_shadow_test.go
+++ b/sdk/agent/intervention_shadow_test.go
@@ -1,0 +1,155 @@
+package agent
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/timwhitez/agent-sdk-golang/sdk/llm"
+	"github.com/timwhitez/agent-sdk-golang/sdk/tools"
+)
+
+func TestShadowRepeatedSignatureIntervention(t *testing.T) {
+	for _, test := range []struct {
+		name        string
+		observation repeatedSignatureObservation
+		want        interventionDecision
+	}{
+		{
+			name:        "below threshold",
+			observation: repeatedSignatureObservation{count: 2, threshold: 3, reminderConfigured: true, nextStrike: 1, strikeLimit: 2},
+			want:        interventionDecision{detection: interventionDetection{kind: interventionKindRepeatedSignature}, action: interventionActionProceed},
+		},
+		{
+			name:        "threshold with reminder",
+			observation: repeatedSignatureObservation{count: 3, threshold: 3, reminderConfigured: true, nextStrike: 1, strikeLimit: 2},
+			want:        interventionDecision{detection: interventionDetection{kind: interventionKindRepeatedSignature, active: true}, action: interventionActionSuppressTool, queueReminder: true},
+		},
+		{
+			name:        "threshold without reminder",
+			observation: repeatedSignatureObservation{count: 3, threshold: 3, nextStrike: 1, strikeLimit: 2},
+			want:        interventionDecision{detection: interventionDetection{kind: interventionKindRepeatedSignature, active: true}, action: interventionActionSuppressTool},
+		},
+		{
+			name:        "exhausted normal repeat proceeds",
+			observation: repeatedSignatureObservation{count: 3, threshold: 3, exhausted: true, reminderConfigured: true, nextStrike: 2, strikeLimit: 2},
+			want:        interventionDecision{detection: interventionDetection{kind: interventionKindRepeatedSignature, active: true}, action: interventionActionProceed},
+		},
+		{
+			name:        "exhausted recycled repeat is suppressed",
+			observation: repeatedSignatureObservation{count: 3, threshold: 3, exhausted: true, lastResultRecycled: true, nextStrike: 2, strikeLimit: 2},
+			want:        interventionDecision{detection: interventionDetection{kind: interventionKindRepeatedSignature, active: true}, action: interventionActionSuppressTool, queueReminder: true},
+		},
+		{
+			name:        "strike boundary downgrades",
+			observation: repeatedSignatureObservation{count: 3, threshold: 3, reminderConfigured: true, nextStrike: 2, strikeLimit: 2},
+			want:        interventionDecision{detection: interventionDetection{kind: interventionKindRepeatedSignature, active: true}, action: interventionActionSuppressTool, queueReminder: true, downgradeGuard: true},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			if got := shadowRepeatedSignatureIntervention(test.observation); got != test.want {
+				t.Fatalf("decision=%#v want %#v", got, test.want)
+			}
+		})
+	}
+}
+
+func TestObserveRepeatedSignatureInterventionComparesEveryFieldSafely(t *testing.T) {
+	legacy := interventionDecision{
+		detection:      interventionDetection{kind: interventionKindRepeatedSignature, active: true},
+		action:         interventionActionSuppressTool,
+		queueReminder:  true,
+		downgradeGuard: true,
+	}
+	for _, test := range []struct {
+		name         string
+		shadow       interventionDecision
+		wantWarnings int
+	}{
+		{name: "equal", shadow: legacy},
+		{name: "kind", shadow: interventionDecision{detection: interventionDetection{active: true}, action: interventionActionSuppressTool, queueReminder: true, downgradeGuard: true}, wantWarnings: 1},
+		{name: "active", shadow: interventionDecision{detection: interventionDetection{kind: interventionKindRepeatedSignature}, action: interventionActionSuppressTool, queueReminder: true, downgradeGuard: true}, wantWarnings: 1},
+		{name: "action", shadow: interventionDecision{detection: interventionDetection{kind: interventionKindRepeatedSignature, active: true}, queueReminder: true, downgradeGuard: true}, wantWarnings: 1},
+		{name: "reminder", shadow: interventionDecision{detection: interventionDetection{kind: interventionKindRepeatedSignature, active: true}, action: interventionActionSuppressTool, downgradeGuard: true}, wantWarnings: 1},
+		{name: "downgrade", shadow: interventionDecision{detection: interventionDetection{kind: interventionKindRepeatedSignature, active: true}, action: interventionActionSuppressTool, queueReminder: true}, wantWarnings: 1},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			observations, warnings := 0, 0
+			agent := &Agent{
+				repeatInterventionShadowObserved: func(interventionDecision, interventionDecision) { observations++ },
+				warningf:                         func(string, ...any) { warnings++ },
+			}
+			agent.observeRepeatedSignatureIntervention(legacy, test.shadow)
+			if observations != 1 || warnings != test.wantWarnings {
+				t.Fatalf("observations=%d warnings=%d want 1/%d", observations, warnings, test.wantWarnings)
+			}
+		})
+	}
+
+	var warning string
+	agent := &Agent{warningf: func(format string, args ...any) { warning = fmt.Sprintf(format, args...) }}
+	agent.observeRepeatedSignatureIntervention(
+		interventionDecision{detection: interventionDetection{kind: interventionKind(255)}, action: interventionAction(255)},
+		legacy,
+	)
+	if !strings.Contains(warning, "legacy_kind=unknown") || !strings.Contains(warning, "legacy_action=unknown") {
+		t.Fatalf("unsafe mismatch warning: %q", warning)
+	}
+}
+
+func TestRepeatedSignatureInterventionRuntimeObservationCounts(t *testing.T) {
+	for _, test := range []struct {
+		name      string
+		model     *repeatedInterventionRecordingModel
+		threshold int
+		want      int
+	}{
+		{name: "enabled", model: &repeatedInterventionRecordingModel{}, threshold: 3, want: 4},
+		{name: "terminal provider failure", model: &repeatedInterventionRecordingModel{failAfterIntervention: true}, threshold: 3, want: 3},
+		{name: "disabled", model: &repeatedInterventionRecordingModel{}, want: 0},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			agent, _ := newRepeatedInterventionCharacterizationAgent(t, test.model, test.threshold)
+			observations := 0
+			agent.repeatInterventionShadowObserved = func(legacy, shadow interventionDecision) {
+				observations++
+				if legacy != shadow {
+					t.Errorf("legacy=%#v shadow=%#v", legacy, shadow)
+				}
+			}
+			collectEvents(agent.QueryStream(context.Background(), llm.TextContent("loop")))
+			if observations != test.want {
+				t.Fatalf("observations=%d want %d", observations, test.want)
+			}
+		})
+	}
+}
+
+func TestRepeatedSignatureInterventionSkipsEvidenceTools(t *testing.T) {
+	model := &cancelBoundaryScriptModel{toolCalls: []llm.ToolCall{cancelBoundaryCall("read-1", "read")}}
+	read := tools.Func[struct{}]("read", "read", func(context.Context, struct{}, *tools.Container) (any, error) { return "ok", nil })
+	agent, err := New(Config{LLM: model, Tools: []tools.Tool{read}, RepeatToolSignatureThreshold: 2})
+	if err != nil {
+		t.Fatal(err)
+	}
+	agent.repeatInterventionShadowObserved = func(interventionDecision, interventionDecision) {
+		t.Fatal("evidence tool entered repeated-signature intervention shadow")
+	}
+	collectEvents(agent.QueryStream(context.Background(), llm.TextContent("read")))
+}
+
+var benchmarkInterventionDecision interventionDecision
+
+func BenchmarkShadowRepeatedSignatureIntervention(b *testing.B) {
+	observation := repeatedSignatureObservation{count: 3, threshold: 3, reminderConfigured: true, nextStrike: 2, strikeLimit: 2}
+	legacy := shadowRepeatedSignatureIntervention(observation)
+	agent := &Agent{warningf: func(string, ...any) {}}
+	b.ReportAllocs()
+	var decision interventionDecision
+	for i := 0; i < b.N; i++ {
+		decision = shadowRepeatedSignatureIntervention(observation)
+		agent.observeRepeatedSignatureIntervention(legacy, decision)
+	}
+	benchmarkInterventionDecision = decision
+}


### PR DESCRIPTION
Progresses #87.

## Scope

- add private typed Detection and Decision shadows for the existing repeated-signature guard only;
- model proceed/suppress-tool, reminder queueing, and guard downgrade from captured scalar facts;
- call stateful signature observation once and cache the existing recycled-result lookup;
- keep legacy `blocked`, strike/reset, history, events, Tool Results, and continuation as the sole behavior authority;
- emit only closed kind/action labels and booleans on mismatch;
- use package-private test seams to cover exhausted/recycled runtime inputs and deliberately divergent shadow decisions.

## Non-goals

No Application type or writer; no Prompt/history/event/provider payload changes; no thresholds or guard behavior changes; no idle, RequireDone, evidence recovery, retry, steering/cancel, compaction, public API, persistence, Frame, or EventEnvelope integration.

## Local verification

Exact base: `d2616fceb7187ac226962a9c9b1379253a7a584f`
Exact head: `82cda0fa9d424896f1a0c6001a385958c86edd1d`

- new shadow/runtime focused tests x100
- existing repeat Provider transcript/event/failure/default/downgrade tests x100
- focused repeat race x20
- `go test ./... -count=1`
- `go vet ./...`
- `go test -race ./sdk/agent -count=1`
- `BenchmarkShadowRepeatedSignatureIntervention` x10: median 4.588 ns/op, 0 B/op, 0 allocs/op
- `git diff --check`

Independent exact-head review is required before merge.