### PR TITLE
fix(agent): discard unaccepted continuation on terminal invoke error

### DIFF
--- a/agent_docs/testing.md
+++ b/agent_docs/testing.md
@@ -20,6 +20,11 @@ This document summarizes recommended test commands and current coverage focus.
 - Anthropic provider: `go test ./sdk/llm/anthropic`
 
 ## Coverage Map (Representative)
+- `agent_continuation_provider_failure_test.go` checks terminal invocation
+  failure after an unaccepted max-token tool block: discard only abandoned
+  ToolCalls/provider state, preserve visible text and earlier completed blocks
+  with reused IDs, retain partial usage/error provenance, invent no tool
+  execution/results/accounting, and leave the next query with zero repairs.
 - `sdk/agent/agent_test.go` - max-token auto-continue metadata emission, overflow-triggered compaction checks, async compaction apply-on-next-turn behavior, structured compaction telemetry, compaction system-message deduplication, tool-call delta merge behavior, and truncation metadata/path persistence (`sdk/agent/agent_test.go:180`, `sdk/agent/agent_test.go:402`, `sdk/agent/agent_test.go:271`, `sdk/agent/agent_test.go:210`, `sdk/agent/agent_test.go:421`)
 - `sdk/accounting/projector_contract_test.go` and
   `sdk/agent/agent_accounting_contract_test.go` cover allowlisted bounded

--- a/sdk/agent/agent.go
+++ b/sdk/agent/agent.go
@@ -849,6 +849,11 @@ func (a *Agent) queryStreamWithSteering(ctx context.Context, input llm.Content, 
 					}
 				}
 
+				// A failed continuation was never accepted for execution. Remove
+				// its staged tool topology before publishing the terminal error.
+				if cont.hasPending() {
+					a.discardContinuationToolCalls(&cont, -1)
+				}
 				// Save partial assistant message if any text was streamed,
 				// so the conversation history reflects what the user saw.
 				if comp != nil && !comp.Content.IsEmpty() {

--- a/sdk/agent/agent_continuation_provider_failure_test.go
+++ b/sdk/agent/agent_continuation_provider_failure_test.go
@@ -1,0 +1,124 @@
+package agent
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/timwhitez/agent-sdk-golang/sdk/llm"
+	"github.com/timwhitez/agent-sdk-golang/sdk/tools"
+)
+
+func TestProviderFailureDiscardsUnacceptedContinuation(t *testing.T) {
+	for _, scenario := range []string{"provider_error", "provider_canceled_live_root", "root_canceled"} {
+		t.Run(scenario, func(t *testing.T) {
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			partial, err := llm.WithProviderState(llm.TextContent("visible partial text"), []llm.ProviderState{{Provider: "fixture", Kind: "partial", Data: json.RawMessage(`{"private":"opaque marker"}`)}})
+			if err != nil {
+				t.Fatal(err)
+			}
+			calls, handled := 0, 0
+			model := &frameScriptModel{invoke: func(request llm.InvokeRequest) (*llm.Completion, error) {
+				calls++
+				switch calls {
+				case 1:
+					return &llm.Completion{Content: partial, StopReason: "max_tokens", ToolCalls: []llm.ToolCall{{ID: "call_0", Function: llm.FunctionCall{Name: "work", Arguments: `{"value":`}}}}, nil
+				case 2:
+					failure := errors.New("fixture provider failure")
+					if scenario == "provider_canceled_live_root" {
+						failure = context.Canceled
+					}
+					if scenario == "root_canceled" {
+						cancel()
+						failure = context.Canceled
+					}
+					return &llm.Completion{Content: llm.TextContent("failed response text"), ResponseID: "failed-response", Usage: &llm.Usage{PromptTokens: 17, CompletionTokens: 3, TotalTokens: 20}}, failure
+				default:
+					return &llm.Completion{Content: llm.TextContent("next turn")}, nil
+				}
+			}}
+			a, err := New(Config{LLM: model, InvokeRetryMaxAttempts: 1, Tools: []tools.Tool{{Name: "work", Handler: func(context.Context, json.RawMessage, *tools.Container) (llm.Content, error) {
+				handled++
+				return llm.TextContent("must not execute"), nil
+			}}}})
+			if err != nil {
+				t.Fatal(err)
+			}
+			// An earlier completed block with the same ID must survive.
+			prior := []llm.Message{
+				{Role: llm.RoleAssistant, Content: partial, ToolCalls: []llm.ToolCall{{ID: "call_0", Function: llm.FunctionCall{Name: "work", Arguments: `{}`}}}},
+				{Role: llm.RoleTool, ToolCallID: "call_0", ToolName: "work", Content: llm.TextContent("prior result")},
+			}
+			a.ReplaceHistory(prior)
+			errorsSeen, usageSeen, accountingSeen := 0, 0, 0
+			for envelope := range a.QueryStreamEnveloped(ctx, llm.TextContent("run")) {
+				switch event := envelope.Event.(type) {
+				case ErrorEvent:
+					errorsSeen++
+					wantOrigin := EventOriginProvider
+					if scenario == "root_canceled" {
+						wantOrigin = EventOriginSDKDriver
+					}
+					if envelope.Origin != wantOrigin {
+						t.Errorf("error origin=%s want %s", envelope.Origin, wantOrigin)
+					}
+				case ToolCallEvent, ToolResultEvent, StepStartEvent, StepCompleteEvent:
+					t.Errorf("unaccepted call emitted %T", event)
+				case UsageEvent:
+					usageSeen++
+					if event.ResponseID != "failed-response" || event.Usage.PromptTokens != 17 || event.Usage.CompletionTokens != 3 {
+						t.Error("partial usage changed")
+					}
+				case AccountingEvent:
+					accountingSeen++
+					if event.ToolCallID != "" || event.ResponseID != "failed-response" {
+						t.Error("invented tool accounting")
+					}
+				}
+			}
+			if calls != 2 || handled != 0 || errorsSeen != 1 {
+				t.Fatalf("calls/handled/errors=%d/%d/%d", calls, handled, errorsSeen)
+			}
+			if scenario != "root_canceled" && (usageSeen != 1 || accountingSeen != 1) {
+				t.Fatalf("usage/accounting=%d/%d", usageSeen, accountingSeen)
+			}
+			history := a.Messages()
+			if len(history) < 2 || !reflect.DeepEqual(history[:2], prior) {
+				t.Fatal("cleanup changed an earlier accepted block with reused IDs")
+			}
+			visible, failedText := false, false
+			for _, message := range history[2:] {
+				if len(message.ToolCalls) != 0 || message.Role == llm.RoleTool {
+					t.Fatal("failed unaccepted continuation retained tool topology")
+				}
+				if strings.Contains(message.Content.PlainText(), "visible partial text") {
+					visible = true
+					if llm.HasProviderState(message.Content) {
+						t.Fatal("abandoned partial retained opaque provider state")
+					}
+				}
+				if strings.Contains(message.Content.PlainText(), "failed response text") {
+					failedText = true
+				}
+			}
+			if !visible || !failedText {
+				t.Fatal("cleanup lost visible text")
+			}
+			if _, changed, _ := repairToolCallPairsDetailed(history); changed {
+				t.Fatal("history requires outbound repair")
+			}
+			for event := range a.QueryStream(context.Background(), llm.TextContent("next")) {
+				if warning, ok := event.(WarnEvent); ok && warning.Kind == "tool_pairing_repaired" {
+					t.Error("next turn required repair")
+				}
+			}
+			if calls != 3 {
+				t.Fatalf("provider calls=%d", calls)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Scope

Closes #110. Prerequisite defect found while auditing #83; this is not the ExecutionFrame authority switch.

On terminal invocation error, discard pending unaccepted continuation tool topology using the existing boundary-aware helper before publishing the error. Preserve visible partial text, failed response text/usage, and earlier completed blocks even when IDs recur. No synthetic Tool Result or execution is introduced.

Recoverable steering/idle paths, Provider serialization, prompts, public API and persistence format are unchanged. This does not claim to fix every possible continuation exit.

## Evidence

- Reproduced on base e5ce39dc1e419b680e4199104e521ad71c5e519a: regression failed because unaccepted tool topology remained in history.
- Final head 93156c626a07b85f7ed023d80ccb003541e06a7a: gofmt, focused regression x100, go test ./... -count=1, go vet ./..., go test -race ./sdk/agent -count=1, git diff --check passed locally (Go 1.22.12).
- Failure injection covers generic provider error, live-root provider cancellation, and root cancellation; validates immediate history pairing, next-query zero repairs, preserved prior opaque state and removed abandoned opaque state.
- No new logging or dependency; no live Provider smoke or performance claim. Benchmark not run for failure-only cleanup.
- Independent exact-head review APPROVE (sdk105_final_review): full test/vet/agent race, continuation/steering/idle focused x20, gofmt/diff-check passed. Removing the cleanup fails all three regression scenarios. No unresolved findings. Logs: /tmp/sdk110-review-gates.log and /tmp/sdk110-review-focused.log.
