### PR TITLE
feat(llm): attach owned request-local CachePlan intent

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,8 +16,9 @@ and progressive disclosure through `agent_docs/`.
 - Message and tool-call model: `ToolChoice`, `ToolDefinition`, `ToolCall`, `Content`, `Message`, `Completion` (`sdk/llm/types.go:17`, `sdk/llm/types.go:25`, `sdk/llm/types.go:37`, `sdk/llm/types.go:68`, `sdk/llm/types.go:100`, `sdk/llm/types.go:133`)
 - Request-local prompt-cache intent and concrete-client capability types:
   `CachePlan`, `CacheDirective`, `CacheTarget`, `PromptCacheCapabilities`, and
-  `PromptCacheCapabilityProvider` (`sdk/llm/cache_plan.go`). These types are not
-  yet attached to `InvokeRequest` or consumed by Provider serializers.
+  `PromptCacheCapabilityProvider` (`sdk/llm/cache_plan.go`). `InvokeRequest`
+  carries an experimental owned `CachePlan` excluded from JSON; Provider
+  serializers do not yet consume it or enforce its policies.
 - Tool system primitives: `Tool`, `Func`, `SchemaFor`, `SerializeResult` (`sdk/tools/tool.go:15`, `sdk/tools/tool.go:701`, `sdk/tools/schema.go:8`, `sdk/tools/result.go:10`)
 - Tool dependency context and metadata: `Container`, `WithToolCallID`, `WithToolResultMetadata` (`sdk/tools/deps.go:156`, `sdk/tools/deps.go:27`, `sdk/tools/deps.go:56`)
 - Compaction service: `compaction.Service` (`sdk/agent/compaction/service.go:10`)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,8 +16,9 @@ and progressive disclosure through `agent_docs/`.
 - Message and tool-call model: `ToolChoice`, `ToolDefinition`, `ToolCall`, `Content`, `Message`, `Completion` (`sdk/llm/types.go:17`, `sdk/llm/types.go:25`, `sdk/llm/types.go:37`, `sdk/llm/types.go:68`, `sdk/llm/types.go:100`, `sdk/llm/types.go:133`)
 - Request-local prompt-cache intent and concrete-client capability types:
   `CachePlan`, `CacheDirective`, `CacheTarget`, `PromptCacheCapabilities`, and
-  `PromptCacheCapabilityProvider` (`sdk/llm/cache_plan.go`). These types are not
-  yet attached to `InvokeRequest` or consumed by Provider serializers.
+  `PromptCacheCapabilityProvider` (`sdk/llm/cache_plan.go`). `InvokeRequest`
+  carries an experimental owned `CachePlan` excluded from JSON; Provider
+  serializers do not yet consume it or enforce its policies.
 - Tool system primitives: `Tool`, `Func`, `SchemaFor`, `SerializeResult` (`sdk/tools/tool.go:15`, `sdk/tools/tool.go:701`, `sdk/tools/schema.go:8`, `sdk/tools/result.go:10`)
 - Tool dependency context and metadata: `Container`, `WithToolCallID`, `WithToolResultMetadata` (`sdk/tools/deps.go:156`, `sdk/tools/deps.go:27`, `sdk/tools/deps.go:56`)
 - Compaction service: `compaction.Service` (`sdk/agent/compaction/service.go:10`)

--- a/agent_docs/providers.md
+++ b/agent_docs/providers.md
@@ -4,6 +4,15 @@ This document explains provider implementations, compatibility fallbacks,
 stream normalization, and response metadata behavior.
 
 ## Shared LLM Contracts
+- `InvokeRequest.CachePlan` is experimental in-memory intent, owned by
+  `CloneInvokeRequest` and the private execution frame, and excluded from JSON.
+  Built-in serializers still ignore it: fingerprint/target validation,
+  required/best-effort policy and capability-gated wire mapping are not enabled.
+  Legacy `Message.Cache` behavior is unchanged; do not use the new field as a
+  cache-control guarantee. No Agent Config or host plan generator is added.
+  Adding this exported field preserves keyed literals but external unkeyed
+  `InvokeRequest` literals must be updated. Message/Completion layouts and
+  session JSON are unchanged.
 - Provider-neutral interfaces: `ChatModel`, `StreamingChatModel` (`sdk/llm/model.go:8`, `sdk/llm/model.go:17`)
 - Unified request envelope: `InvokeRequest` (messages, tools, tool choice, temperature, responses options) (`sdk/llm/model.go:82`)
 - Unified stream event union: text/thinking/tool-call deltas, usage, done, response metadata, errors (`sdk/llm/model.go:24`, `sdk/llm/model.go:28`, `sdk/llm/model.go:33`, `sdk/llm/model.go:39`, `sdk/llm/model.go:50`, `sdk/llm/model.go:55`, `sdk/llm/model.go:62`, `sdk/llm/model.go:70`)

--- a/agent_docs/testing.md
+++ b/agent_docs/testing.md
@@ -20,6 +20,11 @@ This document summarizes recommended test commands and current coverage focus.
 - Anthropic provider: `go test ./sdk/llm/anthropic`
 
 ## Coverage Map (Representative)
+- CachePlan request attachment: `sdk/llm/cache_request_test.go` proves nil/empty
+  ownership and JSON exclusion; `cache_plan_wire_test.go` freezes buffered and
+  streaming Chat/Responses/Anthropic wire payloads with legacy cache flags and
+  injected HTTP failures. Existing Agent retry/Frame ownership fixtures include
+  CachePlan mutation isolation. No explicit cache policy enforcement is claimed.
 - `execution_frame_test.go` validates actual captured-handler dispatch across
   exact/alias/hidden/registered and internal fallback paths, request ownership
   across retries, finalizing continuation authority, and fail-closed snapshot

--- a/sdk/agent/agent_request_ownership_test.go
+++ b/sdk/agent/agent_request_ownership_test.go
@@ -117,6 +117,8 @@ func (m *providerAdmissionModel) Invoke(_ context.Context, request llm.InvokeReq
 		m.onFirst()
 	}
 	if call == 1 && m.retryFirst {
+		request.CachePlan.RequestFingerprint = "mutated"
+		request.CachePlan.Directives[0].Target.MessageIndex = 999
 		request.Messages[0].Content.Blocks[0].Text = "mutated"
 		request.Tools[1].Parameters["limit"] = int64(99)
 		request.Tools[1].Parameters["items"].([]any)[0] = "mutated"
@@ -232,6 +234,11 @@ func providerAdmissionRequest() llm.InvokeRequest {
 		ToolChoice:      llm.ToolChoice("required"),
 		Temperature:     &temperature,
 		DisableThinking: true,
+		CachePlan: &llm.CachePlan{
+			SchemaVersion:      llm.CachePlanSchemaVersion,
+			RequestFingerprint: "fixture-request",
+			Directives:         []llm.CacheDirective{{Target: llm.CacheTarget{Kind: llm.CacheAfterMessage, MessageIndex: 0}, Policy: llm.CacheBestEffort}},
+		},
 		Responses: &llm.ResponsesOptions{
 			UseResponseItems:  &yes,
 			UseInstructions:   &no,

--- a/sdk/agent/execution_frame_test.go
+++ b/sdk/agent/execution_frame_test.go
@@ -42,6 +42,8 @@ func TestExecutionFrameOwnsRequestAndResolverSchemas(t *testing.T) {
 		t.Fatal(err)
 	}
 	request.Messages[0].Content.Blocks[0].Text = "changed"
+	request.CachePlan.RequestFingerprint = "changed"
+	request.CachePlan.Directives[0].Target.MessageIndex = 999
 	request.Tools[1].Parameters["limit"] = int64(999)
 	tool.Schema["nested"].(map[string]any)["value"] = int64(999)
 	delete(exact, tool.Name)

--- a/sdk/llm/cache_plan_wire_test.go
+++ b/sdk/llm/cache_plan_wire_test.go
@@ -1,0 +1,113 @@
+package llm_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/timwhitez/agent-sdk-golang/sdk/llm"
+	"github.com/timwhitez/agent-sdk-golang/sdk/llm/anthropic"
+	"github.com/timwhitez/agent-sdk-golang/sdk/llm/openai"
+)
+
+type cacheWireTransport func(*http.Request) (*http.Response, error)
+
+func (f cacheWireTransport) RoundTrip(r *http.Request) (*http.Response, error) { return f(r) }
+
+func TestCachePlanAttachmentPreservesLegacyWireGolden(t *testing.T) {
+	for _, provider := range []string{"chat", "responses", "anthropic"} {
+		for _, stream := range []bool{false, true} {
+			t.Run(fmt.Sprintf("%s/stream=%v", provider, stream), func(t *testing.T) {
+				var baseline []byte
+				for _, plan := range []*llm.CachePlan{nil, {Directives: []llm.CacheDirective{}}, {
+					SchemaVersion: -1, RequestFingerprint: "private-plan-marker",
+					Directives: []llm.CacheDirective{{Target: llm.CacheTarget{Kind: llm.CacheAfterMessageBlock, MessageIndex: -1, ExpectedObjectFingerprint: "private-plan-marker"}, Policy: llm.CacheRequired, TTL: "unsupported"}},
+				}} {
+					calls := 0
+					var payload []byte
+					httpClient := &http.Client{Transport: cacheWireTransport(func(r *http.Request) (*http.Response, error) {
+						calls++
+						var err error
+						payload, err = io.ReadAll(r.Body)
+						if err != nil {
+							return nil, err
+						}
+						return &http.Response{StatusCode: http.StatusUnauthorized, Header: make(http.Header), Body: io.NopCloser(strings.NewReader(`{"error":{"message":"fixture rejected"}}`)), Request: r}, nil
+					})}
+					var model llm.StreamingChatModel
+					switch provider {
+					case "chat":
+						model = &openai.ChatClient{HTTPClient: httpClient, BaseURL: "https://fixture.invalid", ModelName: "fixture", MaxRetries: 1}
+					case "responses":
+						model = &openai.ResponsesClient{HTTPClient: httpClient, BaseURL: "https://fixture.invalid", ModelName: "fixture", MaxRetries: 1}
+					case "anthropic":
+						model = &anthropic.Client{HTTPClient: httpClient, BaseURL: "https://fixture.invalid", APIKey: "fixture-key", ModelName: "fixture", MaxTokens: 64, MaxRetries: 1, MaxCachedToolDefinitions: 1}
+					}
+					request := llm.InvokeRequest{
+						Messages:  []llm.Message{{Role: llm.RoleSystem, Content: llm.TextContent("system"), Cache: true}, {Role: llm.RoleUser, Content: llm.TextContent("hello"), Cache: true}},
+						Tools:     []llm.ToolDefinition{{Name: "work", Description: "fixture", Parameters: map[string]any{"type": "object"}}},
+						CachePlan: plan,
+					}
+					before, err := json.Marshal(request.Messages)
+					if err != nil {
+						t.Fatal(err)
+					}
+					planBefore := llm.CloneCachePlan(plan)
+					failures := 0
+					if stream {
+						events, err := model.InvokeStream(context.Background(), request)
+						if err != nil {
+							failures++
+						} else {
+							for event := range events {
+								if _, ok := event.(llm.StreamErrorEvent); ok {
+									failures++
+								}
+							}
+						}
+					} else if _, err := model.Invoke(context.Background(), request); err != nil {
+						failures++
+					}
+					if calls != 1 || failures != 1 {
+						t.Fatalf("requests/failures=%d/%d", calls, failures)
+					}
+					after, err := json.Marshal(request.Messages)
+					if err != nil {
+						t.Fatal(err)
+					}
+					if !bytes.Equal(before, after) || !reflect.DeepEqual(plan, planBefore) {
+						t.Fatal("serializer mutated request history or plan")
+					}
+					if bytes.Contains(payload, []byte("private-plan-marker")) || bytes.Contains(payload, []byte("CachePlan")) {
+						t.Fatal("plan leaked to Provider")
+					}
+					if baseline == nil {
+						baseline = payload
+					} else if !bytes.Equal(payload, baseline) {
+						t.Fatal("inert plan changed legacy payload")
+					}
+				}
+				// Fixed local wire golden: no remote endpoint is contacted.
+				golden := cacheWireGoldens[fmt.Sprintf("%s/%v", provider, stream)]
+				if string(baseline) != golden {
+					t.Fatalf("wire golden mismatch: %s", baseline)
+				}
+			})
+		}
+	}
+}
+
+var cacheWireGoldens = map[string]string{
+	"chat/false":      `{"messages":[{"content":"system","role":"system"},{"content":"hello","role":"user"}],"model":"fixture","tool_choice":"auto","tools":[{"function":{"description":"fixture","name":"work","parameters":{"type":"object"}},"type":"function"}]}`,
+	"chat/true":       `{"messages":[{"content":"system","role":"system"},{"content":"hello","role":"user"}],"model":"fixture","stream":true,"stream_options":{"include_usage":true},"tool_choice":"auto","tools":[{"function":{"description":"fixture","name":"work","parameters":{"type":"object"}},"type":"function"}]}`,
+	"responses/false": `{"input":[{"type":"message","role":"user","content":[{"type":"input_text","text":"hello"}]}],"instructions":"system","model":"fixture","tools":[{"type":"function","name":"work","description":"fixture","parameters":{"type":"object"}}]}`,
+	"responses/true":  `{"input":[{"type":"message","role":"user","content":[{"type":"input_text","text":"hello"}]}],"instructions":"system","model":"fixture","stream":true,"tools":[{"type":"function","name":"work","description":"fixture","parameters":{"type":"object"}}]}`,
+	"anthropic/false": `{"model":"fixture","max_tokens":64,"system":[{"type":"text","text":"system","cache_control":{"type":"ephemeral"}}],"messages":[{"role":"user","content":[{"type":"text","text":"hello","cache_control":{"type":"ephemeral"}}]}],"tools":[{"name":"work","description":"fixture","input_schema":{"type":"object"},"cache_control":{"type":"ephemeral"}}],"tool_choice":{"type":"auto"}}`,
+	"anthropic/true":  `{"model":"fixture","max_tokens":64,"system":[{"type":"text","text":"system","cache_control":{"type":"ephemeral"}}],"messages":[{"role":"user","content":[{"type":"text","text":"hello","cache_control":{"type":"ephemeral"}}]}],"tools":[{"name":"work","description":"fixture","input_schema":{"type":"object"},"cache_control":{"type":"ephemeral"}}],"tool_choice":{"type":"auto"},"stream":true}`,
+}

--- a/sdk/llm/cache_request_test.go
+++ b/sdk/llm/cache_request_test.go
@@ -1,0 +1,58 @@
+package llm
+
+import (
+	"bytes"
+	"encoding/json"
+	"reflect"
+	"testing"
+)
+
+func TestInvokeRequestCachePlanOwnershipAndJSONBoundary(t *testing.T) {
+	for _, plan := range []*CachePlan{nil, {}, {Directives: []CacheDirective{}}, {
+		SchemaVersion: CachePlanSchemaVersion, RequestFingerprint: "private-marker",
+		Directives: []CacheDirective{{Target: CacheTarget{Kind: CacheAfterMessageBlock, MessageIndex: 3, BlockOrdinal: 2, ExpectedObjectFingerprint: "private-marker"}, Policy: CacheRequired, TTL: CacheTTL1Hour}},
+	}} {
+		request := InvokeRequest{Messages: []Message{NewUserMessage("fixture")}, CachePlan: plan}
+		cloned, err := CloneInvokeRequest(request)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !reflect.DeepEqual(cloned, request) {
+			t.Fatal("clone changed nil/empty/plan fields")
+		}
+		if plan != nil {
+			if cloned.CachePlan == plan {
+				t.Fatal("shared plan pointer")
+			}
+			cloned.CachePlan.RequestFingerprint = "clone-only"
+			if len(plan.Directives) > 0 {
+				cloned.CachePlan.Directives[0].Target.MessageIndex = 99
+				if plan.Directives[0].Target.MessageIndex != 3 {
+					t.Fatal("shared directives")
+				}
+			}
+			if plan.RequestFingerprint == "clone-only" {
+				t.Fatal("shared plan scalar")
+			}
+		}
+		with, err := json.Marshal(request)
+		if err != nil {
+			t.Fatal(err)
+		}
+		request.CachePlan = nil
+		without, err := json.Marshal(request)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !bytes.Equal(with, without) || bytes.Contains(with, []byte("private-marker")) {
+			t.Fatal("plan leaked into request JSON")
+		}
+		var restored InvokeRequest
+		if err := json.Unmarshal([]byte(`{"CachePlan":{"RequestFingerprint":"private-marker"}}`), &restored); err != nil {
+			t.Fatal(err)
+		}
+		if restored.CachePlan != nil {
+			t.Fatal("JSON restored request-local plan")
+		}
+	}
+}

--- a/sdk/llm/clone.go
+++ b/sdk/llm/clone.go
@@ -11,6 +11,7 @@ import (
 // safely copy without unsafe access.
 func CloneInvokeRequest(request InvokeRequest) (InvokeRequest, error) {
 	out := request
+	out.CachePlan = CloneCachePlan(request.CachePlan)
 	out.Messages = CloneMessages(request.Messages)
 	if request.Tools != nil {
 		out.Tools = make([]ToolDefinition, len(request.Tools))

--- a/sdk/llm/model.go
+++ b/sdk/llm/model.go
@@ -129,4 +129,10 @@ type InvokeRequest struct {
 
 	// Responses options (OpenAI Responses API). Ignored by providers that don't use it.
 	Responses *ResponsesOptions
+
+	// CachePlan is experimental, in-memory request-local intent. It is cloned
+	// with the request but excluded from JSON and not consumed by providers yet;
+	// neither required nor best-effort policies are enforced at this stage.
+	// Do not rely on it for cache control until capability-gated mapping exists.
+	CachePlan *CachePlan `json:"-"`
 }


### PR DESCRIPTION
## Scope

Advances #89; does not close this multi-phase Issue. Add experimental `InvokeRequest.CachePlan` and reuse `CloneCachePlan` in the existing request ownership path. Frame and per-attempt clones now own plan state without a second cloning pipeline.

The field is excluded from JSON (`json:"-"`), not added to Message/Completion or Agent Config. Built-in providers do not consume it yet; fingerprints, targets, required/best-effort policy and capabilities are NOT enforced. This is explicit inert intent plumbing, not usable cache-control support. No new logs, dependency, Prompt, serializer or persistence protocol change.

## Compatibility and tests

- Keyed request literals remain compatible; adding a public struct field requires external unkeyed InvokeRequest literals to be updated. Do not claim unchanged public API.
- Nil, nil directives and non-nil empty directives preserved; clone pointer/directive ownership and generic JSON input/output exclusion checked.
- Existing framework retry and Frame ownership tests now include plan mutations; dynamic wrappers still do not freeze concrete model identity.
- Six fixed wire goldens exercise real built-in Chat/Responses/Anthropic buffered/streaming entrypoints through local HTTP transports. Legacy system/user/tool cache flags remain unchanged across nil/empty/malformed required intents. Injected 401 response remains one observable failure, no history/plan mutation, no plan marker in wire. This is not a test claiming required policy is implemented.
- Local focused x100, full/vet and race across llm/providers/agent passed. gofmt/diff-check passed at head 30430659f2e147d1635f30110d4fac6efe9be6e7.
- Independent exact-head APPROVE (sdk105_final_review): full/vet/llm-provider-agent race/focused x100/gofmt/diff-check passed. All three mutations detected (missing clone, shallow directives, missing JSON exclusion). Six wire goldens also passed on old base c961e5f with only the unavailable request field omitted; no unresolved findings. Log /tmp/sdk113-review-gates.log.

No benchmark, hosted CI or live Provider claim. Existing benchmark helper now includes CachePlan, so historical fixture timings are not a matched before/after comparison.
