### PR TITLE
refactor(agent): share Tool Result projection records

### DIFF
--- a/agent_docs/testing.md
+++ b/agent_docs/testing.md
@@ -20,6 +20,11 @@ This document summarizes recommended test commands and current coverage focus.
 - Anthropic provider: `go test ./sdk/llm/anthropic`
 
 ## Coverage Map (Representative)
+- `tool_result_projection_test.go` checks the shared result record's canonical
+  history/identity/flags, explicit event-view override, original/visible
+  measurements, opaque-state exclusion from visible text, and delivery-gated
+  Accounting on absent or abandoned output. Existing guard transcript goldens
+  preserve richer history text and delayed result publication.
 - `tool_outcome_projection_test.go` joins execution knowledge, exactly one
   history result, delivered ToolResultEvent/Accounting adjacency, original and
   visible measurements, and Artifact disposition in one real Agent trajectory.

--- a/sdk/agent/agent.go
+++ b/sdk/agent/agent.go
@@ -1347,7 +1347,12 @@ func (a *Agent) queryStreamWithSteering(ctx context.Context, input llm.Content, 
 					a.observeRepeatedSignatureIntervention(legacyDecision, shadowDecision)
 					if blocked {
 						loopGuardStrikes++
-						closeToolResults(idx, toolCallAccepted, "loop_guard", loopGuardSkippedToolResults(tc, resolvedName)...)
+						// Accepted blocks have non-empty IDs, so this helper returns
+						// one history result. Keep its richer history-only suffix.
+						guardHistory := loopGuardSkippedToolResults(tc, resolvedName)
+						guardResult := projectToolResult(guardHistory[0], map[string]any{"loop_guard_suppressed": true}, "[ERROR] Tool call skipped by loop guard - Repeated identical tool call blocked before execution.")
+						guardResult.visible = guardResult.original
+						closeToolResults(idx, toolCallAccepted, "loop_guard", guardResult.history)
 						reminder := strings.TrimSpace(a.loopGuardUserMsg)
 						if repeatGuard.exhausted {
 							// The default reminder can mislead here ("reuse prior
@@ -1401,12 +1406,7 @@ func (a *Agent) queryStreamWithSteering(ctx context.Context, input llm.Content, 
 							Tool: resolvedName, Args: norm.Display, ArgsJSON: norm.Normalized,
 							ArgsMeta: norm.Meta, ToolCallID: tc.ID, DisplayName: resolvedName,
 						})
-						guardResult := ToolResultEvent{
-							Tool: resolvedName, ToolCallID: tc.ID, IsError: true,
-							Result:   "[ERROR] Tool call skipped by loop guard - Repeated identical tool call blocked before execution.",
-							Metadata: map[string]any{"loop_guard_suppressed": true},
-						}
-						a.emitToolResultWithAccounting(out, guardResult, guardResult.Result, 0)
+						a.emitToolResultWithAccounting(out, guardResult, 0)
 						a.emitEvent(out, StepCompleteEvent{StepID: tc.ID, Status: "error"})
 						continue
 					}
@@ -1428,15 +1428,12 @@ func (a *Agent) queryStreamWithSteering(ctx context.Context, input llm.Content, 
 					decision := progressLedger.preflight(evidenceReq, a.compactionGeneration.Load())
 					if decision.suppress {
 						content := llm.TextContent(decision.content)
-						closeToolResults(idx, toolCallAccepted, "evidence_suppressed", llm.Message{
+						suppressedResult := projectToolResult(llm.Message{
 							Role: llm.RoleTool, ToolCallID: tc.ID, ToolName: resolvedName,
 							Content: content, IsError: false, Ephemeral: tool.EphemeralKeep > 0,
-						})
-						suppressedResult := ToolResultEvent{
-							Tool: resolvedName, Result: content.PlainText(), ToolCallID: tc.ID,
-							IsError: false, Metadata: decision.metadata,
-						}
-						a.emitToolResultWithAccounting(out, suppressedResult, suppressedResult.Result, 0)
+						}, decision.metadata, content.PlainText())
+						closeToolResults(idx, toolCallAccepted, "evidence_suppressed", suppressedResult.history)
+						a.emitToolResultWithAccounting(out, suppressedResult, 0)
 						a.emitEvent(out, StepCompleteEvent{StepID: tc.ID, Status: "completed"})
 						if decision.recovery {
 							reminder := evidenceRecoveryMessage(evidenceReq)
@@ -1504,8 +1501,9 @@ func (a *Agent) queryStreamWithSteering(ctx context.Context, input llm.Content, 
 					originalResult := content.PlainText()
 					content, meta = a.applyToolResultTruncation(ctx, content, meta, resolvedName, tc.ID)
 					// append tool message and finish
-					closeToolResults(idx, toolCallRunning, "task_complete", llm.Message{Role: llm.RoleTool, ToolCallID: tc.ID, ToolName: resolvedName, Content: content, IsError: false, Ephemeral: ephemeral})
-					a.emitToolResultWithAccounting(out, ToolResultEvent{Tool: resolvedName, Result: content.PlainText(), ToolCallID: tc.ID, IsError: false, Metadata: meta}, originalResult, time.Since(start))
+					result := projectToolResult(llm.Message{Role: llm.RoleTool, ToolCallID: tc.ID, ToolName: resolvedName, Content: content, IsError: false, Ephemeral: ephemeral}, meta, originalResult)
+					closeToolResults(idx, toolCallRunning, "task_complete", result.history)
+					a.emitToolResultWithAccounting(out, result, time.Since(start))
 					a.emitEvent(out, StepCompleteEvent{StepID: tc.ID, Status: status, DurationMS: time.Since(start).Milliseconds()})
 					if err := ctx.Err(); err != nil {
 						closeToolResults(idx+1, toolCallAccepted, "root_cancel_after_task_complete", skippedToolResults(comp.ToolCalls[idx+1:], toolSkippedByCancellationText)...)
@@ -1547,9 +1545,10 @@ func (a *Agent) queryStreamWithSteering(ctx context.Context, input llm.Content, 
 				content, meta = a.applyToolResultTruncation(ctx, content, meta, resolvedName, tc.ID)
 
 				// append tool message
-				closeToolResults(idx, toolCallRunning, "handler_return", llm.Message{Role: llm.RoleTool, ToolCallID: tc.ID, ToolName: resolvedName, Content: content, IsError: isError, Ephemeral: ephemeral})
+				result := projectToolResult(llm.Message{Role: llm.RoleTool, ToolCallID: tc.ID, ToolName: resolvedName, Content: content, IsError: isError, Ephemeral: ephemeral}, meta, originalResult)
+				closeToolResults(idx, toolCallRunning, "handler_return", result.history)
 
-				a.emitToolResultWithAccounting(out, ToolResultEvent{Tool: resolvedName, Result: content.PlainText(), ToolCallID: tc.ID, IsError: isError, Metadata: meta}, originalResult, time.Since(start))
+				a.emitToolResultWithAccounting(out, result, time.Since(start))
 				a.emitEvent(out, StepCompleteEvent{StepID: tc.ID, Status: status, DurationMS: time.Since(start).Milliseconds()})
 				if rootCancelErr == nil {
 					rootCancelErr = ctx.Err()
@@ -2706,14 +2705,15 @@ func (a *Agent) emitUsageWithAccounting(out *eventOutput, usage llm.Usage, respo
 	})
 }
 
-func (a *Agent) emitToolResultWithAccounting(out *eventOutput, event ToolResultEvent, original string, duration time.Duration) {
+func (a *Agent) emitToolResultWithAccounting(out *eventOutput, result toolResultProjection, duration time.Duration) {
+	event := result.event()
 	if !a.emitEvent(out, event) {
 		return
 	}
 	a.emitAccounting(out, AccountingEvent{
 		Payload: sdkaccounting.ProjectToolResult(sdkaccounting.ToolResultInput{
 			Tool:     event.Tool,
-			Original: original,
+			Original: result.original,
 			Visible:  event.Result,
 			IsError:  event.IsError,
 			Metadata: event.Metadata,

--- a/sdk/agent/tool_result_projection.go
+++ b/sdk/agent/tool_result_projection.go
@@ -1,0 +1,21 @@
+package agent
+
+import "github.com/timwhitez/agent-sdk-golang/sdk/llm"
+
+// toolResultProjection is local to one result, not a second terminal authority.
+// History commit and event publication keep their existing separate boundaries.
+// The loop guard intentionally has a shorter event view than its history view.
+type toolResultProjection struct {
+	history  llm.Message
+	visible  string
+	original string
+	metadata map[string]any
+}
+
+func projectToolResult(history llm.Message, metadata map[string]any, original string) toolResultProjection {
+	return toolResultProjection{history: history, visible: history.Content.PlainText(), original: original, metadata: metadata}
+}
+
+func (p toolResultProjection) event() ToolResultEvent {
+	return ToolResultEvent{Tool: p.history.ToolName, ToolCallID: p.history.ToolCallID, IsError: p.history.IsError, Result: p.visible, Metadata: p.metadata}
+}

--- a/sdk/agent/tool_result_projection_test.go
+++ b/sdk/agent/tool_result_projection_test.go
@@ -1,0 +1,69 @@
+package agent
+
+import (
+	"context"
+	"encoding/json"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/timwhitez/agent-sdk-golang/sdk/llm"
+)
+
+func TestToolResultProjectionViewsAndDeliveryGate(t *testing.T) {
+	content, err := llm.WithProviderState(llm.TextContent("visible"), []llm.ProviderState{{Provider: "fixture", Kind: "opaque", Data: json.RawMessage(`{"private":"state"}`)}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	message := llm.Message{Role: llm.RoleTool, ToolCallID: "call", ToolName: "work", Content: content, IsError: true, Ephemeral: true}
+	metadata := map[string]any{"result_truncated": true}
+	result := projectToolResult(message, metadata, "original-long-result")
+	if !reflect.DeepEqual(result.history, message) || result.original != "original-long-result" {
+		t.Fatal("projection changed history or original result")
+	}
+	want := ToolResultEvent{Tool: "work", ToolCallID: "call", Result: "visible", IsError: true, Metadata: metadata}
+	if !reflect.DeepEqual(result.event(), want) {
+		t.Fatal("canonical identity/flags/visible metadata lost")
+	}
+	// Explicit compatibility view override does not rewrite history or identity.
+	result.visible = "short event view"
+	want.Result = "short event view"
+	if !reflect.DeepEqual(result.event(), want) || !reflect.DeepEqual(result.history, message) {
+		t.Fatal("event view rewrote history")
+	}
+
+	ag, err := New(Config{LLM: historyCloneModel{}, Warningf: func(string, ...any) {}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	out := newEventOutput(2, false, "", nil)
+	ag.emitToolResultWithAccounting(out, result, time.Millisecond)
+	event := (<-out.legacy).(ToolResultEvent)
+	accounting := (<-out.legacy).(AccountingEvent)
+	if !reflect.DeepEqual(event, want) || accounting.ToolCallID != "call" || accounting.Payload.Status != "error" || accounting.DurationMS != 1 {
+		t.Fatal("delivery projections diverged")
+	}
+	if *accounting.Payload.Measurements.OriginalBytes != int64(len(result.original)) || *accounting.Payload.Measurements.VisibleBytes != int64(len(result.visible)) {
+		t.Fatal("measurement views conflated")
+	}
+	if len(ag.Messages()) != 0 {
+		t.Fatal("publishing unexpectedly committed history")
+	}
+
+	// The existing publisher is delivery-gated: absent/abandoned output must
+	// not allocate another accounting sequence or invent an accounting event.
+	ag.emitToolResultWithAccounting(nil, result, 0)
+	blocked := newEventOutput(1, false, "", nil)
+	blocked.legacy <- WarnEvent{Message: "filler"}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	defer ag.registerTurnCancellation(blocked, ctx)()
+	ag.eventSendTimeout = time.Nanosecond
+	ag.emitToolResultWithAccounting(blocked, result, 0)
+	if ag.accountingSequence.Load() != 1 || ag.eventDropCount.Load() != 1 {
+		t.Fatal("undelivered result emitted accounting or lost drop evidence")
+	}
+	if len(blocked.legacy) != 1 {
+		t.Fatal("abandoned output changed")
+	}
+}


### PR DESCRIPTION
## Scope

Advances #84, does not close it. Use one private per-result projection record for ordinary handler return, TaskComplete, evidence suppression and loop guard. Event identity/error flags derive from the same message used by the existing history writer; original and visible text remain distinct accounting inputs.

Remove duplicate ToolResultEvent construction at all four publishing sites. Reuse the existing publisher and its delivery-gated Accounting. History commit and publish timing stay separate. Loop guard intentionally keeps its richer history text and shorter event/accounting view; synthetic tails remain history-only. Accepted Tool Call IDs are normalized/non-empty before the loop, so the existing guard history helper returns one entry.

No new terminal authority, duplicate-completion enforcement, Scheduler, public API, Provider serializer, Prompt, persistence protocol, new logging or dependency. The record is local, not stored as a second ledger; raw original text is used transiently for existing accounting projection.

## Validation

New projection test covers canonical history/identity/flags, opaque-state exclusion from visible text, explicit view override, original/visible measurements, and absent/abandoned output Accounting gate. Existing #114 six joint trajectories and guard transcript/event-order goldens are retained.

Exact head 7e945fc8eb1b112e20f75c693c174e7bf7239bc9: local gofmt/diff-check, focused x100, full/vet/agent race passed. Logs /tmp/sdk-result-projection-{focused,full,race}.log.

Independent exact-head APPROVE (pin194_review): full/vet/agent race, projection/outcome x100 and guard golden x100 passed. Five mutations detected: original=visible, lost short guard view, early guard publication, Accounting bypassing delivery gate, identity mismatch. Guard history indexing precondition confirmed for ordinary and continuation-finalized accepted IDs. Mutation tree restored and retested, no unresolved findings. Logs /tmp/review115-{full,vet,race,focused,guard100}.log.

Goode main876f849 preview against this exact SDK head passed full/vet/app-ui-acp-subtask race. No benchmark or live Provider claim.
