### PR TITLE
refactor(agent): bind actual invocation and dispatch to ExecutionFrame

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -102,13 +102,13 @@ agent_docs/          Detailed architecture/provider/tool/build/test documentatio
 - Unknown tool dispatch uses a registered `invalid` tool when present, otherwise
   constructs the internal fallback at dispatch; `Agent.New` does not add it to
   the advertised tool list (`sdk/agent/agent.go`).
-- A private `executionFrame` shadows each logical request with owned request
-  and resolver schemas plus captured model/handler handles. Legacy invocation
-  and dispatch remain authoritative. Continued arguments can have multiple
-  request sources; the dispatch shadow belongs to the finalizing request.
-  Diagnostics use structural `Warningf` messages only, not a second event path
-  (`sdk/agent/execution_frame.go`). This is not concrete-model snapshotting or
-  proof of mutable handler closure identity.
+- A private `executionFrame` owns each logical request and resolver schemas,
+  with captured model/handler handles used by actual invocation and dispatch.
+  Snapshot or structural binding failure terminates before admission with a
+  source-negative SDK-origin error, discarding unaccepted continuation topology.
+  Continued arguments can have multiple request sources; dispatch uses the
+  finalizing request's frame (`sdk/agent/execution_frame.go`). This is not
+  concrete-model snapshotting or proof of mutable handler closure identity.
 
 ### Execution APIs
 - `Query(ctx, text)` for synchronous usage (`sdk/agent/agent.go:159`)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -69,13 +69,13 @@ agent_docs/          Detailed architecture/provider/tool/build/test documentatio
 - Unknown tool dispatch uses a registered `invalid` tool when present, otherwise
   constructs the internal fallback at dispatch; `Agent.New` does not add it to
   the advertised tool list (`sdk/agent/agent.go`).
-- A private `executionFrame` shadows each logical request with owned request
-  and resolver schemas plus captured model/handler handles. Legacy invocation
-  and dispatch remain authoritative. Continued arguments can have multiple
-  request sources; the dispatch shadow belongs to the finalizing request.
-  Diagnostics use structural `Warningf` messages only, not a second event path
-  (`sdk/agent/execution_frame.go`). This is not concrete-model snapshotting or
-  proof of mutable handler closure identity.
+- A private `executionFrame` owns each logical request and resolver schemas,
+  with captured model/handler handles used by actual invocation and dispatch.
+  Snapshot or structural binding failure terminates before admission with a
+  source-negative SDK-origin error, discarding unaccepted continuation topology.
+  Continued arguments can have multiple request sources; dispatch uses the
+  finalizing request's frame (`sdk/agent/execution_frame.go`). This is not
+  concrete-model snapshotting or proof of mutable handler closure identity.
 
 ### Execution APIs
 - `Query(ctx, text)` for synchronous usage (`sdk/agent/agent.go:159`)

--- a/agent_docs/testing.md
+++ b/agent_docs/testing.md
@@ -20,6 +20,14 @@ This document summarizes recommended test commands and current coverage focus.
 - Anthropic provider: `go test ./sdk/llm/anthropic`
 
 ## Coverage Map (Representative)
+- `execution_frame_test.go` validates actual captured-handler dispatch across
+  exact/alias/hidden/registered and internal fallback paths, request ownership
+  across retries, finalizing continuation authority, and fail-closed snapshot
+  or structural binding errors with source-negative SDK provenance. Root
+  cancellation takes priority and unaccepted calls create no Tool Results.
+  Scaling benchmarks measure constructor plus binding checks, not Provider or
+  task success; mutable model wrappers and handler closure state remain outside
+  the snapshot guarantee.
 - `agent_continuation_provider_failure_test.go` checks terminal invocation
   failure after an unaccepted max-token tool block: discard only abandoned
   ToolCalls/provider state, preserve visible text and earlier completed blocks

--- a/sdk/agent/agent.go
+++ b/sdk/agent/agent.go
@@ -765,18 +765,30 @@ func (a *Agent) queryStreamWithSteering(ctx context.Context, input llm.Content, 
 				DisableThinking: requireDoneRecoveryDisableThinkingActive,
 			}
 			frame, frameErr := newExecutionFrame(a.llm, request, a.toolMap, a.toolMapNormalized)
+			frameFailure := ""
 			if frameErr != nil {
 				// Clone errors may contain schema data. Keep diagnostics structural.
-				a.warnf("warning: execution frame shadow snapshot unavailable")
+				frameFailure = "execution frame snapshot unavailable"
+			} else if !frame.validBindings() {
+				frameFailure = "execution frame tool bindings inconsistent"
 			}
-			a.observeFrameAdvertisement(frame)
+			if frameFailure != "" {
+				a.warnf("warning: %s", frameFailure)
+				if cont.hasPending() {
+					a.discardContinuationToolCalls(&cont, -1)
+				}
+			}
 			// Preparation/Warningf can synchronously cancel the root turn.
 			// Keep the final gate immediately before actual provider admission.
 			if err := ctx.Err(); err != nil {
 				emitSDKErr(a.errEvent(err))
 				return
 			}
-			comp, streamedText, err := a.invokeCompletionWithRetryAndSteering(ctx, request, out, steeringCh)
+			if frameFailure != "" {
+				emitSDKErr(ErrorEvent{Kind: "invalid_request", Message: frameFailure + "; rebuild the Agent with consistent, cloneable tool definitions"})
+				return
+			}
+			comp, streamedText, err := a.invokeModelCompletionWithRetryAndSteering(ctx, frame.model, frame.request, out, steeringCh)
 			if err != nil {
 				// Check for steering interrupt - handle specially
 				var steerErr *llm.SteeringInterruptError
@@ -1236,7 +1248,7 @@ func (a *Agent) queryStreamWithSteering(ctx context.Context, input llm.Content, 
 				originalName := tc.Function.Name
 
 				// Resolve tool: exact match → normalized/alias match → fallback
-				tool, resolvedName, found, normalizedAlias := a.resolveToolByName(tc.Function.Name)
+				tool, resolvedName, found, normalizedAlias := resolveToolByName(tc.Function.Name, frame.exact, frame.normalized)
 				unknownToolFallback := false
 				execArgs := tc.Function.Arguments
 
@@ -1244,16 +1256,14 @@ func (a *Agent) queryStreamWithSteering(ctx context.Context, input llm.Content, 
 					unknownToolFallback = true
 					resolvedName = "invalid"
 					execArgs = wrapInvalidToolArgs(originalName, tc.Function.Arguments)
-					if inv, ok := a.toolMap["invalid"]; ok {
+					if inv, ok := frame.exact["invalid"]; ok {
 						tool = inv
 					} else {
 						tool = autoInvalidTool()
 					}
 				}
 
-				a.observeFrameResolution(frame, idx, originalName, tool, resolvedName, found, normalizedAlias)
 				if err := ctx.Err(); err != nil {
-					// Shadow diagnostics can cancel the root turn synchronously.
 					// Close every unstarted call before any handler can execute.
 					closeToolResults(idx, toolCallAccepted, "root_cancel_before_start", skippedToolResults(comp.ToolCalls[idx:], toolSkippedByCancellationText)...)
 					a.appendMessages(pendingBlockMessages)

--- a/sdk/agent/execution_frame.go
+++ b/sdk/agent/execution_frame.go
@@ -7,7 +7,7 @@ import (
 	"github.com/timwhitez/agent-sdk-golang/sdk/tools"
 )
 
-// executionFrame shadows one logical request, not the final provider payload.
+// executionFrame owns one logical request, not the final provider payload.
 // For continued tool calls it is the finalizing request's dispatch snapshot;
 // the merged arguments may originate from multiple earlier requests.
 // Model/Handler values retain runtime handles, not immutable closure state or
@@ -50,36 +50,21 @@ func newExecutionFrame(model llm.ChatModel, request llm.InvokeRequest, exact, no
 	return &executionFrame{model: model, request: owned, exact: ownedExact, normalized: ownedNormalized}, nil
 }
 
-func (a *Agent) observeFrameAdvertisement(frame *executionFrame) {
-	if frame == nil {
-		return
-	}
-	for index, definition := range frame.request.Tools {
+// validBindings checks structural agreement, not mutable closure identity.
+// Hidden tools and the dispatch-time internal invalid fallback remain legal.
+func (frame *executionFrame) validBindings() bool {
+	for _, definition := range frame.request.Tools {
 		tool, ok := frame.exact[definition.Name]
 		if !ok || tool.Hidden || !reflect.DeepEqual(definition, tool.Definition()) {
-			a.warnf("warning: execution frame shadow mismatch: advertised_tool[%d]", index)
+			return false
 		}
 	}
-}
-
-func (a *Agent) observeFrameResolution(frame *executionFrame, index int, name string, actual tools.Tool, resolved string, found, alias bool) {
-	if frame == nil {
-		return
-	}
-	expected, expectedName, expectedFound, expectedAlias := resolveToolByName(name, frame.exact, frame.normalized)
-	if !expectedFound {
-		expectedName = "invalid"
-		var ok bool
-		expected, ok = frame.exact["invalid"]
-		if !ok {
-			expected = autoInvalidTool()
+	for _, normalized := range frame.normalized {
+		exact, ok := frame.exact[normalized.Name]
+		if !ok || normalized.Hidden != exact.Hidden || normalized.EphemeralKeep != exact.EphemeralKeep ||
+			(normalized.Handler == nil) != (exact.Handler == nil) || !reflect.DeepEqual(normalized.Definition(), exact.Definition()) {
+			return false
 		}
 	}
-	// Functions cannot prove closure identity through comparison. Check only
-	// resolution and metadata; retain the captured Handler for later authority.
-	if expectedName != resolved || expectedFound != found || expectedAlias != alias ||
-		expected.Hidden != actual.Hidden || expected.EphemeralKeep != actual.EphemeralKeep ||
-		(expected.Handler == nil) != (actual.Handler == nil) || !reflect.DeepEqual(expected.Definition(), actual.Definition()) {
-		a.warnf("warning: execution frame shadow mismatch: resolved_tool[%d]", index)
-	}
+	return true
 }

--- a/sdk/agent/execution_frame_test.go
+++ b/sdk/agent/execution_frame_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net"
 	"reflect"
 	"strings"
 	"testing"
@@ -68,14 +69,11 @@ func TestExecutionFrameOwnsRequestAndResolverSchemas(t *testing.T) {
 	}
 }
 
-func TestExecutionFrameResolutionCompatibilityAndSafeDiagnostics(t *testing.T) {
-	var warnings []string
+func TestExecutionFrameBindings(t *testing.T) {
 	a, err := New(Config{LLM: historyCloneModel{}, Tools: []tools.Tool{
-		{Name: "read_file", Description: "secret-schema-marker", Handler: func(context.Context, json.RawMessage, *tools.Container) (llm.Content, error) {
-			return llm.TextContent("one"), nil
-		}},
+		{Name: "read_file", Description: "private metadata"},
 		{Name: "ReadFile", Hidden: true},
-	}, Warningf: func(format string, args ...any) { warnings = append(warnings, fmt.Sprintf(format, args...)) }})
+	}})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -84,272 +82,321 @@ func TestExecutionFrameResolutionCompatibilityAndSafeDiagnostics(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	a.observeFrameAdvertisement(frame)
-	for i, name := range []string{"read_file", "read", " READ_FILE ", "ReadFile", "invalid", "unknown-secret-name"} {
-		tool, resolved, found, alias := a.resolveToolByName(name)
-		if !found {
-			var ok bool
-			tool, ok = a.toolMap["invalid"]
-			if !ok {
-				tool = autoInvalidTool()
-			}
-			resolved = "invalid"
+	if !frame.validBindings() {
+		t.Fatal("valid hidden/collision/alias binding rejected")
+	}
+	for _, name := range []string{"read_file", "read", " READ_FILE ", "ReadFile", "unknown", "invalid"} {
+		want, wn, wf, wa := resolveToolByName(name, a.toolMap, a.toolMapNormalized)
+		got, gn, gf, ga := resolveToolByName(name, frame.exact, frame.normalized)
+		if !reflect.DeepEqual(want.Definition(), got.Definition()) || wn != gn || wf != gf || wa != ga {
+			t.Errorf("resolution changed for %q", name)
 		}
-		a.observeFrameResolution(frame, i, name, tool, resolved, found, alias)
 	}
-	// A distinct closure is not comparable identity evidence. Equal metadata
-	// must not generate a false mismatch merely because Handler is non-nil.
-	actual := a.toolMap["read_file"]
-	actual.Handler = func(context.Context, json.RawMessage, *tools.Container) (llm.Content, error) {
-		return llm.TextContent("two"), nil
+	frame.request.Tools[0].Description = "different"
+	if frame.validBindings() {
+		t.Fatal("advertisement mismatch accepted")
 	}
-	a.observeFrameResolution(frame, 0, "read_file", actual, "read_file", true, false)
-	registeredFallback := autoInvalidTool()
-	registeredFallback.Description = "registered private fallback"
-	a.toolMap["invalid"] = registeredFallback
-	registeredFrame, err := newExecutionFrame(a.llm, request, a.toolMap, a.toolMapNormalized)
-	if err != nil {
-		t.Fatal(err)
-	}
-	a.observeFrameResolution(registeredFrame, 0, "unknown", registeredFallback, "invalid", false, false)
-	a.observeFrameResolution(registeredFrame, 0, "invalid", registeredFallback, "invalid", true, false)
-	if len(warnings) != 0 {
-		t.Fatalf("false warnings: %v", warnings)
-	}
-	actual.Description = "other-secret-marker"
-	a.observeFrameResolution(frame, 3, "read_file", actual, "read_file", true, false)
-	frame.request.Tools[0].Description = "private-prompt-marker"
-	a.observeFrameAdvertisement(frame)
-	want := []string{"warning: execution frame shadow mismatch: resolved_tool[3]", "warning: execution frame shadow mismatch: advertised_tool[0]"}
-	if !reflect.DeepEqual(warnings, want) {
-		t.Fatalf("unsafe/unexpected diagnostics: %v", warnings)
+	frame.request.Tools[0] = frame.exact["read_file"].Definition()
+	alias := frame.normalized["read"]
+	alias.Description = "different"
+	frame.normalized["read"] = alias
+	if frame.validBindings() {
+		t.Fatal("normalized binding mismatch accepted")
 	}
 }
 
-func TestExecutionFrameShadowFailureDoesNotTakeAuthority(t *testing.T) {
-	for _, cancelOnWarning := range []bool{false, true} {
-		t.Run(fmt.Sprint(cancelOnWarning), func(t *testing.T) {
-			ctx, cancel := context.WithCancel(context.Background())
-			defer cancel()
-			calls, handled := 0, 0
-			model := &frameScriptModel{invoke: func(req llm.InvokeRequest) (*llm.Completion, error) {
-				calls++
-				if len(req.Tools) != 1 || req.Tools[0].Name != "work" {
-					t.Error("shadow altered provider tools")
+func TestExecutionFrameFailureStopsBeforeAdmission(t *testing.T) {
+	for _, corrupt := range []string{"request", "registry", "advertisement", "normalized"} {
+		for _, cancelOnWarning := range []bool{false, true} {
+			t.Run(fmt.Sprintf("%s/cancel=%v", corrupt, cancelOnWarning), func(t *testing.T) {
+				ctx, cancel := context.WithCancel(context.Background())
+				defer cancel()
+				calls, handled, errorsSeen := 0, 0, 0
+				var warnings []string
+				model := &frameScriptModel{invoke: func(llm.InvokeRequest) (*llm.Completion, error) {
+					calls++
+					return &llm.Completion{Content: llm.TextContent("unexpected")}, nil
+				}}
+				a, err := New(Config{LLM: model, Tools: []tools.Tool{{Name: "work", Handler: func(context.Context, json.RawMessage, *tools.Container) (llm.Content, error) {
+					handled++
+					return llm.Content{}, nil
+				}}}, Warningf: func(format string, args ...any) {
+					warnings = append(warnings, fmt.Sprintf(format, args...))
+					if cancelOnWarning {
+						cancel()
+					}
+				}})
+				if err != nil {
+					t.Fatal(err)
 				}
-				return &llm.Completion{ToolCalls: []llm.ToolCall{{ID: "a", Function: llm.FunctionCall{Name: "work", Arguments: "{}"}}}}, nil
-			}}
-			var warnings []string
-			a, err := New(Config{LLM: model, Tools: []tools.Tool{{Name: "work", Handler: func(context.Context, json.RawMessage, *tools.Container) (llm.Content, error) {
-				handled++
-				return llm.Content{}, tools.TaskComplete("legacy result")
-			}}}, Warningf: func(format string, args ...any) {
-				warnings = append(warnings, fmt.Sprintf(format, args...))
-				if cancelOnWarning {
-					cancel()
+				switch corrupt {
+				case "request":
+					a.tools[0].Schema = map[string]any{"secret-marker": func() {}}
+				case "registry":
+					a.toolMap["hidden"] = tools.Tool{Name: "hidden", Hidden: true, Schema: map[string]any{"secret-marker": func() {}}}
+				case "advertisement":
+					a.tools[0].Description = "secret-marker"
+				case "normalized":
+					tool := a.toolMapNormalized["work"]
+					tool.Description = "secret-marker"
+					a.toolMapNormalized["work"] = tool
 				}
-			}})
-			if err != nil {
-				t.Fatal(err)
-			}
-			// Hidden runtime-only corruption cannot affect the old request clone.
-			a.toolMap["hidden"] = tools.Tool{Hidden: true, Schema: map[string]any{"private-marker": func() {}}}
-			for range a.QueryStream(ctx, llm.TextContent("private prompt")) {
-			}
-			wantCalls := 1
-			if cancelOnWarning {
-				wantCalls = 0
-			}
-			if calls != wantCalls || handled != wantCalls {
-				t.Fatalf("provider/handler=%d/%d want %d", calls, handled, wantCalls)
-			}
-			if !reflect.DeepEqual(warnings, []string{"warning: execution frame shadow snapshot unavailable"}) {
-				t.Fatalf("warnings=%v", warnings)
-			}
-		})
+				for envelope := range a.QueryStreamEnveloped(ctx, llm.TextContent("secret-marker")) {
+					switch event := envelope.Event.(type) {
+					case ErrorEvent:
+						errorsSeen++
+						want := "invalid_request"
+						if cancelOnWarning {
+							want = "canceled"
+						}
+						if event.Kind != want || envelope.Origin != EventOriginSDKDriver || strings.Contains(event.Message, "secret-marker") {
+							t.Errorf("unsafe error or provenance: %#v / %s", event, envelope.Origin)
+						}
+					case ToolCallEvent, ToolResultEvent, StepStartEvent, StepCompleteEvent:
+						t.Errorf("unexpected tool event %T", event)
+					}
+				}
+				if calls != 0 || handled != 0 || errorsSeen != 1 {
+					t.Fatalf("calls/handled/errors=%d/%d/%d", calls, handled, errorsSeen)
+				}
+				wantWarning := "warning: execution frame tool bindings inconsistent"
+				if corrupt == "request" || corrupt == "registry" {
+					wantWarning = "warning: execution frame snapshot unavailable"
+				}
+				if !reflect.DeepEqual(warnings, []string{wantWarning}) {
+					t.Fatalf("warnings=%v", warnings)
+				}
+			})
+		}
 	}
 }
 
-func TestExecutionFrameContinuationUsesFinalizingRequest(t *testing.T) {
+func TestExecutionFrameDispatchUsesCapturedHandlers(t *testing.T) {
+	for _, name := range []string{"work", " WORK ", "read", "hidden", "invalid", "unknown"} {
+		for _, canceled := range []bool{false, true} {
+			t.Run(fmt.Sprintf("%s/cancel=%v", name, canceled), func(t *testing.T) {
+				ctx, cancel := context.WithCancel(context.Background())
+				defer cancel()
+				var a *Agent
+				providerCalls, capturedCalls, replacementCalls := 0, 0, 0
+				captured := func(_ context.Context, args json.RawMessage, _ *tools.Container) (llm.Content, error) {
+					capturedCalls++
+					if name == "unknown" && !strings.Contains(string(args), "unknown") {
+						t.Error("fallback args not wrapped")
+					}
+					return llm.Content{}, tools.TaskComplete("captured result")
+				}
+				model := &frameScriptModel{invoke: func(llm.InvokeRequest) (*llm.Completion, error) {
+					providerCalls++
+					for key, tool := range a.toolMap {
+						tool.Description = "changed"
+						tool.Handler = func(context.Context, json.RawMessage, *tools.Container) (llm.Content, error) {
+							replacementCalls++
+							return llm.Content{}, tools.TaskComplete("replacement result")
+						}
+						a.toolMap[key] = tool
+					}
+					a.toolMapNormalized = buildNormalizedToolMap(a.toolMap, a.tools)
+					if canceled {
+						cancel()
+					}
+					return &llm.Completion{ToolCalls: []llm.ToolCall{{ID: "a", Function: llm.FunctionCall{Name: name, Arguments: "{}"}}}}, nil
+				}}
+				var err error
+				a, err = New(Config{LLM: model, Tools: []tools.Tool{
+					{Name: "work", Handler: captured}, {Name: "read_file", Handler: captured},
+					{Name: "hidden", Hidden: true, Handler: captured}, {Name: "invalid", Hidden: true, Handler: captured},
+				}})
+				if err != nil {
+					t.Fatal(err)
+				}
+				for range a.QueryStream(ctx, llm.TextContent("run")) {
+				}
+				wantCalls := 1
+				if canceled {
+					wantCalls = 0
+				}
+				if providerCalls != 1 || capturedCalls != wantCalls || replacementCalls != 0 {
+					t.Fatalf("provider/captured/replacement=%d/%d/%d", providerCalls, capturedCalls, replacementCalls)
+				}
+				results := 0
+				for _, message := range a.Messages() {
+					if message.Role != llm.RoleTool {
+						continue
+					}
+					results++
+					want := "captured result"
+					if canceled {
+						want = toolSkippedByCancellationText
+					}
+					if message.ToolCallID != "a" || !strings.Contains(message.Content.PlainText(), want) {
+						t.Error("wrong terminal result")
+					}
+				}
+				if results != wantCalls {
+					t.Fatalf("results=%d", results)
+				}
+			})
+		}
+	}
+}
+
+func TestExecutionFrameRetryOwnsLogicalRequest(t *testing.T) {
 	var a *Agent
-	var warnings []string
-	calls, handled := 0, 0
-	setDescription := func(description string, advertised bool) {
-		tool := a.toolMap["work"]
-		tool.Description = description
-		a.toolMap["work"] = tool
-		a.toolMapNormalized = buildNormalizedToolMap(a.toolMap, a.tools)
-		if advertised {
-			a.tools[0] = tool
-		}
-	}
+	calls, replacementCalls := 0, 0
+	replacement := &frameScriptModel{invoke: func(llm.InvokeRequest) (*llm.Completion, error) {
+		replacementCalls++
+		return &llm.Completion{}, nil
+	}}
 	model := &frameScriptModel{invoke: func(req llm.InvokeRequest) (*llm.Completion, error) {
 		calls++
+		if req.Tools[0].Parameters["value"] != int64(7) {
+			t.Error("logical request changed across attempts")
+		}
 		if calls == 1 {
-			setDescription("finalizing", true)
-			a.toolChoice = "required"
-			return &llm.Completion{StopReason: "max_tokens", ToolCalls: []llm.ToolCall{{ID: "a", Function: llm.FunctionCall{Name: "work", Arguments: `{"text":`}}}}, nil
+			a.tools[0].Schema["value"] = int64(99)
+			req.Tools[0].Parameters["value"] = int64(88)
+			a.llm = replacement
+			return nil, &net.DNSError{Err: "fixture timeout", IsTimeout: true}
 		}
-		if calls != 2 {
-			t.Error("unexpected extra admission")
-		}
-		if req.Tools[0].Description != "finalizing" || req.ToolChoice != "required" {
-			t.Error("finalizing request not refreshed")
-		}
-		// Restore the first frame's metadata. Only the finalizing frame can
-		// detect this drift; dispatch deliberately remains the legacy path.
-		setDescription("initial", false)
-		return &llm.Completion{StopReason: "tool_calls", ToolCalls: []llm.ToolCall{{ID: "a", Function: llm.FunctionCall{Name: "work", Arguments: `"ok"}`}}}}, nil
+		return &llm.Completion{Content: llm.TextContent("done")}, nil
 	}}
 	var err error
-	a, err = New(Config{LLM: model, ToolChoice: "auto", Tools: []tools.Tool{{Name: "work", Description: "initial", Handler: func(_ context.Context, args json.RawMessage, _ *tools.Container) (llm.Content, error) {
-		handled++
-		if !strings.Contains(string(args), "ok") {
-			t.Errorf("merged args=%s", args)
-		}
-		return llm.Content{}, tools.TaskComplete("legacy result")
-	}}}, Warningf: func(format string, args ...any) { warnings = append(warnings, fmt.Sprintf(format, args...)) }})
+	a, err = New(Config{LLM: model, InvokeRetryMaxAttempts: 2, Tools: []tools.Tool{{Name: "work", Schema: map[string]any{"value": int64(7)}}}})
 	if err != nil {
 		t.Fatal(err)
 	}
-	for range a.QueryStream(context.Background(), llm.TextContent("continue")) {
+	for range a.QueryStream(context.Background(), llm.TextContent("run")) {
 	}
-	if calls != 2 || handled != 1 {
-		t.Fatalf("calls/handled=%d/%d", calls, handled)
-	}
-	var frameWarnings []string
-	for _, warning := range warnings {
-		if strings.Contains(warning, "execution frame") {
-			frameWarnings = append(frameWarnings, warning)
-		}
-	}
-	if !reflect.DeepEqual(frameWarnings, []string{"warning: execution frame shadow mismatch: resolved_tool[0]"}) {
-		t.Fatalf("frame warnings=%v", frameWarnings)
-	}
-	if _, changed, _ := repairToolCallPairsDetailed(a.Messages()); changed {
-		t.Fatal("shadow changed tool pair topology")
+	if calls != 2 || replacementCalls != 0 {
+		t.Fatalf("calls/replacement=%d/%d", calls, replacementCalls)
 	}
 }
 
-func TestExecutionFrameResolutionDriftKeepsLegacyAuthorityAndCancellation(t *testing.T) {
-	for _, cancelOnWarning := range []bool{false, true} {
-		t.Run(fmt.Sprint(cancelOnWarning), func(t *testing.T) {
-			ctx, cancel := context.WithCancel(context.Background())
-			defer cancel()
+func TestExecutionFrameUnregisteredInvalidStaysInternal(t *testing.T) {
+	var a *Agent
+	calls, injected := 0, 0
+	model := &frameScriptModel{invoke: func(llm.InvokeRequest) (*llm.Completion, error) {
+		calls++
+		if calls == 1 {
+			a.toolMap["invalid"] = tools.Tool{Name: "invalid", Hidden: true, Handler: func(context.Context, json.RawMessage, *tools.Container) (llm.Content, error) {
+				injected++
+				return llm.Content{}, tools.TaskComplete("wrong fallback")
+			}}
+			return &llm.Completion{ToolCalls: []llm.ToolCall{{ID: "a", Function: llm.FunctionCall{Name: "unknown", Arguments: "{}"}}}}, nil
+		}
+		return &llm.Completion{Content: llm.TextContent("done")}, nil
+	}}
+	var err error
+	a, err = New(Config{LLM: model})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for range a.QueryStream(context.Background(), llm.TextContent("run")) {
+	}
+	if calls != 2 || injected != 0 {
+		t.Fatalf("provider/injected=%d/%d", calls, injected)
+	}
+	results := 0
+	for _, message := range a.Messages() {
+		if message.Role == llm.RoleTool {
+			results++
+			if message.ToolCallID != "a" || !message.IsError {
+				t.Error("internal fallback result changed")
+			}
+		}
+	}
+	if results != 1 {
+		t.Fatalf("results=%d", results)
+	}
+}
+
+func TestExecutionFrameContinuationFinalizingAuthority(t *testing.T) {
+	for _, failure := range []string{"none", "snapshot", "binding"} {
+		t.Run(failure, func(t *testing.T) {
 			var a *Agent
-			providerCalls, oldCalls, newCalls := 0, 0, 0
-			var warnings []string
-			model := &frameScriptModel{invoke: func(llm.InvokeRequest) (*llm.Completion, error) {
-				providerCalls++
-				changed := a.toolMap["work"]
-				changed.Description = "private changed definition"
-				changed.Handler = func(context.Context, json.RawMessage, *tools.Container) (llm.Content, error) {
-					newCalls++
-					return llm.Content{}, tools.TaskComplete("new legacy result")
+			calls, first, last, errorsSeen := 0, 0, 0, 0
+			model := &frameScriptModel{invoke: func(req llm.InvokeRequest) (*llm.Completion, error) {
+				calls++
+				if calls == 1 {
+					tool := a.toolMap["work"]
+					tool.Description = "finalizing"
+					tool.Handler = func(_ context.Context, args json.RawMessage, _ *tools.Container) (llm.Content, error) {
+						last++
+						if !strings.Contains(string(args), "ok") {
+							t.Error("merged args lost")
+						}
+						return llm.Content{}, tools.TaskComplete("finalizing")
+					}
+					a.tools[0] = tool
+					a.toolMap["work"] = tool
+					a.toolMapNormalized = buildNormalizedToolMap(a.toolMap, a.tools)
+					a.toolChoice = "required"
+					if failure == "snapshot" {
+						a.tools[0].Schema = map[string]any{"private": func() {}}
+					}
+					if failure == "binding" {
+						a.tools[0].Description = "private"
+					}
+					return &llm.Completion{Content: llm.TextContent("partial visible"), StopReason: "max_tokens", ToolCalls: []llm.ToolCall{{ID: "a", Function: llm.FunctionCall{Name: "work", Arguments: `{"text":`}}}}, nil
 				}
-				a.toolMap["work"] = changed
-				return &llm.Completion{ToolCalls: []llm.ToolCall{{ID: "a", Function: llm.FunctionCall{Name: "work", Arguments: "{}"}}}}, nil
+				if req.Tools[0].Description != "finalizing" || req.ToolChoice != "required" {
+					t.Error("wrong finalizing request")
+				}
+				tool := a.toolMap["work"]
+				tool.Handler = func(context.Context, json.RawMessage, *tools.Container) (llm.Content, error) {
+					first++
+					return llm.Content{}, tools.TaskComplete("wrong")
+				}
+				a.toolMap["work"] = tool
+				return &llm.Completion{ToolCalls: []llm.ToolCall{{ID: "a", Function: llm.FunctionCall{Name: "work", Arguments: `"ok"}`}}}}, nil
 			}}
 			var err error
 			a, err = New(Config{LLM: model, Tools: []tools.Tool{{Name: "work", Handler: func(context.Context, json.RawMessage, *tools.Container) (llm.Content, error) {
-				oldCalls++
-				return llm.Content{}, tools.TaskComplete("old shadow result")
-			}}}, Warningf: func(format string, args ...any) {
-				warnings = append(warnings, fmt.Sprintf(format, args...))
-				if cancelOnWarning {
-					cancel()
-				}
-			}})
+				first++
+				return llm.Content{}, nil
+			}}}})
 			if err != nil {
 				t.Fatal(err)
 			}
-			for range a.QueryStream(ctx, llm.TextContent("run")) {
-			}
-			wantNew := 1
-			if cancelOnWarning {
-				wantNew = 0
-			}
-			if providerCalls != 1 || oldCalls != 0 || newCalls != wantNew {
-				t.Fatalf("provider/old/new calls=%d/%d/%d", providerCalls, oldCalls, newCalls)
-			}
-			if !reflect.DeepEqual(warnings, []string{"warning: execution frame shadow mismatch: resolved_tool[0]"}) {
-				t.Fatalf("warnings=%v", warnings)
-			}
-			results := 0
-			for _, message := range a.Messages() {
-				if message.Role != llm.RoleTool {
-					continue
-				}
-				results++
-				if message.ToolCallID != "a" {
-					t.Error("tool identity changed")
-				}
-				if !cancelOnWarning && !strings.Contains(message.Content.PlainText(), "new legacy result") {
-					t.Error("shadow changed result")
-				}
-				if cancelOnWarning && message.Content.PlainText() != toolSkippedByCancellationText {
-					t.Error("unstarted call not closed as cancellation")
+			for event := range a.QueryStream(context.Background(), llm.TextContent("run")) {
+				if _, ok := event.(ErrorEvent); ok {
+					errorsSeen++
 				}
 			}
-			if results != 1 {
-				t.Fatalf("terminal results=%d", results)
-			}
-		})
-	}
-}
-
-func TestExecutionFrameRuntimeAdvertisementKeepsRequestAndLegacyAuthority(t *testing.T) {
-	for _, cancelOnWarning := range []bool{false, true} {
-		t.Run(fmt.Sprint(cancelOnWarning), func(t *testing.T) {
-			ctx, cancel := context.WithCancel(context.Background())
-			defer cancel()
-			providerCalls, handlerCalls := 0, 0
-			var warnings []string
-			model := &frameScriptModel{invoke: func(request llm.InvokeRequest) (*llm.Completion, error) {
-				providerCalls++
-				if len(request.Tools) != 1 || request.Tools[0].Description != "private advertised metadata" || request.ToolChoice != "required" {
-					t.Error("shadow altered provider request")
+			if failure == "none" {
+				if calls != 2 || first != 0 || last != 1 || errorsSeen != 0 {
+					t.Fatalf("calls/first/last/errors=%d/%d/%d/%d", calls, first, last, errorsSeen)
 				}
-				return &llm.Completion{ToolCalls: []llm.ToolCall{{ID: "a", Function: llm.FunctionCall{Name: "work", Arguments: "{}"}}}}, nil
-			}}
-			a, err := New(Config{LLM: model, ToolChoice: "required", Tools: []tools.Tool{{Name: "work", Description: "private advertised metadata", Handler: func(context.Context, json.RawMessage, *tools.Container) (llm.Content, error) {
-				handlerCalls++
-				return llm.Content{}, tools.TaskComplete("legacy result")
-			}}}, Warningf: func(format string, args ...any) {
-				warnings = append(warnings, fmt.Sprintf(format, args...))
-				if cancelOnWarning {
-					cancel()
+			} else {
+				if calls != 1 || first != 0 || last != 0 || errorsSeen != 1 {
+					t.Fatalf("calls/first/last/errors=%d/%d/%d/%d", calls, first, last, errorsSeen)
 				}
-			}})
-			if err != nil {
-				t.Fatal(err)
-			}
-			runtimeTool := a.toolMap["work"]
-			runtimeTool.Description = "private runtime metadata"
-			a.toolMap["work"] = runtimeTool
-			for range a.QueryStream(ctx, llm.TextContent("private prompt")) {
-			}
-			wantCalls := 1
-			if cancelOnWarning {
-				wantCalls = 0
-			}
-			if providerCalls != wantCalls || handlerCalls != wantCalls {
-				t.Fatalf("provider/handler=%d/%d want %d", providerCalls, handlerCalls, wantCalls)
-			}
-			if !reflect.DeepEqual(warnings, []string{"warning: execution frame shadow mismatch: advertised_tool[0]"}) {
-				t.Fatalf("warnings=%v", warnings)
-			}
-			results := 0
-			for _, message := range a.Messages() {
-				if message.Role == llm.RoleTool {
-					results++
-					if message.ToolCallID != "a" || !strings.Contains(message.Content.PlainText(), "legacy result") {
-						t.Error("shadow changed legacy result")
+				for _, m := range a.Messages() {
+					if len(m.ToolCalls) != 0 || m.Role == llm.RoleTool {
+						t.Fatal("unaccepted continuation survived failure")
 					}
 				}
 			}
-			if results != wantCalls {
-				t.Fatalf("terminal results=%d want %d", results, wantCalls)
+			if _, changed, _ := repairToolCallPairsDetailed(a.Messages()); changed {
+				t.Fatal("history requires repair")
+			}
+			if failure != "none" {
+				// Repair only the injected private registry corruption, not history.
+				a.tools[0] = a.toolMap["work"]
+				nextCalls := 0
+				a.llm = &frameScriptModel{invoke: func(llm.InvokeRequest) (*llm.Completion, error) {
+					nextCalls++
+					return &llm.Completion{Content: llm.TextContent("next")}, nil
+				}}
+				for event := range a.QueryStream(context.Background(), llm.TextContent("next")) {
+					if warning, ok := event.(WarnEvent); ok && warning.Kind == "tool_pairing_repaired" {
+						t.Error("next query needed history repair")
+					}
+				}
+				if nextCalls != 1 {
+					t.Fatalf("next provider calls=%d", nextCalls)
+				}
 			}
 		})
 	}
@@ -367,5 +414,33 @@ func BenchmarkExecutionFrameSnapshot(b *testing.B) {
 		if _, err := newExecutionFrame(a.llm, request, a.toolMap, a.toolMapNormalized); err != nil {
 			b.Fatal(err)
 		}
+	}
+}
+
+func BenchmarkExecutionFrameAdmissionScaling(b *testing.B) {
+	for _, size := range []struct{ tools, messages int }{{1, 1}, {32, 32}, {128, 256}} {
+		b.Run(fmt.Sprintf("tools%d/messages%d", size.tools, size.messages), func(b *testing.B) {
+			registry := make([]tools.Tool, size.tools)
+			request := llm.InvokeRequest{}
+			for i := range registry {
+				registry[i] = tools.Tool{Name: fmt.Sprintf("tool_%d", i), Schema: map[string]any{"type": "object", "properties": map[string]any{"value": map[string]any{"type": "string"}}}}
+				request.Tools = append(request.Tools, registry[i].Definition())
+			}
+			for i := 0; i < size.messages; i++ {
+				request.Messages = append(request.Messages, llm.NewUserMessage(strings.Repeat("fixture ", 128)))
+			}
+			a, err := New(Config{LLM: historyCloneModel{}, Tools: registry})
+			if err != nil {
+				b.Fatal(err)
+			}
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				frame, err := newExecutionFrame(a.llm, request, a.toolMap, a.toolMapNormalized)
+				if err != nil || !frame.validBindings() {
+					b.Fatal("invalid fixture frame")
+				}
+			}
+		})
 	}
 }

--- a/sdk/agent/tool_resolve.go
+++ b/sdk/agent/tool_resolve.go
@@ -104,10 +104,6 @@ func pickToolCandidate(candidates []string, toolMap map[string]tools.Tool, normM
 	return tools.Tool{}, false
 }
 
-func (a *Agent) resolveToolByName(name string) (tools.Tool, string, bool, bool) {
-	return resolveToolByName(name, a.toolMap, a.toolMapNormalized)
-}
-
 func resolveToolByName(name string, exact, normalized map[string]tools.Tool) (tools.Tool, string, bool, bool) {
 	raw := strings.TrimSpace(name)
 	if raw == "" {


### PR DESCRIPTION
## Scope

Advances #83; does not close this multi-phase issue. Based on #111's separately reviewed continuation-error prerequisite.

- Actual framework invocation/retry consumes the private frame's captured model and owned logical request. Existing per-attempt clone and Provider shaping stay in place.
- Accepted Tool Block dispatch resolves exact/normalized/hidden tools and registered invalid fallback from that same frame. Internal invalid remains an unregistered dispatch-time fallback. Remove obsolete resolution shadow and Agent-bound resolver wrapper, not maintain dual dispatch.
- Finalizing continuation request owns dispatch; merged arguments may have multiple request sources.

## Intentional failure semantics

Snapshot failure or structural disagreement between advertised/exact/normalized definitions now fails closed before Provider admission. Emit fixed source-negative SDK-origin invalid_request diagnostics, with root cancellation taking precedence. Discard pending unaccepted continuation topology, without fabricating Tool Results.

This is normal-flow equivalence plus explicit invalid-binding enforcement, not a claim of zero behavior change for corrupted private registries. Function values retain runtime handles; no proof of mutable closure identity or concrete dynamic-model snapshot. No FrameID/lineage/public API, Provider serializer/Prompt/persistence protocol, second event sequence, or production concurrency change.

## Validation

Runtime tests cover captured exact/alias/hidden/registered/internal fallback handlers, request/schema and outer-model ownership across retry, finalizing continuation, snapshot/request/registry/binding failures, safe error origin, cancellation precedence, and next-query zero repair. Existing Provider goldens and ownership/ToolPair/guard/steering/cancellation suites are included in full test.

Local exact head d6c21f2f6cbeccee478d9c8f9d5278a2ec390a07: gofmt/diff-check, full test, vet, agent race, focused x100 passed with Go 1.22.12. Logs /tmp/sdk-frame-authority-final-{focused,full,race}.log.

Five-sample harness medians (ns/op, B/op, allocs/op): existing constructor fixture 5102/4688/66; constructor + binding validation at tools/messages 1/1: 8907/6096/91, 32/32: 269725/154489/2695, 128/256: 1244911/643728/10761. These are cost/scaling observations, not a matched before/after speedup or task/model failure claim.

Independent exact-head review APPROVE (sdk105_final_review): full/vet/agent race, Frame plus accepted-block cancellation focused x100, gofmt/diff-check, five-sample benchmarks passed. All six mutations were detected: original request instead of frame request, live resolver dispatch, live invalid fallback, skipped binding validation, skipped failure exit, and removed continuation cleanup. No unresolved findings. Logs /tmp/sdk112-review-{gates,focused,bench}.log.

Goode preview at main 3aa36c9 with this SDK branch passed full/vet/app-ui-acp-subtask race. No hosted CI or live Provider claim. Accepted-block cancellation remains covered by existing tests; Provider-internal cancellation in the new test intentionally proves pre-acceptance zero results.
