### PR TITLE
refactor(agent): centralize Tool Result history closure

### DIFF
--- a/sdk/agent/agent.go
+++ b/sdk/agent/agent.go
@@ -683,6 +683,14 @@ func (a *Agent) queryStreamWithSteering(ctx context.Context, input llm.Content, 
 			emitErr(e, origin)
 		}
 		var activeToolBlock *toolBlockState
+		// All accepted Tool Result history commits pass through this writer.
+		// Event/accounting projection stays at each existing emission boundary.
+		closeToolResults := func(start int, expected toolCallPhase, reason string, messages ...llm.Message) {
+			a.appendMessages(messages)
+			for offset := range messages {
+				activeToolBlock.markTerminal(start+offset, expected, reason)
+			}
+		}
 		finishToolBlock := func() {
 			block := activeToolBlock
 			activeToolBlock = nil
@@ -1216,8 +1224,7 @@ func (a *Agent) queryStreamWithSteering(ctx context.Context, input llm.Content, 
 				if err := ctx.Err(); err != nil {
 					// Close every unstarted tool call before terminating so a later
 					// turn never inherits an unpaired assistant tool-call block.
-					a.appendCancellationSkippedToolResults(comp.ToolCalls[idx:])
-					activeToolBlock.markTerminalRange(idx, toolCallAccepted, "root_cancel_before_start")
+					closeToolResults(idx, toolCallAccepted, "root_cancel_before_start", skippedToolResults(comp.ToolCalls[idx:], toolSkippedByCancellationText)...)
 					a.appendMessages(pendingBlockMessages)
 					pendingBlockMessages = nil
 					emitSDKErr(a.errEvent(err))
@@ -1318,8 +1325,7 @@ func (a *Agent) queryStreamWithSteering(ctx context.Context, input llm.Content, 
 					a.observeRepeatedSignatureIntervention(legacyDecision, shadowDecision)
 					if blocked {
 						loopGuardStrikes++
-						a.appendLoopGuardSkippedToolResult(tc, resolvedName)
-						activeToolBlock.markTerminal(idx, toolCallAccepted, "loop_guard")
+						closeToolResults(idx, toolCallAccepted, "loop_guard", loopGuardSkippedToolResults(tc, resolvedName)...)
 						reminder := strings.TrimSpace(a.loopGuardUserMsg)
 						if repeatGuard.exhausted {
 							// The default reminder can mislead here ("reuse prior
@@ -1400,13 +1406,10 @@ func (a *Agent) queryStreamWithSteering(ctx context.Context, input llm.Content, 
 					decision := progressLedger.preflight(evidenceReq, a.compactionGeneration.Load())
 					if decision.suppress {
 						content := llm.TextContent(decision.content)
-						a.mu.Lock()
-						a.messages = append(a.messages, llm.Message{
+						closeToolResults(idx, toolCallAccepted, "evidence_suppressed", llm.Message{
 							Role: llm.RoleTool, ToolCallID: tc.ID, ToolName: resolvedName,
 							Content: content, IsError: false, Ephemeral: tool.EphemeralKeep > 0,
 						})
-						a.mu.Unlock()
-						activeToolBlock.markTerminal(idx, toolCallAccepted, "evidence_suppressed")
 						suppressedResult := ToolResultEvent{
 							Tool: resolvedName, Result: content.PlainText(), ToolCallID: tc.ID,
 							IsError: false, Metadata: decision.metadata,
@@ -1479,15 +1482,11 @@ func (a *Agent) queryStreamWithSteering(ctx context.Context, input llm.Content, 
 					originalResult := content.PlainText()
 					content, meta = a.applyToolResultTruncation(ctx, content, meta, resolvedName, tc.ID)
 					// append tool message and finish
-					a.mu.Lock()
-					a.messages = append(a.messages, llm.Message{Role: llm.RoleTool, ToolCallID: tc.ID, ToolName: resolvedName, Content: content, IsError: false, Ephemeral: ephemeral})
-					a.mu.Unlock()
-					activeToolBlock.markTerminal(idx, toolCallRunning, "task_complete")
+					closeToolResults(idx, toolCallRunning, "task_complete", llm.Message{Role: llm.RoleTool, ToolCallID: tc.ID, ToolName: resolvedName, Content: content, IsError: false, Ephemeral: ephemeral})
 					a.emitToolResultWithAccounting(out, ToolResultEvent{Tool: resolvedName, Result: content.PlainText(), ToolCallID: tc.ID, IsError: false, Metadata: meta}, originalResult, time.Since(start))
 					a.emitEvent(out, StepCompleteEvent{StepID: tc.ID, Status: status, DurationMS: time.Since(start).Milliseconds()})
 					if err := ctx.Err(); err != nil {
-						a.appendCancellationSkippedToolResults(comp.ToolCalls[idx+1:])
-						activeToolBlock.markTerminalRange(idx+1, toolCallAccepted, "root_cancel_after_task_complete")
+						closeToolResults(idx+1, toolCallAccepted, "root_cancel_after_task_complete", skippedToolResults(comp.ToolCalls[idx+1:], toolSkippedByCancellationText)...)
 						a.appendMessages(pendingBlockMessages)
 						pendingBlockMessages = nil
 						emitSDKErr(a.errEvent(err))
@@ -1497,8 +1496,7 @@ func (a *Agent) queryStreamWithSteering(ctx context.Context, input llm.Content, 
 					// still be closed: a parallel `done` that is not the last
 					// call would otherwise leave tool_use blocks with no result,
 					// making the *next* turn's first provider request invalid.
-					a.appendTurnEndSkippedToolResults(comp.ToolCalls[idx+1:])
-					activeToolBlock.markTerminalRange(idx+1, toolCallAccepted, "task_complete_tail")
+					closeToolResults(idx+1, toolCallAccepted, "task_complete_tail", skippedToolResults(comp.ToolCalls[idx+1:], toolSkippedByTurnEndText)...)
 					a.appendMessages(pendingBlockMessages)
 					pendingBlockMessages = nil
 					if a.hasCompactor {
@@ -1527,10 +1525,7 @@ func (a *Agent) queryStreamWithSteering(ctx context.Context, input llm.Content, 
 				content, meta = a.applyToolResultTruncation(ctx, content, meta, resolvedName, tc.ID)
 
 				// append tool message
-				a.mu.Lock()
-				a.messages = append(a.messages, llm.Message{Role: llm.RoleTool, ToolCallID: tc.ID, ToolName: resolvedName, Content: content, IsError: isError, Ephemeral: ephemeral})
-				a.mu.Unlock()
-				activeToolBlock.markTerminal(idx, toolCallRunning, "handler_return")
+				closeToolResults(idx, toolCallRunning, "handler_return", llm.Message{Role: llm.RoleTool, ToolCallID: tc.ID, ToolName: resolvedName, Content: content, IsError: isError, Ephemeral: ephemeral})
 
 				a.emitToolResultWithAccounting(out, ToolResultEvent{Tool: resolvedName, Result: content.PlainText(), ToolCallID: tc.ID, IsError: isError, Metadata: meta}, originalResult, time.Since(start))
 				a.emitEvent(out, StepCompleteEvent{StepID: tc.ID, Status: status, DurationMS: time.Since(start).Milliseconds()})
@@ -1538,8 +1533,7 @@ func (a *Agent) queryStreamWithSteering(ctx context.Context, input llm.Content, 
 					rootCancelErr = ctx.Err()
 				}
 				if rootCancelErr != nil {
-					a.appendCancellationSkippedToolResults(comp.ToolCalls[idx+1:])
-					activeToolBlock.markTerminalRange(idx+1, toolCallAccepted, "root_cancel_after_handler")
+					closeToolResults(idx+1, toolCallAccepted, "root_cancel_after_handler", skippedToolResults(comp.ToolCalls[idx+1:], toolSkippedByCancellationText)...)
 					a.appendMessages(pendingBlockMessages)
 					pendingBlockMessages = nil
 					emitSDKErr(a.errEvent(rootCancelErr))
@@ -1561,8 +1555,7 @@ func (a *Agent) queryStreamWithSteering(ctx context.Context, input llm.Content, 
 					// *before* the steering text enters history. A user message
 					// between two tool results of the same assistant block makes
 					// the whole conversation permanently unsendable.
-					a.appendSteeringSkippedToolResults(comp.ToolCalls[idx+1:])
-					activeToolBlock.markTerminalRange(idx+1, toolCallAccepted, "steering")
+					closeToolResults(idx+1, toolCallAccepted, "steering", skippedToolResults(comp.ToolCalls[idx+1:], toolSkippedBySteeringText)...)
 					pendingBlockMessages = append(pendingBlockMessages, steeringMessages...)
 					break
 				}
@@ -2472,10 +2465,10 @@ func stopTimerDrain(t *time.Timer) {
 	}
 }
 
-func (a *Agent) appendLoopGuardSkippedToolResult(call llm.ToolCall, currentResolvedName string) {
+func loopGuardSkippedToolResults(call llm.ToolCall, currentResolvedName string) []llm.Message {
 	id := strings.TrimSpace(call.ID)
 	if id == "" {
-		return
+		return nil
 	}
 	content := llm.TextContent("[ERROR] Tool call skipped by loop guard - Repeated identical tool call blocked before execution. Reuse previous results, change arguments, or call done if the task is complete.")
 	name := strings.TrimSpace(currentResolvedName)
@@ -2485,34 +2478,7 @@ func (a *Agent) appendLoopGuardSkippedToolResult(call llm.ToolCall, currentResol
 	if name == "" {
 		name = "unknown"
 	}
-	a.mu.Lock()
-	a.messages = append(a.messages, llm.NewToolMessage(id, name, content, true))
-	a.mu.Unlock()
-}
-
-func (a *Agent) appendSteeringSkippedToolResults(calls []llm.ToolCall) {
-	if a == nil || len(calls) == 0 {
-		return
-	}
-	a.appendMessages(skippedToolResults(calls, toolSkippedBySteeringText))
-}
-
-// appendTurnEndSkippedToolResults closes a tool-call block whose remaining calls
-// were never executed because the turn completed early (e.g. a parallel `done`).
-func (a *Agent) appendTurnEndSkippedToolResults(calls []llm.ToolCall) {
-	if a == nil || len(calls) == 0 {
-		return
-	}
-	a.appendMessages(skippedToolResults(calls, toolSkippedByTurnEndText))
-}
-
-// appendCancellationSkippedToolResults closes a tool-call block whose
-// remaining calls were never executed because the root turn was canceled.
-func (a *Agent) appendCancellationSkippedToolResults(calls []llm.ToolCall) {
-	if a == nil || len(calls) == 0 {
-		return
-	}
-	a.appendMessages(skippedToolResults(calls, toolSkippedByCancellationText))
+	return []llm.Message{llm.NewToolMessage(id, name, content, true)}
 }
 
 const (

--- a/sdk/agent/agent_tool_block_closure_characterization_test.go
+++ b/sdk/agent/agent_tool_block_closure_characterization_test.go
@@ -150,6 +150,69 @@ func TestToolBlockSequentialClosureCharacterization(t *testing.T) {
 	}
 }
 
+func TestToolBlockClosureWriterPreservesSyntheticIDDoneTail(t *testing.T) {
+	model := &cancelBoundaryScriptModel{toolCalls: []llm.ToolCall{
+		cancelBoundaryCall("", "done"), cancelBoundaryCall("", "tail"),
+	}}
+	done := tools.Func[struct{}]("done", "done", func(context.Context, struct{}, *tools.Container) (any, error) {
+		return nil, tools.TaskComplete("finished")
+	})
+	done.EphemeralKeep = 3
+	tail := tools.Func[struct{}]("tail", "tail", func(context.Context, struct{}, *tools.Container) (any, error) {
+		t.Error("unstarted tail ran")
+		return "unexpected", nil
+	})
+	tail.EphemeralKeep = 3
+	ag, err := New(Config{LLM: model, Tools: []tools.Tool{done, tail}, Warningf: failOnToolBlockShadowWarning(t)})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var states []toolCallState
+	ag.toolBlockStateObserved = func(block *toolBlockState) { states = append(states, block.calls...) }
+	events := collectEvents(ag.QueryStream(context.Background(), llm.TextContent("run")))
+	if len(states) != 2 || states[0].terminalCount != 1 || states[1].terminalCount != 1 ||
+		states[0].closure != "task_complete" || states[1].closure != "task_complete_tail" ||
+		states[0].executionKnowledge != toolExecutionOutcomeObserved || states[1].executionKnowledge != toolExecutionNotStarted {
+		t.Fatalf("closure states=%#v", states)
+	}
+	var results []llm.Message
+	for _, message := range ag.Messages() {
+		if message.Role == llm.RoleTool {
+			results = append(results, message)
+		}
+	}
+	if len(results) != 2 {
+		t.Fatalf("results=%#v", results)
+	}
+	if results[0].ToolCallID != "call_0" || results[1].ToolCallID != "call_1" ||
+		results[0].ToolName != "done" || results[1].ToolName != "tail" ||
+		!results[0].Ephemeral || results[1].Ephemeral || results[0].IsError || !results[1].IsError ||
+		results[0].PlainText() != "Task completed: finished" || results[1].PlainText() != toolSkippedByTurnEndText {
+		t.Fatalf("result fields changed: %#v", results)
+	}
+	if _, changed, unexpected := repairToolCallPairsDetailed(ag.Messages()); changed || unexpected {
+		t.Fatal("synthetic-ID block required outbound repair")
+	}
+	for _, event := range events {
+		id := ""
+		switch event := event.(type) {
+		case ToolResultEvent:
+			id = event.ToolCallID
+		case ToolCallEvent:
+			id = event.ToolCallID
+		case AccountingEvent:
+			id = event.ToolCallID
+		case StepStartEvent:
+			id = event.StepID
+		case StepCompleteEvent:
+			id = event.StepID
+		}
+		if id == "call_1" {
+			t.Fatalf("history-only tail gained event: %#v", event)
+		}
+	}
+}
+
 func TestToolBlockShadowAllowsIDsReusedAcrossBlocks(t *testing.T) {
 	model := &reusedToolCallIDAcrossBlocksModel{}
 	echoStarts := 0


### PR DESCRIPTION
## Scope

Advances #84; does not close the multi-phase issue.

Centralizes the nine accepted Tool Result history commits through one query-local writer, preserving append-before-shadow-terminal ordering. Reuses existing message construction and removes redundant append wrappers. Adds synthetic-ID, done-not-last, history flags/text, terminal execution knowledge, and history-only tail regression coverage.

No changes to provider-visible text/payload, execution order, event/accounting/artifact boundaries, persistence, public APIs, or concurrency. Duplicate-completion enforcement and shared terminal-outcome projections remain future slices.

## Local validation at fbea5d836d247edc1d319faae4533d2bc97e9ae2

- gofmt and git diff --check
- focused closure/cancellation/guard characterization tests x100
- go test ./... -count=1
- go vet ./...
- go test -race ./sdk/agent -count=1
- BenchmarkToolBlockShadowLifecycle: five samples, median 722.6 ns/op, 432 B/op, 2 allocs/op; this measures the existing state lifecycle, not an end-to-end speedup.

Go 1.22.12. Independent exact-head review APPROVE: all nine paths checked, full/vet/focused x20 passed and four mutations detected. Initial independent agent race failed on the existing zero-event steering fixture; base reproduces 60 failures in race x1000. Tracked and fixed separately in #107/#108. Subsequent independent same-head agent race single run and x3 passed. See the review comment for evidence; the initial failure is not hidden.
