### PR TITLE
agent: observe conservative tool-call plans

### DIFF
--- a/sdk/agent/agent.go
+++ b/sdk/agent/agent.go
@@ -174,6 +174,7 @@ type Agent struct {
 	repeatInterventionShadowObserved  func(interventionDecision, interventionDecision)
 	repeatInterventionShadowEvaluator func(repeatedSignatureObservation) interventionDecision
 	repeatResultRecycled              func(string) bool
+	toolPlanShadowEvaluator           func(toolPlanningObservation) toolCallPlan
 
 	tools             []tools.Tool
 	toolMap           map[string]tools.Tool
@@ -1226,7 +1227,7 @@ func (a *Agent) queryStreamWithSteering(ctx context.Context, input llm.Content, 
 				originalName := tc.Function.Name
 
 				// Resolve tool: exact match → normalized/alias match → fallback
-				tool, resolvedName, found, _ := a.resolveToolByName(tc.Function.Name)
+				tool, resolvedName, found, normalizedAlias := a.resolveToolByName(tc.Function.Name)
 				unknownToolFallback := false
 				execArgs := tc.Function.Arguments
 
@@ -1242,6 +1243,23 @@ func (a *Agent) queryStreamWithSteering(ctx context.Context, input llm.Content, 
 				}
 
 				norm := tools.NormalizeToolArgs(resolvedName, execArgs, tool.Schema)
+				resolution := toolResolutionExact
+				if unknownToolFallback {
+					resolution = toolResolutionUnknownFallback
+				} else if normalizedAlias {
+					resolution = toolResolutionNormalizedAlias
+				}
+				argsState := toolArgsNormalized
+				if norm.Err != nil {
+					argsState = toolArgsInvalid
+				}
+				planningObservation := toolPlanningObservation{ordinal: idx, resolution: resolution, args: argsState}
+				legacyPlan := toolCallPlan{ordinal: idx, class: toolPlanExclusive}
+				shadowPlan := shadowToolCallPlan(planningObservation)
+				if a.toolPlanShadowEvaluator != nil {
+					shadowPlan = a.toolPlanShadowEvaluator(planningObservation)
+				}
+				a.observeToolCallPlan(legacyPlan, shadowPlan)
 				evidenceReq, evidenceTool := newEvidenceRequest(resolvedName, norm.Normalized, execArgs, a.deps)
 				if !strings.EqualFold(strings.TrimSpace(resolvedName), "done") {
 					pendingRequireDoneFinalText = ""

--- a/sdk/agent/tool_plan_shadow.go
+++ b/sdk/agent/tool_plan_shadow.go
@@ -1,0 +1,60 @@
+package agent
+
+type toolPlanClass uint8
+type toolResolutionState uint8
+type toolArgsState uint8
+
+const (
+	toolPlanUnknown toolPlanClass = iota
+	toolPlanExclusive
+)
+
+const (
+	toolResolutionExact toolResolutionState = iota
+	toolResolutionNormalizedAlias
+	toolResolutionUnknownFallback
+)
+
+const (
+	toolArgsNormalized toolArgsState = iota
+	toolArgsInvalid
+)
+
+// toolPlanningObservation intentionally excludes names, arguments, schemas,
+// handlers, and dependency state.
+type toolPlanningObservation struct {
+	ordinal    int
+	resolution toolResolutionState
+	args       toolArgsState
+}
+
+type toolCallPlan struct {
+	ordinal int
+	class   toolPlanClass
+}
+
+// shadowToolCallPlan is observe-only. Without an explicit effect contract,
+// every reached call remains exclusive and the legacy loop stays authoritative.
+func shadowToolCallPlan(observation toolPlanningObservation) toolCallPlan {
+	return toolCallPlan{ordinal: observation.ordinal, class: toolPlanExclusive}
+}
+
+func (a *Agent) observeToolCallPlan(legacy, shadow toolCallPlan) {
+	if legacy == shadow {
+		return
+	}
+	a.warnf(
+		"agent: tool planner shadow mismatch: legacy_ordinal=%d shadow_ordinal=%d legacy_class=%s shadow_class=%s",
+		legacy.ordinal,
+		shadow.ordinal,
+		safeToolPlanClass(legacy.class),
+		safeToolPlanClass(shadow.class),
+	)
+}
+
+func safeToolPlanClass(class toolPlanClass) string {
+	if class == toolPlanExclusive {
+		return "exclusive"
+	}
+	return "unknown"
+}

--- a/sdk/agent/tool_plan_shadow_test.go
+++ b/sdk/agent/tool_plan_shadow_test.go
@@ -1,0 +1,277 @@
+package agent
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"slices"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/timwhitez/agent-sdk-golang/sdk/llm"
+	"github.com/timwhitez/agent-sdk-golang/sdk/tools"
+)
+
+type toolPlanScriptModel struct {
+	calls     int
+	toolCalls []llm.ToolCall
+}
+
+func (m *toolPlanScriptModel) Provider() string { return "fixture" }
+func (m *toolPlanScriptModel) Model() string    { return "tool-plan" }
+func (m *toolPlanScriptModel) Invoke(context.Context, llm.InvokeRequest) (*llm.Completion, error) {
+	m.calls++
+	if m.calls == 1 {
+		return &llm.Completion{StopReason: "tool_calls", ToolCalls: m.toolCalls}, nil
+	}
+	return &llm.Completion{StopReason: "stop", Content: llm.TextContent("finished")}, nil
+}
+
+func TestShadowToolCallPlanDefaultsExclusive(t *testing.T) {
+	for _, observation := range []toolPlanningObservation{
+		{ordinal: 0, resolution: toolResolutionExact, args: toolArgsNormalized},
+		{ordinal: 1, resolution: toolResolutionNormalizedAlias, args: toolArgsNormalized},
+		{ordinal: 2, resolution: toolResolutionUnknownFallback, args: toolArgsInvalid},
+	} {
+		if got, want := shadowToolCallPlan(observation), (toolCallPlan{ordinal: observation.ordinal, class: toolPlanExclusive}); got != want {
+			t.Fatalf("plan=%#v want %#v", got, want)
+		}
+	}
+}
+
+func TestObserveToolCallPlanComparesEveryFieldSafely(t *testing.T) {
+	legacy := toolCallPlan{ordinal: 2, class: toolPlanExclusive}
+	var warnings []string
+	agent := &Agent{warningf: func(format string, args ...any) { warnings = append(warnings, fmt.Sprintf(format, args...)) }}
+	agent.observeToolCallPlan(legacy, legacy)
+	agent.observeToolCallPlan(legacy, toolCallPlan{ordinal: 3, class: toolPlanExclusive})
+	agent.observeToolCallPlan(legacy, toolCallPlan{ordinal: 2, class: toolPlanClass(255)})
+	if len(warnings) != 2 || !strings.Contains(warnings[0], "legacy_ordinal=2 shadow_ordinal=3") || !strings.Contains(warnings[1], "shadow_class=unknown") {
+		t.Fatalf("warnings=%v", warnings)
+	}
+}
+
+func TestToolPlanShadowObservesResolutionWithoutChangingExecution(t *testing.T) {
+	const secret = "secret-tool-or-args-sentinel"
+	call := func(id, name, args string) llm.ToolCall {
+		return llm.ToolCall{ID: id, Type: "function", Function: llm.FunctionCall{Name: name, Arguments: args}}
+	}
+	model := &toolPlanScriptModel{toolCalls: []llm.ToolCall{
+		call("exact-1", "exact", `{}`),
+		call("alias-2", "read", `{}`),
+		call("invalid-3", "batch", `[secret-tool-or-args-sentinel`),
+		call("unknown-4", secret, `{"secret":"secret-tool-or-args-sentinel"}`),
+	}}
+	var starts []string
+	makeTool := func(name string) tools.Tool {
+		return tools.Func[struct{}](name, name, func(context.Context, struct{}, *tools.Container) (any, error) {
+			starts = append(starts, name)
+			return "ok", nil
+		})
+	}
+	agent, err := New(Config{LLM: model, Tools: []tools.Tool{makeTool("exact"), makeTool("read_file"), makeTool("batch")}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var observations []toolPlanningObservation
+	var warnings []string
+	agent.toolPlanShadowEvaluator = func(observation toolPlanningObservation) toolCallPlan {
+		observations = append(observations, observation)
+		return toolCallPlan{ordinal: observation.ordinal, class: toolPlanUnknown}
+	}
+	agent.warningf = func(format string, args ...any) { warnings = append(warnings, fmt.Sprintf(format, args...)) }
+	collectEvents(agent.QueryStream(context.Background(), llm.TextContent("run")))
+
+	wantObservations := []toolPlanningObservation{
+		{ordinal: 0, resolution: toolResolutionExact, args: toolArgsNormalized},
+		{ordinal: 1, resolution: toolResolutionNormalizedAlias, args: toolArgsNormalized},
+		{ordinal: 2, resolution: toolResolutionExact, args: toolArgsInvalid},
+		{ordinal: 3, resolution: toolResolutionUnknownFallback, args: toolArgsNormalized},
+	}
+	if !slices.Equal(observations, wantObservations) || !slices.Equal(starts, []string{"exact", "read_file"}) || model.calls != 2 {
+		t.Fatalf("observations=%#v starts=%v provider_calls=%d", observations, starts, model.calls)
+	}
+	if len(warnings) != 4 {
+		t.Fatalf("warnings=%v want four mismatches", warnings)
+	}
+	for _, warning := range warnings {
+		if !strings.Contains(warning, "tool planner shadow mismatch") || strings.Contains(warning, secret) {
+			t.Fatalf("unsafe mismatch warning: %q", warning)
+		}
+	}
+	toolResults := 0
+	for _, message := range agent.Messages() {
+		if message.Role == llm.RoleTool {
+			toolResults++
+		}
+	}
+	if toolResults != 4 {
+		t.Fatalf("tool results=%d want 4", toolResults)
+	}
+}
+
+func TestToolPlanShadowObservesOnlyReachedMixedBlockCalls(t *testing.T) {
+	starts := map[string]int{}
+	makeTool := func(name string, handler func() (llm.Content, error)) tools.Tool {
+		return tools.Tool{Name: name, Handler: func(context.Context, json.RawMessage, *tools.Container) (llm.Content, error) {
+			starts[name]++
+			return handler()
+		}}
+	}
+	invalid := makeTool("invalid", func() (llm.Content, error) { return llm.TextContent("invalid"), nil })
+	panicTool := makeTool("panic_tool", func() (llm.Content, error) { panic("boom") })
+	errorTool := makeTool("error_tool", func() (llm.Content, error) { return llm.Content{}, errors.New("failed") })
+	done := makeTool("done", func() (llm.Content, error) { return llm.Content{}, tools.TaskComplete("finished") })
+	tail := makeTool("tail_tool", func() (llm.Content, error) { return llm.TextContent("must not run"), nil })
+	agent, err := New(Config{LLM: mixedToolBlockModel{}, Tools: []tools.Tool{invalid, panicTool, errorTool, done, tail}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var observations []toolPlanningObservation
+	agent.toolPlanShadowEvaluator = func(observation toolPlanningObservation) toolCallPlan {
+		observations = append(observations, observation)
+		return shadowToolCallPlan(observation)
+	}
+	collectEvents(agent.QueryStream(context.Background(), llm.TextContent("run")))
+	want := []toolPlanningObservation{
+		{ordinal: 0, resolution: toolResolutionUnknownFallback, args: toolArgsNormalized},
+		{ordinal: 1, resolution: toolResolutionExact, args: toolArgsNormalized},
+		{ordinal: 2, resolution: toolResolutionExact, args: toolArgsNormalized},
+		{ordinal: 3, resolution: toolResolutionExact, args: toolArgsNormalized},
+	}
+	if !slices.Equal(observations, want) || starts["tail_tool"] != 0 {
+		t.Fatalf("observations=%#v tail_starts=%d", observations, starts["tail_tool"])
+	}
+}
+
+func TestToolPlanShadowCancellationAndInvalidBlockBoundaries(t *testing.T) {
+	t.Run("running cancellation", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		model := &runningCancelOutcomeModel{}
+		running := tools.Func[struct{}]("running", "running", func(context.Context, struct{}, *tools.Container) (any, error) {
+			cancel()
+			return "possibly changed", nil
+		})
+		tail := tools.Func[struct{}]("tail", "tail", func(context.Context, struct{}, *tools.Container) (any, error) { return "must not run", nil })
+		agent, err := New(Config{LLM: model, Tools: []tools.Tool{running, tail}})
+		if err != nil {
+			t.Fatal(err)
+		}
+		var ordinals []int
+		agent.toolPlanShadowEvaluator = func(observation toolPlanningObservation) toolCallPlan {
+			ordinals = append(ordinals, observation.ordinal)
+			return shadowToolCallPlan(observation)
+		}
+		collectEvents(agent.QueryStream(ctx, llm.TextContent("run")))
+		if !slices.Equal(ordinals, []int{0}) {
+			t.Fatalf("planned ordinals=%v want [0]", ordinals)
+		}
+	})
+
+	t.Run("cancellation before first call", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		dropped := make(chan struct{})
+		var sawDrop atomic.Bool
+		agent, err := New(Config{
+			LLM:               cancelBeforeToolStartModel{},
+			Tools:             []tools.Tool{tools.Func[struct{}]("mutate", "mutate", func(context.Context, struct{}, *tools.Container) (any, error) { return "must not run", nil })},
+			EventBufferSize:   1,
+			EventSendTimeout:  time.Millisecond,
+			EventDropLogEvery: 1,
+			Warningf: func(format string, _ ...any) {
+				if strings.Contains(format, "dropping agent event") && sawDrop.CompareAndSwap(false, true) {
+					cancel()
+					close(dropped)
+				}
+			},
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		observations := 0
+		agent.toolPlanShadowEvaluator = func(observation toolPlanningObservation) toolCallPlan {
+			observations++
+			return shadowToolCallPlan(observation)
+		}
+		events := agent.QueryStream(ctx, llm.TextContent("run"))
+		select {
+		case <-dropped:
+		case <-time.After(2 * time.Second):
+			t.Fatal("timeout waiting for controlled event drop")
+		}
+		collectEvents(events)
+		if observations != 0 {
+			t.Fatalf("observations=%d want 0", observations)
+		}
+	})
+
+	t.Run("duplicate ids", func(t *testing.T) {
+		model := &cancelBoundaryScriptModel{toolCalls: []llm.ToolCall{cancelBoundaryCall("duplicate", "echo"), cancelBoundaryCall("duplicate", "echo")}}
+		agent, err := New(Config{LLM: model, Tools: []tools.Tool{tools.Func[struct{}]("echo", "echo", func(context.Context, struct{}, *tools.Container) (any, error) { return "must not run", nil })}})
+		if err != nil {
+			t.Fatal(err)
+		}
+		observations := 0
+		agent.toolPlanShadowEvaluator = func(observation toolPlanningObservation) toolCallPlan {
+			observations++
+			return shadowToolCallPlan(observation)
+		}
+		collectEvents(agent.QueryStream(context.Background(), llm.TextContent("run")))
+		if observations != 0 {
+			t.Fatalf("observations=%d want 0", observations)
+		}
+	})
+}
+
+func TestToolPlanShadowObservesBeforeLegacyGuards(t *testing.T) {
+	t.Run("repeat suppression", func(t *testing.T) {
+		agent, _ := newRepeatedInterventionCharacterizationAgent(t, &repeatedInterventionRecordingModel{}, 3)
+		observations := 0
+		agent.toolPlanShadowEvaluator = func(observation toolPlanningObservation) toolCallPlan {
+			observations++
+			return shadowToolCallPlan(observation)
+		}
+		collectEvents(agent.QueryStream(context.Background(), llm.TextContent("loop")))
+		if observations != 4 {
+			t.Fatalf("observations=%d want 4", observations)
+		}
+	})
+
+	t.Run("evidence suppression", func(t *testing.T) {
+		model := &evidenceFixtureModel{}
+		read := tools.Func[evidenceReadArgs]("read", "read", func(context.Context, evidenceReadArgs, *tools.Container) (any, error) { return "same block", nil })
+		readAlias := read
+		readAlias.Name = "read_file"
+		done := tools.Func[evidenceDoneArgs]("done", "done", func(_ context.Context, args evidenceDoneArgs, _ *tools.Container) (any, error) {
+			return nil, tools.TaskComplete(args.Message)
+		})
+		agent, err := New(Config{LLM: model, Tools: []tools.Tool{read, readAlias, done}, MaxIterations: -1, RequireDoneTool: true})
+		if err != nil {
+			t.Fatal(err)
+		}
+		observations := 0
+		agent.toolPlanShadowEvaluator = func(observation toolPlanningObservation) toolCallPlan {
+			observations++
+			return shadowToolCallPlan(observation)
+		}
+		collectEvents(agent.QueryStream(context.Background(), llm.TextContent("inspect")))
+		if observations != 5 {
+			t.Fatalf("observations=%d want 5", observations)
+		}
+	})
+}
+
+var benchmarkToolCallPlan toolCallPlan
+
+func BenchmarkShadowToolCallPlan(b *testing.B) {
+	observation := toolPlanningObservation{ordinal: 3, resolution: toolResolutionUnknownFallback, args: toolArgsInvalid}
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		benchmarkToolCallPlan = shadowToolCallPlan(observation)
+	}
+}

--- a/sdk/agent/tool_plan_shadow_test.go
+++ b/sdk/agent/tool_plan_shadow_test.go
@@ -54,6 +54,36 @@ func TestObserveToolCallPlanComparesEveryFieldSafely(t *testing.T) {
 	}
 }
 
+func TestToolPlanShadowRuntimeDefaultsReadAndBatchToExclusive(t *testing.T) {
+	call := func(id, name string) llm.ToolCall {
+		return llm.ToolCall{ID: id, Type: "function", Function: llm.FunctionCall{Name: name, Arguments: `{}`}}
+	}
+	model := &toolPlanScriptModel{toolCalls: []llm.ToolCall{call("read-1", "read"), call("batch-2", "batch")}}
+	var starts []string
+	makeTool := func(name string) tools.Tool {
+		return tools.Func[struct{}](name, name, func(context.Context, struct{}, *tools.Container) (any, error) {
+			starts = append(starts, name)
+			return "ok", nil
+		})
+	}
+	agent, err := New(Config{
+		LLM:   model,
+		Tools: []tools.Tool{makeTool("read_file"), makeTool("batch")},
+		Warningf: func(format string, args ...any) {
+			if strings.Contains(format, "tool planner shadow mismatch") {
+				t.Errorf("unexpected planner warning: %s", fmt.Sprintf(format, args...))
+			}
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	collectEvents(agent.QueryStream(context.Background(), llm.TextContent("run")))
+	if !slices.Equal(starts, []string{"read_file", "batch"}) || model.calls != 2 {
+		t.Fatalf("starts=%v provider_calls=%d", starts, model.calls)
+	}
+}
+
 func TestToolPlanShadowObservesResolutionWithoutChangingExecution(t *testing.T) {
 	const secret = "secret-tool-or-args-sentinel"
 	call := func(id, name, args string) llm.ToolCall {


### PR DESCRIPTION
Advances #85 without closing the multi-phase issue.

## Scope

- add a package-private per-call shadow planning observation after legacy tool resolution and argument normalization
- classify every reached call as `Exclusive` with its original ordinal
- compare the shadow result with the still-authoritative sequential loop and emit only an allowlisted mismatch warning
- cover exact/alias/fallback resolution, invalid arguments, done/cancel/duplicate-ID boundaries, repeat/evidence suppression, non-authoritative mismatches, and secret-negative diagnostics

## Safety / non-goals

- no production concurrency, waves, batching, traits, conflict keys, or public API
- no tool-name/schema/prompt semantic guessing; observation contains no names, IDs, arguments, schemas, handlers, deps, or context
- no changes to Provider payloads, Tool Results/history/events/accounting, retry, steering, cancellation, compaction, or Goode batch behavior
- the legacy sequential loop remains the sole execution authority
- the first normalization is observational only; `Tool.Execute` still performs the existing second normalization/possible schema-key repair

## Local verification

- `gofmt -w sdk/agent/agent.go sdk/agent/tool_plan_shadow.go sdk/agent/tool_plan_shadow_test.go`
- focused runtime/closure/cancel/guard suite `-count=100`
- `go test ./... -count=1`
- `go vet ./...`
- `go test -race ./sdk/agent -count=1`
- `BenchmarkShadowToolCallPlan -benchmem -count=10`: median about 0.265 ns/op, 0 B/op, 0 allocs/op
- `git diff --check`

Exact base: `3680d808515c1c983b67a9a05ce0dad1effa7a55`
Exact head: `2f5276a14a575c2c5ac0a3ae1706eeda8ec20728`

Independent review approved this head. Eight mutation categories were rejected by tests, including the original read/batch classification survivor. Focused x100, full tests, vet, and agent race passed on this commit.

