### PR TITLE
feat(agent): shadow logical requests with execution frames

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -99,7 +99,16 @@ agent_docs/          Detailed architecture/provider/tool/build/test documentatio
 
 ### Configuration
 - Configure behavior via `agent.Config` (LLM, tools, tool choice, compaction, history, dependency context) (`sdk/agent/agent.go:20`)
-- `Agent.New` injects hidden `invalid` fallback tool when absent (`sdk/agent/agent.go:68`, `sdk/tools/invalid.go:15`)
+- Unknown tool dispatch uses a registered `invalid` tool when present, otherwise
+  constructs the internal fallback at dispatch; `Agent.New` does not add it to
+  the advertised tool list (`sdk/agent/agent.go`).
+- A private `executionFrame` shadows each logical request with owned request
+  and resolver schemas plus captured model/handler handles. Legacy invocation
+  and dispatch remain authoritative. Continued arguments can have multiple
+  request sources; the dispatch shadow belongs to the finalizing request.
+  Diagnostics use structural `Warningf` messages only, not a second event path
+  (`sdk/agent/execution_frame.go`). This is not concrete-model snapshotting or
+  proof of mutable handler closure identity.
 
 ### Execution APIs
 - `Query(ctx, text)` for synchronous usage (`sdk/agent/agent.go:159`)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,7 +66,16 @@ agent_docs/          Detailed architecture/provider/tool/build/test documentatio
 
 ### Configuration
 - Configure behavior via `agent.Config` (LLM, tools, tool choice, compaction, history, dependency context) (`sdk/agent/agent.go:20`)
-- `Agent.New` injects hidden `invalid` fallback tool when absent (`sdk/agent/agent.go:68`, `sdk/tools/invalid.go:15`)
+- Unknown tool dispatch uses a registered `invalid` tool when present, otherwise
+  constructs the internal fallback at dispatch; `Agent.New` does not add it to
+  the advertised tool list (`sdk/agent/agent.go`).
+- A private `executionFrame` shadows each logical request with owned request
+  and resolver schemas plus captured model/handler handles. Legacy invocation
+  and dispatch remain authoritative. Continued arguments can have multiple
+  request sources; the dispatch shadow belongs to the finalizing request.
+  Diagnostics use structural `Warningf` messages only, not a second event path
+  (`sdk/agent/execution_frame.go`). This is not concrete-model snapshotting or
+  proof of mutable handler closure identity.
 
 ### Execution APIs
 - `Query(ctx, text)` for synchronous usage (`sdk/agent/agent.go:159`)

--- a/sdk/agent/agent.go
+++ b/sdk/agent/agent.go
@@ -753,14 +753,7 @@ func (a *Agent) queryStreamWithSteering(ctx context.Context, input llm.Content, 
 					requestToolChoice = llm.ToolChoice("required")
 				}
 			}
-			// Steering delivery and request preparation above can synchronously
-			// unblock a host that cancels the root turn. Recheck at the actual
-			// provider-admission boundary, not only at iteration entry.
-			if err := ctx.Err(); err != nil {
-				emitSDKErr(a.errEvent(err))
-				return
-			}
-			comp, streamedText, err := a.invokeCompletionWithRetryAndSteering(ctx, llm.InvokeRequest{
+			request := llm.InvokeRequest{
 				Messages:   messages,
 				Tools:      toolDefs,
 				ToolChoice: requestToolChoice,
@@ -770,7 +763,20 @@ func (a *Agent) queryStreamWithSteering(ctx context.Context, input llm.Content, 
 				// work tool, its follow-up request must stay in the same thinking mode
 				// until done, steering, or turn termination closes the subloop.
 				DisableThinking: requireDoneRecoveryDisableThinkingActive,
-			}, out, steeringCh)
+			}
+			frame, frameErr := newExecutionFrame(a.llm, request, a.toolMap, a.toolMapNormalized)
+			if frameErr != nil {
+				// Clone errors may contain schema data. Keep diagnostics structural.
+				a.warnf("warning: execution frame shadow snapshot unavailable")
+			}
+			a.observeFrameAdvertisement(frame)
+			// Preparation/Warningf can synchronously cancel the root turn.
+			// Keep the final gate immediately before actual provider admission.
+			if err := ctx.Err(); err != nil {
+				emitSDKErr(a.errEvent(err))
+				return
+			}
+			comp, streamedText, err := a.invokeCompletionWithRetryAndSteering(ctx, request, out, steeringCh)
 			if err != nil {
 				// Check for steering interrupt - handle specially
 				var steerErr *llm.SteeringInterruptError
@@ -1221,15 +1227,6 @@ func (a *Agent) queryStreamWithSteering(ctx context.Context, input llm.Content, 
 			activeToolBlock = newToolBlockState(comp.ToolCalls)
 			var pendingBlockMessages []llm.Message
 			for idx, tc := range comp.ToolCalls {
-				if err := ctx.Err(); err != nil {
-					// Close every unstarted tool call before terminating so a later
-					// turn never inherits an unpaired assistant tool-call block.
-					closeToolResults(idx, toolCallAccepted, "root_cancel_before_start", skippedToolResults(comp.ToolCalls[idx:], toolSkippedByCancellationText)...)
-					a.appendMessages(pendingBlockMessages)
-					pendingBlockMessages = nil
-					emitSDKErr(a.errEvent(err))
-					return
-				}
 				step := idx + 1
 				originalName := tc.Function.Name
 
@@ -1249,6 +1246,16 @@ func (a *Agent) queryStreamWithSteering(ctx context.Context, input llm.Content, 
 					}
 				}
 
+				a.observeFrameResolution(frame, idx, originalName, tool, resolvedName, found, normalizedAlias)
+				if err := ctx.Err(); err != nil {
+					// Shadow diagnostics can cancel the root turn synchronously.
+					// Close every unstarted call before any handler can execute.
+					closeToolResults(idx, toolCallAccepted, "root_cancel_before_start", skippedToolResults(comp.ToolCalls[idx:], toolSkippedByCancellationText)...)
+					a.appendMessages(pendingBlockMessages)
+					pendingBlockMessages = nil
+					emitSDKErr(a.errEvent(err))
+					return
+				}
 				norm := tools.NormalizeToolArgs(resolvedName, execArgs, tool.Schema)
 				resolution := toolResolutionExact
 				if unknownToolFallback {

--- a/sdk/agent/execution_frame.go
+++ b/sdk/agent/execution_frame.go
@@ -1,0 +1,85 @@
+package agent
+
+import (
+	"reflect"
+
+	"github.com/timwhitez/agent-sdk-golang/sdk/llm"
+	"github.com/timwhitez/agent-sdk-golang/sdk/tools"
+)
+
+// executionFrame shadows one logical request, not the final provider payload.
+// For continued tool calls it is the finalizing request's dispatch snapshot;
+// the merged arguments may originate from multiple earlier requests.
+// Model/Handler values retain runtime handles, not immutable closure state or
+// a dynamic model wrapper's concrete target. Nothing here is persisted/emitted.
+type executionFrame struct {
+	model      llm.ChatModel
+	request    llm.InvokeRequest
+	exact      map[string]tools.Tool
+	normalized map[string]tools.Tool
+}
+
+func newExecutionFrame(model llm.ChatModel, request llm.InvokeRequest, exact, normalized map[string]tools.Tool) (*executionFrame, error) {
+	owned, err := llm.CloneInvokeRequest(request)
+	if err != nil {
+		return nil, err
+	}
+	cloneRegistry := func(source map[string]tools.Tool) (map[string]tools.Tool, error) {
+		if source == nil {
+			return nil, nil
+		}
+		result := make(map[string]tools.Tool, len(source))
+		for name, tool := range source {
+			cloned, err := llm.CloneInvokeRequest(llm.InvokeRequest{Tools: []llm.ToolDefinition{tool.Definition()}})
+			if err != nil {
+				return nil, err
+			}
+			tool.Schema = cloned.Tools[0].Parameters
+			result[name] = tool
+		}
+		return result, nil
+	}
+	ownedExact, err := cloneRegistry(exact)
+	if err != nil {
+		return nil, err
+	}
+	ownedNormalized, err := cloneRegistry(normalized)
+	if err != nil {
+		return nil, err
+	}
+	return &executionFrame{model: model, request: owned, exact: ownedExact, normalized: ownedNormalized}, nil
+}
+
+func (a *Agent) observeFrameAdvertisement(frame *executionFrame) {
+	if frame == nil {
+		return
+	}
+	for index, definition := range frame.request.Tools {
+		tool, ok := frame.exact[definition.Name]
+		if !ok || tool.Hidden || !reflect.DeepEqual(definition, tool.Definition()) {
+			a.warnf("warning: execution frame shadow mismatch: advertised_tool[%d]", index)
+		}
+	}
+}
+
+func (a *Agent) observeFrameResolution(frame *executionFrame, index int, name string, actual tools.Tool, resolved string, found, alias bool) {
+	if frame == nil {
+		return
+	}
+	expected, expectedName, expectedFound, expectedAlias := resolveToolByName(name, frame.exact, frame.normalized)
+	if !expectedFound {
+		expectedName = "invalid"
+		var ok bool
+		expected, ok = frame.exact["invalid"]
+		if !ok {
+			expected = autoInvalidTool()
+		}
+	}
+	// Functions cannot prove closure identity through comparison. Check only
+	// resolution and metadata; retain the captured Handler for later authority.
+	if expectedName != resolved || expectedFound != found || expectedAlias != alias ||
+		expected.Hidden != actual.Hidden || expected.EphemeralKeep != actual.EphemeralKeep ||
+		(expected.Handler == nil) != (actual.Handler == nil) || !reflect.DeepEqual(expected.Definition(), actual.Definition()) {
+		a.warnf("warning: execution frame shadow mismatch: resolved_tool[%d]", index)
+	}
+}

--- a/sdk/agent/execution_frame_test.go
+++ b/sdk/agent/execution_frame_test.go
@@ -298,6 +298,63 @@ func TestExecutionFrameResolutionDriftKeepsLegacyAuthorityAndCancellation(t *tes
 	}
 }
 
+func TestExecutionFrameRuntimeAdvertisementKeepsRequestAndLegacyAuthority(t *testing.T) {
+	for _, cancelOnWarning := range []bool{false, true} {
+		t.Run(fmt.Sprint(cancelOnWarning), func(t *testing.T) {
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			providerCalls, handlerCalls := 0, 0
+			var warnings []string
+			model := &frameScriptModel{invoke: func(request llm.InvokeRequest) (*llm.Completion, error) {
+				providerCalls++
+				if len(request.Tools) != 1 || request.Tools[0].Description != "private advertised metadata" || request.ToolChoice != "required" {
+					t.Error("shadow altered provider request")
+				}
+				return &llm.Completion{ToolCalls: []llm.ToolCall{{ID: "a", Function: llm.FunctionCall{Name: "work", Arguments: "{}"}}}}, nil
+			}}
+			a, err := New(Config{LLM: model, ToolChoice: "required", Tools: []tools.Tool{{Name: "work", Description: "private advertised metadata", Handler: func(context.Context, json.RawMessage, *tools.Container) (llm.Content, error) {
+				handlerCalls++
+				return llm.Content{}, tools.TaskComplete("legacy result")
+			}}}, Warningf: func(format string, args ...any) {
+				warnings = append(warnings, fmt.Sprintf(format, args...))
+				if cancelOnWarning {
+					cancel()
+				}
+			}})
+			if err != nil {
+				t.Fatal(err)
+			}
+			runtimeTool := a.toolMap["work"]
+			runtimeTool.Description = "private runtime metadata"
+			a.toolMap["work"] = runtimeTool
+			for range a.QueryStream(ctx, llm.TextContent("private prompt")) {
+			}
+			wantCalls := 1
+			if cancelOnWarning {
+				wantCalls = 0
+			}
+			if providerCalls != wantCalls || handlerCalls != wantCalls {
+				t.Fatalf("provider/handler=%d/%d want %d", providerCalls, handlerCalls, wantCalls)
+			}
+			if !reflect.DeepEqual(warnings, []string{"warning: execution frame shadow mismatch: advertised_tool[0]"}) {
+				t.Fatalf("warnings=%v", warnings)
+			}
+			results := 0
+			for _, message := range a.Messages() {
+				if message.Role == llm.RoleTool {
+					results++
+					if message.ToolCallID != "a" || !strings.Contains(message.Content.PlainText(), "legacy result") {
+						t.Error("shadow changed legacy result")
+					}
+				}
+			}
+			if results != wantCalls {
+				t.Fatalf("terminal results=%d want %d", results, wantCalls)
+			}
+		})
+	}
+}
+
 func BenchmarkExecutionFrameSnapshot(b *testing.B) {
 	a, err := New(Config{LLM: historyCloneModel{}, Tools: []tools.Tool{{Name: "read", Schema: map[string]any{"type": "object"}}}})
 	if err != nil {

--- a/sdk/agent/execution_frame_test.go
+++ b/sdk/agent/execution_frame_test.go
@@ -1,0 +1,314 @@
+package agent
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/timwhitez/agent-sdk-golang/sdk/llm"
+	"github.com/timwhitez/agent-sdk-golang/sdk/tools"
+)
+
+type frameScriptModel struct {
+	invoke func(llm.InvokeRequest) (*llm.Completion, error)
+}
+
+func (*frameScriptModel) Provider() string { return "fixture" }
+func (*frameScriptModel) Model() string    { return "frame" }
+func (m *frameScriptModel) Invoke(_ context.Context, req llm.InvokeRequest) (*llm.Completion, error) {
+	return m.invoke(req)
+}
+
+func TestExecutionFrameOwnsRequestAndResolverSchemas(t *testing.T) {
+	request := providerAdmissionRequest()
+	want, err := llm.CloneInvokeRequest(request)
+	if err != nil {
+		t.Fatal(err)
+	}
+	model := &providerAdmissionModel{name: "outer"}
+	handlerCalls := 0
+	tool := tools.Tool{Name: "read_file", Schema: map[string]any{"nested": map[string]any{"value": int64(7)}}, Handler: func(context.Context, json.RawMessage, *tools.Container) (llm.Content, error) {
+		handlerCalls++
+		return llm.TextContent("ok"), nil
+	}}
+	exact := map[string]tools.Tool{tool.Name: tool}
+	normalized := buildNormalizedToolMap(exact, []tools.Tool{tool})
+	frame, err := newExecutionFrame(model, request, exact, normalized)
+	if err != nil {
+		t.Fatal(err)
+	}
+	request.Messages[0].Content.Blocks[0].Text = "changed"
+	request.Tools[1].Parameters["limit"] = int64(999)
+	tool.Schema["nested"].(map[string]any)["value"] = int64(999)
+	delete(exact, tool.Name)
+	delete(normalized, "read")
+	if frame.model != model || !reflect.DeepEqual(frame.request, want) {
+		t.Fatal("frame lost model/request ownership")
+	}
+	for _, registry := range []map[string]tools.Tool{frame.exact, frame.normalized} {
+		for _, owned := range registry {
+			if owned.Schema["nested"].(map[string]any)["value"] != int64(7) {
+				t.Fatal("schema aliased source")
+			}
+		}
+	}
+	resolved, name, found, alias := resolveToolByName("read", frame.exact, frame.normalized)
+	if !found || !alias || name != "read_file" {
+		t.Fatalf("alias result=%q/%v/%v", name, found, alias)
+	}
+	if _, err := resolved.Handler(context.Background(), nil, nil); err != nil || handlerCalls != 1 {
+		t.Fatal("runtime handle not retained")
+	}
+	frame.exact[tool.Name].Schema["nested"].(map[string]any)["value"] = int64(8)
+	if frame.normalized["read"].Schema["nested"].(map[string]any)["value"] != int64(7) {
+		t.Fatal("resolver maps share schema ownership")
+	}
+}
+
+func TestExecutionFrameResolutionCompatibilityAndSafeDiagnostics(t *testing.T) {
+	var warnings []string
+	a, err := New(Config{LLM: historyCloneModel{}, Tools: []tools.Tool{
+		{Name: "read_file", Description: "secret-schema-marker", Handler: func(context.Context, json.RawMessage, *tools.Container) (llm.Content, error) {
+			return llm.TextContent("one"), nil
+		}},
+		{Name: "ReadFile", Hidden: true},
+	}, Warningf: func(format string, args ...any) { warnings = append(warnings, fmt.Sprintf(format, args...)) }})
+	if err != nil {
+		t.Fatal(err)
+	}
+	request := llm.InvokeRequest{Tools: []llm.ToolDefinition{a.tools[0].Definition()}}
+	frame, err := newExecutionFrame(a.llm, request, a.toolMap, a.toolMapNormalized)
+	if err != nil {
+		t.Fatal(err)
+	}
+	a.observeFrameAdvertisement(frame)
+	for i, name := range []string{"read_file", "read", " READ_FILE ", "ReadFile", "invalid", "unknown-secret-name"} {
+		tool, resolved, found, alias := a.resolveToolByName(name)
+		if !found {
+			var ok bool
+			tool, ok = a.toolMap["invalid"]
+			if !ok {
+				tool = autoInvalidTool()
+			}
+			resolved = "invalid"
+		}
+		a.observeFrameResolution(frame, i, name, tool, resolved, found, alias)
+	}
+	// A distinct closure is not comparable identity evidence. Equal metadata
+	// must not generate a false mismatch merely because Handler is non-nil.
+	actual := a.toolMap["read_file"]
+	actual.Handler = func(context.Context, json.RawMessage, *tools.Container) (llm.Content, error) {
+		return llm.TextContent("two"), nil
+	}
+	a.observeFrameResolution(frame, 0, "read_file", actual, "read_file", true, false)
+	registeredFallback := autoInvalidTool()
+	registeredFallback.Description = "registered private fallback"
+	a.toolMap["invalid"] = registeredFallback
+	registeredFrame, err := newExecutionFrame(a.llm, request, a.toolMap, a.toolMapNormalized)
+	if err != nil {
+		t.Fatal(err)
+	}
+	a.observeFrameResolution(registeredFrame, 0, "unknown", registeredFallback, "invalid", false, false)
+	a.observeFrameResolution(registeredFrame, 0, "invalid", registeredFallback, "invalid", true, false)
+	if len(warnings) != 0 {
+		t.Fatalf("false warnings: %v", warnings)
+	}
+	actual.Description = "other-secret-marker"
+	a.observeFrameResolution(frame, 3, "read_file", actual, "read_file", true, false)
+	frame.request.Tools[0].Description = "private-prompt-marker"
+	a.observeFrameAdvertisement(frame)
+	want := []string{"warning: execution frame shadow mismatch: resolved_tool[3]", "warning: execution frame shadow mismatch: advertised_tool[0]"}
+	if !reflect.DeepEqual(warnings, want) {
+		t.Fatalf("unsafe/unexpected diagnostics: %v", warnings)
+	}
+}
+
+func TestExecutionFrameShadowFailureDoesNotTakeAuthority(t *testing.T) {
+	for _, cancelOnWarning := range []bool{false, true} {
+		t.Run(fmt.Sprint(cancelOnWarning), func(t *testing.T) {
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			calls, handled := 0, 0
+			model := &frameScriptModel{invoke: func(req llm.InvokeRequest) (*llm.Completion, error) {
+				calls++
+				if len(req.Tools) != 1 || req.Tools[0].Name != "work" {
+					t.Error("shadow altered provider tools")
+				}
+				return &llm.Completion{ToolCalls: []llm.ToolCall{{ID: "a", Function: llm.FunctionCall{Name: "work", Arguments: "{}"}}}}, nil
+			}}
+			var warnings []string
+			a, err := New(Config{LLM: model, Tools: []tools.Tool{{Name: "work", Handler: func(context.Context, json.RawMessage, *tools.Container) (llm.Content, error) {
+				handled++
+				return llm.Content{}, tools.TaskComplete("legacy result")
+			}}}, Warningf: func(format string, args ...any) {
+				warnings = append(warnings, fmt.Sprintf(format, args...))
+				if cancelOnWarning {
+					cancel()
+				}
+			}})
+			if err != nil {
+				t.Fatal(err)
+			}
+			// Hidden runtime-only corruption cannot affect the old request clone.
+			a.toolMap["hidden"] = tools.Tool{Hidden: true, Schema: map[string]any{"private-marker": func() {}}}
+			for range a.QueryStream(ctx, llm.TextContent("private prompt")) {
+			}
+			wantCalls := 1
+			if cancelOnWarning {
+				wantCalls = 0
+			}
+			if calls != wantCalls || handled != wantCalls {
+				t.Fatalf("provider/handler=%d/%d want %d", calls, handled, wantCalls)
+			}
+			if !reflect.DeepEqual(warnings, []string{"warning: execution frame shadow snapshot unavailable"}) {
+				t.Fatalf("warnings=%v", warnings)
+			}
+		})
+	}
+}
+
+func TestExecutionFrameContinuationUsesFinalizingRequest(t *testing.T) {
+	var a *Agent
+	var warnings []string
+	calls, handled := 0, 0
+	setDescription := func(description string, advertised bool) {
+		tool := a.toolMap["work"]
+		tool.Description = description
+		a.toolMap["work"] = tool
+		a.toolMapNormalized = buildNormalizedToolMap(a.toolMap, a.tools)
+		if advertised {
+			a.tools[0] = tool
+		}
+	}
+	model := &frameScriptModel{invoke: func(req llm.InvokeRequest) (*llm.Completion, error) {
+		calls++
+		if calls == 1 {
+			setDescription("finalizing", true)
+			a.toolChoice = "required"
+			return &llm.Completion{StopReason: "max_tokens", ToolCalls: []llm.ToolCall{{ID: "a", Function: llm.FunctionCall{Name: "work", Arguments: `{"text":`}}}}, nil
+		}
+		if calls != 2 {
+			t.Error("unexpected extra admission")
+		}
+		if req.Tools[0].Description != "finalizing" || req.ToolChoice != "required" {
+			t.Error("finalizing request not refreshed")
+		}
+		// Restore the first frame's metadata. Only the finalizing frame can
+		// detect this drift; dispatch deliberately remains the legacy path.
+		setDescription("initial", false)
+		return &llm.Completion{StopReason: "tool_calls", ToolCalls: []llm.ToolCall{{ID: "a", Function: llm.FunctionCall{Name: "work", Arguments: `"ok"}`}}}}, nil
+	}}
+	var err error
+	a, err = New(Config{LLM: model, ToolChoice: "auto", Tools: []tools.Tool{{Name: "work", Description: "initial", Handler: func(_ context.Context, args json.RawMessage, _ *tools.Container) (llm.Content, error) {
+		handled++
+		if !strings.Contains(string(args), "ok") {
+			t.Errorf("merged args=%s", args)
+		}
+		return llm.Content{}, tools.TaskComplete("legacy result")
+	}}}, Warningf: func(format string, args ...any) { warnings = append(warnings, fmt.Sprintf(format, args...)) }})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for range a.QueryStream(context.Background(), llm.TextContent("continue")) {
+	}
+	if calls != 2 || handled != 1 {
+		t.Fatalf("calls/handled=%d/%d", calls, handled)
+	}
+	var frameWarnings []string
+	for _, warning := range warnings {
+		if strings.Contains(warning, "execution frame") {
+			frameWarnings = append(frameWarnings, warning)
+		}
+	}
+	if !reflect.DeepEqual(frameWarnings, []string{"warning: execution frame shadow mismatch: resolved_tool[0]"}) {
+		t.Fatalf("frame warnings=%v", frameWarnings)
+	}
+	if _, changed, _ := repairToolCallPairsDetailed(a.Messages()); changed {
+		t.Fatal("shadow changed tool pair topology")
+	}
+}
+
+func TestExecutionFrameResolutionDriftKeepsLegacyAuthorityAndCancellation(t *testing.T) {
+	for _, cancelOnWarning := range []bool{false, true} {
+		t.Run(fmt.Sprint(cancelOnWarning), func(t *testing.T) {
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			var a *Agent
+			providerCalls, oldCalls, newCalls := 0, 0, 0
+			var warnings []string
+			model := &frameScriptModel{invoke: func(llm.InvokeRequest) (*llm.Completion, error) {
+				providerCalls++
+				changed := a.toolMap["work"]
+				changed.Description = "private changed definition"
+				changed.Handler = func(context.Context, json.RawMessage, *tools.Container) (llm.Content, error) {
+					newCalls++
+					return llm.Content{}, tools.TaskComplete("new legacy result")
+				}
+				a.toolMap["work"] = changed
+				return &llm.Completion{ToolCalls: []llm.ToolCall{{ID: "a", Function: llm.FunctionCall{Name: "work", Arguments: "{}"}}}}, nil
+			}}
+			var err error
+			a, err = New(Config{LLM: model, Tools: []tools.Tool{{Name: "work", Handler: func(context.Context, json.RawMessage, *tools.Container) (llm.Content, error) {
+				oldCalls++
+				return llm.Content{}, tools.TaskComplete("old shadow result")
+			}}}, Warningf: func(format string, args ...any) {
+				warnings = append(warnings, fmt.Sprintf(format, args...))
+				if cancelOnWarning {
+					cancel()
+				}
+			}})
+			if err != nil {
+				t.Fatal(err)
+			}
+			for range a.QueryStream(ctx, llm.TextContent("run")) {
+			}
+			wantNew := 1
+			if cancelOnWarning {
+				wantNew = 0
+			}
+			if providerCalls != 1 || oldCalls != 0 || newCalls != wantNew {
+				t.Fatalf("provider/old/new calls=%d/%d/%d", providerCalls, oldCalls, newCalls)
+			}
+			if !reflect.DeepEqual(warnings, []string{"warning: execution frame shadow mismatch: resolved_tool[0]"}) {
+				t.Fatalf("warnings=%v", warnings)
+			}
+			results := 0
+			for _, message := range a.Messages() {
+				if message.Role != llm.RoleTool {
+					continue
+				}
+				results++
+				if message.ToolCallID != "a" {
+					t.Error("tool identity changed")
+				}
+				if !cancelOnWarning && !strings.Contains(message.Content.PlainText(), "new legacy result") {
+					t.Error("shadow changed result")
+				}
+				if cancelOnWarning && message.Content.PlainText() != toolSkippedByCancellationText {
+					t.Error("unstarted call not closed as cancellation")
+				}
+			}
+			if results != 1 {
+				t.Fatalf("terminal results=%d", results)
+			}
+		})
+	}
+}
+
+func BenchmarkExecutionFrameSnapshot(b *testing.B) {
+	a, err := New(Config{LLM: historyCloneModel{}, Tools: []tools.Tool{{Name: "read", Schema: map[string]any{"type": "object"}}}})
+	if err != nil {
+		b.Fatal(err)
+	}
+	request := providerAdmissionRequest()
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, err := newExecutionFrame(a.llm, request, a.toolMap, a.toolMapNormalized); err != nil {
+			b.Fatal(err)
+		}
+	}
+}

--- a/sdk/agent/tool_resolve.go
+++ b/sdk/agent/tool_resolve.go
@@ -105,18 +105,22 @@ func pickToolCandidate(candidates []string, toolMap map[string]tools.Tool, normM
 }
 
 func (a *Agent) resolveToolByName(name string) (tools.Tool, string, bool, bool) {
+	return resolveToolByName(name, a.toolMap, a.toolMapNormalized)
+}
+
+func resolveToolByName(name string, exact, normalized map[string]tools.Tool) (tools.Tool, string, bool, bool) {
 	raw := strings.TrimSpace(name)
 	if raw == "" {
 		return tools.Tool{}, "", false, false
 	}
-	if tool, ok := a.toolMap[raw]; ok {
+	if tool, ok := exact[raw]; ok {
 		return tool, raw, true, false
 	}
 	norm := tools.NormalizeToolName(raw)
 	if norm == "" {
 		return tools.Tool{}, "", false, false
 	}
-	if tool, ok := a.toolMapNormalized[norm]; ok {
+	if tool, ok := normalized[norm]; ok {
 		return tool, strings.TrimSpace(tool.Name), true, true
 	}
 	return tools.Tool{}, "", false, false


### PR DESCRIPTION
Advances #83; does not close it.

## Scope

- Private executionFrame owns a cloned SDK logical request and exact/normalized resolver schemas, retaining outer model and handler handles.
- Shared existing resolver implementation; preserve exact/alias/collision/hidden and registered/internal invalid fallback compatibility.
- Observe advertised definitions and dispatch metadata through fixed structural Warningf messages only. No request/schema/raw tool names/results are logged.
- Legacy invoke/dispatch remains authoritative. Continuation dispatch uses the finalizing request snapshot, not a claim that merged arguments have only one request source.
- Warningf may synchronously cancel: actual provider/tool admission gates remain after diagnostics. Tests cover unstarted cancellation closure.
- Correct outdated AGENTS/CLAUDE claim that New injects invalid into its registry.

No FrameID, fingerprint, public API, second event sequence, concrete dynamic-model snapshot, handler closure-identity proof, serializer/Prompt/persistence change or production parallelism. Model/handler closure state and dependency environment remain mutable.

## Tests and cost

Ownership, alias/hidden/fallback, safe diagnostics, clone-failure compatibility, legacy dispatch despite drift, cancellation, continuation finalizing request and repair=0 regressions; focused x100 passes.

Full test/vet/agent race passed at b37d495. Independent review found two surviving runtime-wiring mutations (deleted advertisement observer / empty request capture). Fixed in 1a9d016446a702f3d695397a5b2ae165ac36b9cd with a real QueryStream advertisement/request/legacy-result/cancellation fixture. Final-head author and independent full/vet/agent race/focused x100 passed; independent re-review APPROVE confirmed both mutations are detected. Merged as e5ce39dc1e419b680e4199104e521ad71c5e519a.

Five local microbenchmark samples (Go1.22.12, i9-13900H): existing admission clone median 5871 ns/op, 2240 B/op, 50 allocs/op; new frame constructor median 9964 ns/op, 4688 B/op, 66 allocs/op. These are different operations, not an end-to-end speedup comparison: shadow adds allocation/clone overhead per logical request. Reassess representative registry/history scaling before enabling authority or claiming performance improvements.
