### PR TITLE
test(agent): count explicit canceled terminal drops

### DIFF
--- a/sdk/agent/agent_cancel_boundary_test.go
+++ b/sdk/agent/agent_cancel_boundary_test.go
@@ -422,6 +422,7 @@ func TestRootCancellationBeforeFirstToolClosesAcceptedBlock(t *testing.T) {
 	var runs atomic.Int32
 	dropped := make(chan struct{})
 	var sawDrop atomic.Bool
+	var droppedCanceled atomic.Int32
 	failShadow := failOnToolBlockShadowWarning(t)
 	ag, err := New(Config{
 		LLM:               cancelBeforeToolStartModel{},
@@ -431,6 +432,11 @@ func TestRootCancellationBeforeFirstToolClosesAcceptedBlock(t *testing.T) {
 		EventDropLogEvery: 1,
 		Warningf: func(format string, args ...any) {
 			failShadow(format, args...)
+			if strings.Contains(format, "dropping consistency-critical agent event") && len(args) > 0 {
+				if event, ok := args[0].(ErrorEvent); ok && event.Kind == "canceled" {
+					droppedCanceled.Add(1)
+				}
+			}
 			if strings.Contains(format, "dropping agent event") && sawDrop.CompareAndSwap(false, true) {
 				cancel()
 				close(dropped)
@@ -447,8 +453,10 @@ func TestRootCancellationBeforeFirstToolClosesAcceptedBlock(t *testing.T) {
 		t.Fatal("timeout waiting for controlled event drop")
 	}
 	got := collectCancelBoundaryTerminals(events)
-	if runs.Load() != 0 || got.canceled != 1 || got.finals != 0 {
-		t.Fatalf("runs=%d canceled=%d finals=%d; want 0/1/0", runs.Load(), got.canceled, got.finals)
+	// Cancellation can race with the consumer draining the occupied slot.
+	// Count the actual typed drop, not any missing terminal or arbitrary drop.
+	if runs.Load() != 0 || got.canceled+int(droppedCanceled.Load()) != 1 || got.finals != 0 || ag.criticalEventDropCount.Load() != uint64(droppedCanceled.Load()) {
+		t.Fatalf("runs=%d canceled=%d dropped_canceled=%d critical_drops=%d finals=%d", runs.Load(), got.canceled, droppedCanceled.Load(), ag.criticalEventDropCount.Load(), got.finals)
 	}
 	assertCanceledToolResult(t, ag.Messages(), "never-start")
 }


### PR DESCRIPTION
Closes #116. Tests only; no runtime delivery-policy change.

The cancellation/backpressure fixture now requires exactly one canceled terminal across delivered events and explicitly logged typed ErrorEvent drops, with matching critical-drop accounting. Zero handler execution, zero final response and canceled result history remain required. Arbitrary missing events or drops do not satisfy the assertion.

Baseline d20f1f5 reproduced 11 failures in race x1000; the unmerged authority branch reproduced 8. This is an existing fixture assumption, not a data-race report or proven authority regression.

Exact head672b3d64c7a9910a5734fa4109acf19900d203d4: gofmt/diff-check, focused race x1000, full test, vet, agent race passed (Go1.22.12). Logs /tmp/sdk-cancel-drop-{focused,full,race}.log. Independent exact-head APPROVE (pin194_review): full/vet/agent race/focused race x1000 passed. Deleting the cancellation emission and changing its Kind each failed 100/100; restored tree clean and race x100 passed again. Reviewer confirmed this is a fixture assumption, not evidence for a runtime policy change. Logs /tmp/review117-{full,vet,race,focused,restored}.log. No benchmark/live Provider claim.
