### PR TITLE
feat(agent): enforce sequential terminal and publication authority

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,9 +38,14 @@ and progressive disclosure through `agent_docs/`.
   kind/origin, and observational timestamp. Legacy `QueryStream` uses the same
   direct delivery/backpressure path without metadata; sequence gaps expose
   dropped events (`sdk/agent/event_envelope.go`, `sdk/agent/agent.go`).
-- The sequential Tool Loop mirrors accepted/running/terminal transitions into
-  a query-local, observe-only `toolBlockState`. Mismatches use `Warningf`; the
-  shadow does not construct history, events, Tool Results, or Provider payloads
+- The sequential Tool Loop uses query/block-local `toolBlockState` to accept
+  terminal batches atomically and in ordinal order before history commit.
+  Publishable results are claimed once from that authority; claim does not
+  imply delivery and Accounting remains delivery-gated. Internal rejection
+  closes remaining calls without re-execution, preserves observed execution,
+  marks uncertain results indeterminate, retains queued steering, and emits
+  one source-negative SDK error. History-only tails remain unpublishable.
+  This is not a concurrent scheduler or durable ledger
   (`sdk/agent/tool_block_state.go`, `sdk/agent/agent.go`).
 - Auto-continue on `max_tokens` (including partial tool-call merge) now emits metadata-only `AutoContinueEvent` instead of text markers (`sdk/agent/agent.go:259`, `sdk/agent/agent.go:275`, `sdk/agent/agent.go:298`, `sdk/agent/events.go:113`)
 - Tool resolution via exact + normalized + alias matching (`sdk/agent/tool_resolve.go:107`, `sdk/agent/tool_resolve.go:30`)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,9 +31,14 @@ and progressive disclosure through `agent_docs/`.
   kind/origin, and observational timestamp. Legacy `QueryStream` uses the same
   direct delivery/backpressure path without metadata; sequence gaps expose
   dropped events (`sdk/agent/event_envelope.go`, `sdk/agent/agent.go`).
-- The sequential Tool Loop mirrors accepted/running/terminal transitions into
-  a query-local, observe-only `toolBlockState`. Mismatches use `Warningf`; the
-  shadow does not construct history, events, Tool Results, or Provider payloads
+- The sequential Tool Loop uses query/block-local `toolBlockState` to accept
+  terminal batches atomically and in ordinal order before history commit.
+  Publishable results are claimed once from that authority; claim does not
+  imply delivery and Accounting remains delivery-gated. Internal rejection
+  closes remaining calls without re-execution, preserves observed execution,
+  marks uncertain results indeterminate, retains queued steering, and emits
+  one source-negative SDK error. History-only tails remain unpublishable.
+  This is not a concurrent scheduler or durable ledger
   (`sdk/agent/tool_block_state.go`, `sdk/agent/agent.go`).
 - Auto-continue on `max_tokens` (including partial tool-call merge) now emits metadata-only `AutoContinueEvent` instead of text markers (`sdk/agent/agent.go:259`, `sdk/agent/agent.go:275`, `sdk/agent/agent.go:298`, `sdk/agent/events.go:113`)
 - Tool resolution via exact + normalized + alias matching (`sdk/agent/tool_resolve.go:107`, `sdk/agent/tool_resolve.go:30`)

--- a/agent_docs/testing.md
+++ b/agent_docs/testing.md
@@ -20,6 +20,14 @@ This document summarizes recommended test commands and current coverage focus.
 - Anthropic provider: `go test ./sdk/llm/anthropic`
 
 ## Coverage Map (Representative)
+- `tool_terminal_authority_test.go` checks whole-batch atomicity, ordinal order,
+  invalid role/identity/phase/knowledge, duplicate terminal/start/claim rejection,
+  pending-payload release, unpublishable tails and idempotent abort. Real Driver
+  failure injection proves zero execution after rejected start, conservative
+  result closure after returned effects, preservation of prior terminals and
+  consumed steering, publication rejection, and next-query zero pairing repair.
+  `BenchmarkToolBlockTerminalLifecycle` measures the new sequential lifecycle;
+  it is not a matched comparison with the former shadow-only fixture.
 - `tool_result_projection_test.go` checks the shared result record's canonical
   history/identity/flags, explicit event-view override, original/visible
   measurements, opaque-state exclusion from visible text, and delivery-gated
@@ -30,8 +38,8 @@ This document summarizes recommended test commands and current coverage focus.
   visible measurements, and Artifact disposition in one real Agent trajectory.
   Ordinary success and TaskComplete each cover successful publication, sink
   failure, and persisted-object/codec-budget failure. Projection failure is not
-  reclassified as an unstarted handler; this characterization does not enable
-  new terminal authority or change history-only synthetic tail delivery.
+  reclassified as an unstarted handler; terminal authority is tested separately
+  above, and history-only synthetic tail delivery remains unchanged.
 - CachePlan request attachment: `sdk/llm/cache_request_test.go` proves nil/empty
   ownership and JSON exclusion; `cache_plan_wire_test.go` freezes buffered and
   streaming Chat/Responses/Anthropic wire payloads with legacy cache flags and

--- a/sdk/agent/agent.go
+++ b/sdk/agent/agent.go
@@ -170,6 +170,7 @@ type Agent struct {
 	compactionAdmissionObserved func()
 	compactionShadowObserved    func()
 	toolBlockStateObserved      func(*toolBlockState)
+	toolBlockTestHook           func(*toolBlockState) // private failure-injection hook
 
 	repeatInterventionShadowObserved  func(interventionDecision, interventionDecision)
 	repeatInterventionShadowEvaluator func(repeatedSignatureObservation) interventionDecision
@@ -683,26 +684,55 @@ func (a *Agent) queryStreamWithSteering(ctx context.Context, input llm.Content, 
 			emitErr(e, origin)
 		}
 		var activeToolBlock *toolBlockState
-		// All accepted Tool Result history commits pass through this writer.
-		// Event/accounting projection stays at each existing emission boundary.
-		closeToolResults := func(start int, expected toolCallPhase, reason string, messages ...llm.Message) {
-			a.appendMessages(messages)
-			for offset := range messages {
-				activeToolBlock.markTerminal(start+offset, expected, reason)
+		var pendingBlockMessages []llm.Message
+		blockFailed := false
+		commitToolHistory := func(messages []llm.Message) { a.appendMessages(messages) }
+		failToolBlock := func(err error) bool {
+			if !blockFailed {
+				blockFailed = true
+				commitToolHistory(activeToolBlock.abortOpen())
+				a.appendMessages(pendingBlockMessages)
+				pendingBlockMessages = nil
+				message := "Tool lifecycle validation failed; remaining calls closed without further execution"
+				var transition *toolBlockTransitionError
+				if errors.As(err, &transition) {
+					message += ": " + transition.Error()
+				}
+				emitSDKErr(ErrorEvent{Kind: "invalid_tool_call_block", Message: message})
 			}
+			return false
 		}
-		finishToolBlock := func() {
+		// One acceptance authority precedes the one history writer. Publication
+		// is claimed separately at the existing event boundary, at most once.
+		closeToolResults := func(start int, expected toolCallPhase, reason string, results ...toolResultProjection) bool {
+			messages, err := activeToolBlock.acceptResults(start, expected, reason, results)
+			if err != nil {
+				return failToolBlock(err)
+			}
+			commitToolHistory(messages)
+			return true
+		}
+		publishToolResult := func(index int, duration time.Duration) bool {
+			result, err := activeToolBlock.takePublication(index)
+			if err != nil {
+				return failToolBlock(err)
+			}
+			a.emitToolResultWithAccounting(out, result, duration)
+			return true
+		}
+		finishToolBlock := func() bool {
 			block := activeToolBlock
-			activeToolBlock = nil
 			if block == nil {
-				return
+				return true
 			}
 			if err := block.validateClosed(); err != nil {
-				a.warnf("warning: tool block shadow invariant mismatch: %v", err)
+				failToolBlock(err)
 			}
 			if a.toolBlockStateObserved != nil {
 				a.toolBlockStateObserved(block)
 			}
+			activeToolBlock = nil
+			return !blockFailed
 		}
 		defer finishToolBlock()
 
@@ -1241,8 +1271,15 @@ func (a *Agent) queryStreamWithSteering(ctx context.Context, input llm.Content, 
 			// interleaved with user text, and the malformed history would stay
 			// in place and fail every later turn — so these are only appended
 			// once every tool_use in the block has a matching tool_result.
-			activeToolBlock = newToolBlockState(comp.ToolCalls)
-			var pendingBlockMessages []llm.Message
+			activeToolBlock, err = newToolBlockState(comp.ToolCalls)
+			if err != nil {
+				failToolBlock(err)
+				return
+			}
+			pendingBlockMessages = nil
+			if a.toolBlockTestHook != nil {
+				a.toolBlockTestHook(activeToolBlock)
+			}
 			for idx, tc := range comp.ToolCalls {
 				step := idx + 1
 				originalName := tc.Function.Name
@@ -1265,7 +1302,9 @@ func (a *Agent) queryStreamWithSteering(ctx context.Context, input llm.Content, 
 
 				if err := ctx.Err(); err != nil {
 					// Close every unstarted call before any handler can execute.
-					closeToolResults(idx, toolCallAccepted, "root_cancel_before_start", skippedToolResults(comp.ToolCalls[idx:], toolSkippedByCancellationText)...)
+					if !closeToolResults(idx, toolCallAccepted, "root_cancel_before_start", historyOnlyResults(skippedToolResults(comp.ToolCalls[idx:], toolSkippedByCancellationText))...) {
+						return
+					}
 					a.appendMessages(pendingBlockMessages)
 					pendingBlockMessages = nil
 					emitSDKErr(a.errEvent(err))
@@ -1352,7 +1391,9 @@ func (a *Agent) queryStreamWithSteering(ctx context.Context, input llm.Content, 
 						guardHistory := loopGuardSkippedToolResults(tc, resolvedName)
 						guardResult := projectToolResult(guardHistory[0], map[string]any{"loop_guard_suppressed": true}, "[ERROR] Tool call skipped by loop guard - Repeated identical tool call blocked before execution.")
 						guardResult.visible = guardResult.original
-						closeToolResults(idx, toolCallAccepted, "loop_guard", guardResult.history)
+						if !closeToolResults(idx, toolCallAccepted, "loop_guard", guardResult) {
+							return
+						}
 						reminder := strings.TrimSpace(a.loopGuardUserMsg)
 						if repeatGuard.exhausted {
 							// The default reminder can mislead here ("reuse prior
@@ -1406,7 +1447,9 @@ func (a *Agent) queryStreamWithSteering(ctx context.Context, input llm.Content, 
 							Tool: resolvedName, Args: norm.Display, ArgsJSON: norm.Normalized,
 							ArgsMeta: norm.Meta, ToolCallID: tc.ID, DisplayName: resolvedName,
 						})
-						a.emitToolResultWithAccounting(out, guardResult, 0)
+						if !publishToolResult(idx, 0) {
+							return
+						}
 						a.emitEvent(out, StepCompleteEvent{StepID: tc.ID, Status: "error"})
 						continue
 					}
@@ -1432,8 +1475,12 @@ func (a *Agent) queryStreamWithSteering(ctx context.Context, input llm.Content, 
 							Role: llm.RoleTool, ToolCallID: tc.ID, ToolName: resolvedName,
 							Content: content, IsError: false, Ephemeral: tool.EphemeralKeep > 0,
 						}, decision.metadata, content.PlainText())
-						closeToolResults(idx, toolCallAccepted, "evidence_suppressed", suppressedResult.history)
-						a.emitToolResultWithAccounting(out, suppressedResult, 0)
+						if !closeToolResults(idx, toolCallAccepted, "evidence_suppressed", suppressedResult) {
+							return
+						}
+						if !publishToolResult(idx, 0) {
+							return
+						}
 						a.emitEvent(out, StepCompleteEvent{StepID: tc.ID, Status: "completed"})
 						if decision.recovery {
 							reminder := evidenceRecoveryMessage(evidenceReq)
@@ -1461,11 +1508,18 @@ func (a *Agent) queryStreamWithSteering(ctx context.Context, input llm.Content, 
 				ctxToolBase := tools.WithToolCallID(ctx, tc.ID)
 				ctxToolBase = tools.WithToolResultMetadata(ctxToolBase)
 				ctxTool, finishToolStage := a.beginSteeringInterruptibleStage(ctxToolBase)
-				activeToolBlock.markRunning(idx)
+				if err := activeToolBlock.markRunning(idx); err != nil {
+					finishToolStage()
+					failToolBlock(err)
+					return
+				}
 				content, toolErr := a.executeToolSafely(ctxTool, tool, execArgs)
 				stageInterruptedForSteering := finishToolStage()
 				rootCancelErr := ctx.Err()
-				activeToolBlock.markAttemptReturned(idx, rootCancelErr != nil)
+				if err := activeToolBlock.markAttemptReturned(idx, rootCancelErr != nil); err != nil {
+					failToolBlock(err)
+					return
+				}
 				if rootCancelErr != nil {
 					// Root cancellation outranks a tool's ordinary or task-complete
 					// return. Keep a contiguous result for this call, then terminate.
@@ -1502,11 +1556,17 @@ func (a *Agent) queryStreamWithSteering(ctx context.Context, input llm.Content, 
 					content, meta = a.applyToolResultTruncation(ctx, content, meta, resolvedName, tc.ID)
 					// append tool message and finish
 					result := projectToolResult(llm.Message{Role: llm.RoleTool, ToolCallID: tc.ID, ToolName: resolvedName, Content: content, IsError: false, Ephemeral: ephemeral}, meta, originalResult)
-					closeToolResults(idx, toolCallRunning, "task_complete", result.history)
-					a.emitToolResultWithAccounting(out, result, time.Since(start))
+					if !closeToolResults(idx, toolCallRunning, "task_complete", result) {
+						return
+					}
+					if !publishToolResult(idx, time.Since(start)) {
+						return
+					}
 					a.emitEvent(out, StepCompleteEvent{StepID: tc.ID, Status: status, DurationMS: time.Since(start).Milliseconds()})
 					if err := ctx.Err(); err != nil {
-						closeToolResults(idx+1, toolCallAccepted, "root_cancel_after_task_complete", skippedToolResults(comp.ToolCalls[idx+1:], toolSkippedByCancellationText)...)
+						if !closeToolResults(idx+1, toolCallAccepted, "root_cancel_after_task_complete", historyOnlyResults(skippedToolResults(comp.ToolCalls[idx+1:], toolSkippedByCancellationText))...) {
+							return
+						}
 						a.appendMessages(pendingBlockMessages)
 						pendingBlockMessages = nil
 						emitSDKErr(a.errEvent(err))
@@ -1516,7 +1576,9 @@ func (a *Agent) queryStreamWithSteering(ctx context.Context, input llm.Content, 
 					// still be closed: a parallel `done` that is not the last
 					// call would otherwise leave tool_use blocks with no result,
 					// making the *next* turn's first provider request invalid.
-					closeToolResults(idx+1, toolCallAccepted, "task_complete_tail", skippedToolResults(comp.ToolCalls[idx+1:], toolSkippedByTurnEndText)...)
+					if !closeToolResults(idx+1, toolCallAccepted, "task_complete_tail", historyOnlyResults(skippedToolResults(comp.ToolCalls[idx+1:], toolSkippedByTurnEndText))...) {
+						return
+					}
 					a.appendMessages(pendingBlockMessages)
 					pendingBlockMessages = nil
 					if a.hasCompactor {
@@ -1531,7 +1593,9 @@ func (a *Agent) queryStreamWithSteering(ctx context.Context, input llm.Content, 
 						}
 					}
 					requireDoneRecoveryDisableThinkingActive = false
-					finishToolBlock()
+					if !finishToolBlock() {
+						return
+					}
 					emitFinal(finalContent, finalResponseID)
 					return
 				}
@@ -1546,15 +1610,21 @@ func (a *Agent) queryStreamWithSteering(ctx context.Context, input llm.Content, 
 
 				// append tool message
 				result := projectToolResult(llm.Message{Role: llm.RoleTool, ToolCallID: tc.ID, ToolName: resolvedName, Content: content, IsError: isError, Ephemeral: ephemeral}, meta, originalResult)
-				closeToolResults(idx, toolCallRunning, "handler_return", result.history)
+				if !closeToolResults(idx, toolCallRunning, "handler_return", result) {
+					return
+				}
 
-				a.emitToolResultWithAccounting(out, result, time.Since(start))
+				if !publishToolResult(idx, time.Since(start)) {
+					return
+				}
 				a.emitEvent(out, StepCompleteEvent{StepID: tc.ID, Status: status, DurationMS: time.Since(start).Milliseconds()})
 				if rootCancelErr == nil {
 					rootCancelErr = ctx.Err()
 				}
 				if rootCancelErr != nil {
-					closeToolResults(idx+1, toolCallAccepted, "root_cancel_after_handler", skippedToolResults(comp.ToolCalls[idx+1:], toolSkippedByCancellationText)...)
+					if !closeToolResults(idx+1, toolCallAccepted, "root_cancel_after_handler", historyOnlyResults(skippedToolResults(comp.ToolCalls[idx+1:], toolSkippedByCancellationText))...) {
+						return
+					}
 					a.appendMessages(pendingBlockMessages)
 					pendingBlockMessages = nil
 					emitSDKErr(a.errEvent(rootCancelErr))
@@ -1576,14 +1646,20 @@ func (a *Agent) queryStreamWithSteering(ctx context.Context, input llm.Content, 
 					// *before* the steering text enters history. A user message
 					// between two tool results of the same assistant block makes
 					// the whole conversation permanently unsendable.
-					closeToolResults(idx+1, toolCallAccepted, "steering", skippedToolResults(comp.ToolCalls[idx+1:], toolSkippedBySteeringText)...)
+					// Queue consumed input before terminal acceptance so failure
+					// recovery can retain it after closing the remaining calls.
 					pendingBlockMessages = append(pendingBlockMessages, steeringMessages...)
+					if !closeToolResults(idx+1, toolCallAccepted, "steering", historyOnlyResults(skippedToolResults(comp.ToolCalls[idx+1:], toolSkippedBySteeringText))...) {
+						return
+					}
 					break
 				}
 			}
 			// The assistant tool-call block is now closed: every tool_use has a
 			// tool_result. Only here may user-role messages enter history.
-			finishToolBlock()
+			if !finishToolBlock() {
+				return
+			}
 			a.appendMessages(pendingBlockMessages)
 			pendingBlockMessages = nil
 			if a.hasCompactor {

--- a/sdk/agent/agent.go
+++ b/sdk/agent/agent.go
@@ -1273,6 +1273,9 @@ func (a *Agent) queryStreamWithSteering(ctx context.Context, input llm.Content, 
 			// once every tool_use in the block has a matching tool_result.
 			activeToolBlock, err = newToolBlockState(comp.ToolCalls)
 			if err != nil {
+				// No block was accepted. Defensively discard the staged assistant
+				// topology if IDs changed after the earlier admission check.
+				a.discardContinuationToolCalls(&cont, msgIndex)
 				failToolBlock(err)
 				return
 			}

--- a/sdk/agent/agent_cancel_boundary_test.go
+++ b/sdk/agent/agent_cancel_boundary_test.go
@@ -396,7 +396,7 @@ func finalText(events []Event) string {
 	return ""
 }
 
-func BenchmarkToolBlockShadowLifecycle(b *testing.B) {
+func BenchmarkToolBlockTerminalLifecycle(b *testing.B) {
 	ids := []string{"a", "b", "c", "d", "e", "f", "g", "h"}
 	calls := make([]llm.ToolCall, len(ids))
 	for i, id := range ids {
@@ -404,11 +404,20 @@ func BenchmarkToolBlockShadowLifecycle(b *testing.B) {
 	}
 	b.ReportAllocs()
 	for i := 0; i < b.N; i++ {
-		state := newToolBlockState(calls)
+		state, err := newToolBlockState(calls)
+		if err != nil {
+			b.Fatal(err)
+		}
 		for ordinal := range calls {
 			state.markRunning(ordinal)
 			state.markAttemptReturned(ordinal, false)
-			state.markTerminal(ordinal, toolCallRunning, "handler_return")
+			result := projectToolResult(llm.NewToolMessage(calls[ordinal].ID, "tool", llm.TextContent("ok"), false), nil, "ok")
+			if _, err := state.acceptResults(ordinal, toolCallRunning, "handler_return", []toolResultProjection{result}); err != nil {
+				b.Fatal(err)
+			}
+			if _, err := state.takePublication(ordinal); err != nil {
+				b.Fatal(err)
+			}
 		}
 		if err := state.validateClosed(); err != nil {
 			b.Fatal(err)

--- a/sdk/agent/tool_block_admission_test.go
+++ b/sdk/agent/tool_block_admission_test.go
@@ -1,0 +1,77 @@
+package agent
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/timwhitez/agent-sdk-golang/sdk/llm"
+	"github.com/timwhitez/agent-sdk-golang/sdk/tools"
+)
+
+// Inject corruption after the early provider-ID check, through a synchronous
+// clock callback. Constructor rejection must also discard this unaccepted block.
+func TestToolBlockConstructorFailureDiscardsUnacceptedHistory(t *testing.T) {
+	providers, handled := 0, 0
+	completion := &llm.Completion{Content: llm.TextContent("visible before failure"), ToolCalls: []llm.ToolCall{
+		{ID: "a", Function: llm.FunctionCall{Name: "work", Arguments: "{}"}},
+		{ID: "b", Function: llm.FunctionCall{Name: "work", Arguments: "{}"}},
+	}}
+	model := &frameScriptModel{invoke: func(llm.InvokeRequest) (*llm.Completion, error) {
+		providers++
+		if providers == 1 {
+			return completion, nil
+		}
+		return &llm.Completion{Content: llm.TextContent("next")}, nil
+	}}
+	ag, err := New(Config{LLM: model, Tools: []tools.Tool{{Name: "work", Handler: func(context.Context, json.RawMessage, *tools.Container) (llm.Content, error) {
+		handled++
+		return llm.Content{}, nil
+	}}}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	injected := false
+	ag.eventClock = func() time.Time {
+		if providers == 1 && !injected {
+			completion.ToolCalls[1].ID = "a"
+			injected = true
+		}
+		return time.Unix(0, 0)
+	}
+	errorsSeen := 0
+	for envelope := range ag.QueryStreamEnveloped(context.Background(), llm.TextContent("run")) {
+		switch e := envelope.Event.(type) {
+		case ErrorEvent:
+			errorsSeen++
+			if e.Kind != "invalid_tool_call_block" || envelope.Origin != EventOriginSDKDriver {
+				t.Error("wrong admission failure")
+			}
+		case ToolCallEvent, ToolResultEvent, StepStartEvent, StepCompleteEvent:
+			t.Errorf("unaccepted block emitted %T", e)
+		}
+	}
+	if !injected || providers != 1 || handled != 0 || errorsSeen != 1 {
+		t.Fatal("constructor failure did not stop admission")
+	}
+	visible := false
+	for _, m := range ag.Messages() {
+		if len(m.ToolCalls) != 0 || m.Role == llm.RoleTool {
+			t.Fatal("constructor rejection retained invalid unaccepted topology")
+		}
+		visible = visible || strings.Contains(m.Content.PlainText(), "visible before failure")
+	}
+	if !visible {
+		t.Fatal("discard lost visible text")
+	}
+	for e := range ag.QueryStream(context.Background(), llm.TextContent("next")) {
+		if w, ok := e.(WarnEvent); ok && w.Kind == "tool_pairing_repaired" {
+			t.Fatal("next query needed repair")
+		}
+	}
+	if providers != 2 {
+		t.Fatal("next query failed")
+	}
+}

--- a/sdk/agent/tool_block_state.go
+++ b/sdk/agent/tool_block_state.go
@@ -8,14 +8,12 @@ import (
 )
 
 type toolCallPhase string
-
 type toolExecutionKnowledge uint8
 
 const (
-	toolCallAccepted toolCallPhase = "accepted"
-	toolCallRunning  toolCallPhase = "running"
-	toolCallTerminal toolCallPhase = "terminal"
-
+	toolCallAccepted     toolCallPhase          = "accepted"
+	toolCallRunning      toolCallPhase          = "running"
+	toolCallTerminal     toolCallPhase          = "terminal"
 	toolExecutionUnknown toolExecutionKnowledge = iota
 	toolExecutionNotStarted
 	toolExecutionAttemptStarted
@@ -23,11 +21,32 @@ const (
 	toolExecutionIndeterminate
 )
 
+type toolPublication uint8
+
+const (
+	toolPublicationNone toolPublication = iota // history-only terminal
+	toolPublicationPending
+	toolPublicationClaimed // not a claim of delivery
+	toolPublicationAborted
+)
+
 type toolCallState struct {
+	id, name           string
 	phase              toolCallPhase
 	executionKnowledge toolExecutionKnowledge
 	terminalCount      int
 	closure            string
+	publication        toolPublication
+	result             *toolResultProjection
+}
+
+type toolBlockTransitionError struct {
+	index int
+	code  string
+}
+
+func (e *toolBlockTransitionError) Error() string {
+	return fmt.Sprintf("tool lifecycle call[%d]: %s", e.index, e.code)
 }
 
 func (k toolExecutionKnowledge) String() string {
@@ -45,131 +64,179 @@ func (k toolExecutionKnowledge) String() string {
 	}
 }
 
-// toolBlockState is an observe-only mirror of the sequential Tool Loop. It is
-// deliberately query-local and does not construct history, events, or results.
+// toolBlockState is query/block-local terminal and publication authority, owned
+// by the sequential driver (not a concurrent scheduler or a durable ledger).
+// It retains accepted identity, never arguments. Pending projection payloads
+// are released on publication claim or abort; claim does not imply delivery.
 type toolBlockState struct {
-	calls      []toolCallState
-	violations []string
+	calls        []toolCallState
+	nextTerminal int
 }
 
-func newToolBlockState(calls []llm.ToolCall) *toolBlockState {
-	block := &toolBlockState{calls: make([]toolCallState, len(calls))}
-	seen := make(map[string]int, len(calls))
+func newToolBlockState(calls []llm.ToolCall) (*toolBlockState, error) {
+	b := &toolBlockState{calls: make([]toolCallState, len(calls))}
+	seen := make(map[string]bool, len(calls))
 	for i, call := range calls {
 		id := strings.TrimSpace(call.ID)
-		block.calls[i] = toolCallState{phase: toolCallAccepted, executionKnowledge: toolExecutionNotStarted}
 		if id == "" {
-			block.addViolation("call[%d] has empty id", i)
-			continue
+			return nil, &toolBlockTransitionError{i, "empty_id"}
 		}
-		if first, ok := seen[id]; ok {
-			block.addViolation("call[%d] duplicates the id from call[%d]", i, first)
-			continue
+		if seen[id] {
+			return nil, &toolBlockTransitionError{i, "duplicate_id"}
 		}
-		seen[id] = i
+		seen[id] = true
+		name := strings.TrimSpace(call.Function.Name)
+		if name == "" {
+			name = "unknown"
+		}
+		b.calls[i] = toolCallState{id: id, name: name, phase: toolCallAccepted, executionKnowledge: toolExecutionNotStarted}
 	}
-	return block
+	return b, nil
 }
 
-func (b *toolBlockState) markRunning(index int) {
-	call, ok := b.call(index)
-	if !ok {
-		return
+func (b *toolBlockState) call(index int) (*toolCallState, error) {
+	if b == nil || index < 0 || index >= len(b.calls) {
+		return nil, &toolBlockTransitionError{index, "out_of_range"}
 	}
-	if call.phase != toolCallAccepted {
-		b.addViolation("call[%d] cannot start from phase %q", index, call.phase)
-		return
+	return &b.calls[index], nil
+}
+
+func (b *toolBlockState) markRunning(index int) error {
+	call, err := b.call(index)
+	if err != nil {
+		return err
 	}
-	if call.executionKnowledge != toolExecutionNotStarted {
-		b.addViolation("call[%d] cannot start from execution %q", index, call.executionKnowledge)
-		return
+	if call.phase != toolCallAccepted || call.executionKnowledge != toolExecutionNotStarted || call.terminalCount != 0 {
+		return &toolBlockTransitionError{index, "cannot_start"}
 	}
 	call.phase = toolCallRunning
 	call.executionKnowledge = toolExecutionAttemptStarted
+	return nil
 }
 
-func (b *toolBlockState) markAttemptReturned(index int, rootCanceled bool) {
-	call, ok := b.call(index)
-	if !ok {
-		return
+func (b *toolBlockState) markAttemptReturned(index int, rootCanceled bool) error {
+	call, err := b.call(index)
+	if err != nil {
+		return err
 	}
-	if call.phase != toolCallRunning || call.executionKnowledge != toolExecutionAttemptStarted {
-		b.addViolation("call[%d] cannot observe attempt return from phase %q execution %q", index, call.phase, call.executionKnowledge)
-		return
+	if call.phase != toolCallRunning || call.executionKnowledge != toolExecutionAttemptStarted || call.terminalCount != 0 {
+		return &toolBlockTransitionError{index, "cannot_observe_return"}
 	}
 	call.executionKnowledge = toolExecutionOutcomeObserved
 	if rootCanceled {
 		call.executionKnowledge = toolExecutionIndeterminate
 	}
+	return nil
 }
 
-func (b *toolBlockState) markTerminal(index int, expected toolCallPhase, closure string) {
-	call, ok := b.call(index)
-	if !ok {
-		return
+// acceptResults validates the entire batch before accepting any result. The
+// caller appends returned history exactly once; rejected proposals have no effect.
+func (b *toolBlockState) acceptResults(start int, expected toolCallPhase, closure string, results []toolResultProjection) ([]llm.Message, error) {
+	if b == nil || start < 0 || start > len(b.calls) || len(results) > len(b.calls)-start {
+		return nil, &toolBlockTransitionError{start, "invalid_range"}
 	}
-	call.terminalCount++
-	if call.terminalCount != 1 {
-		b.addViolation("call[%d] has %d terminal transitions", index, call.terminalCount)
-		return
+	if expected != toolCallAccepted && expected != toolCallRunning {
+		return nil, &toolBlockTransitionError{start, "invalid_expected_phase"}
 	}
-	if call.phase != expected {
-		b.addViolation("call[%d] closed by %q from phase %q, want %q", index, closure, call.phase, expected)
-		return
+	if start != b.nextTerminal {
+		if start < b.nextTerminal && len(results) > 0 {
+			return nil, &toolBlockTransitionError{start, "duplicate_terminal"}
+		}
+		return nil, &toolBlockTransitionError{start, "out_of_order_terminal"}
 	}
-	if expected == toolCallAccepted && call.executionKnowledge != toolExecutionNotStarted {
-		b.addViolation("call[%d] closed by %q from execution %q, want %q", index, closure, call.executionKnowledge, toolExecutionNotStarted)
+	for offset, result := range results {
+		index := start + offset
+		call := &b.calls[index]
+		if call.phase == toolCallTerminal || call.terminalCount != 0 {
+			return nil, &toolBlockTransitionError{index, "duplicate_terminal"}
+		}
+		if call.phase != expected {
+			return nil, &toolBlockTransitionError{index, "wrong_phase"}
+		}
+		if (expected == toolCallAccepted && call.executionKnowledge != toolExecutionNotStarted) || (expected == toolCallRunning && call.executionKnowledge != toolExecutionOutcomeObserved && call.executionKnowledge != toolExecutionIndeterminate) {
+			return nil, &toolBlockTransitionError{index, "invalid_execution_knowledge"}
+		}
+		if result.history.Role != llm.RoleTool || result.history.ToolCallID != call.id || len(result.history.ToolCalls) != 0 {
+			return nil, &toolBlockTransitionError{index, "invalid_result_identity"}
+		}
 	}
-	if expected == toolCallRunning && call.executionKnowledge != toolExecutionOutcomeObserved && call.executionKnowledge != toolExecutionIndeterminate {
-		b.addViolation("call[%d] closed by %q from execution %q, want terminal execution knowledge", index, closure, call.executionKnowledge)
+	history := make([]llm.Message, len(results))
+	for offset, result := range results {
+		call := &b.calls[start+offset]
+		result.history = llm.CloneMessage(result.history)
+		if result.metadata != nil {
+			result.metadata = cloneToolResultMetadata(result.metadata)
+		}
+		history[offset] = llm.CloneMessage(result.history)
+		call.phase = toolCallTerminal
+		call.terminalCount = 1
+		call.closure = closure
+		if result.publish {
+			call.publication = toolPublicationPending
+			call.result = &result
+		}
 	}
-	call.phase = toolCallTerminal
-	call.closure = closure
+	b.nextTerminal += len(results)
+	return history, nil
 }
 
-func (b *toolBlockState) markTerminalRange(start int, expected toolCallPhase, closure string) {
+func (b *toolBlockState) takePublication(index int) (toolResultProjection, error) {
+	call, err := b.call(index)
+	if err != nil {
+		return toolResultProjection{}, err
+	}
+	if call.phase != toolCallTerminal || call.terminalCount != 1 || index >= b.nextTerminal || call.publication != toolPublicationPending || call.result == nil {
+		return toolResultProjection{}, &toolBlockTransitionError{index, "publication_unavailable"}
+	}
+	result := *call.result
+	call.result = nil
+	call.publication = toolPublicationClaimed
+	return result, nil
+}
+
+// abortOpen is an idempotent, non-reentrant recovery path. It never rewrites
+// terminal history. Observed execution and failed projection remain distinct.
+func (b *toolBlockState) abortOpen() []llm.Message {
 	if b == nil {
-		return
+		return nil
 	}
-	if start < 0 || start > len(b.calls) {
-		b.addViolation("terminal range start %d outside block length %d", start, len(b.calls))
-		return
+	var rows []llm.Message
+	for i := range b.calls {
+		call := &b.calls[i]
+		call.result = nil
+		if call.publication == toolPublicationPending {
+			call.publication = toolPublicationAborted
+		}
+		if call.terminalCount > 0 {
+			call.phase = toolCallTerminal
+			continue
+		}
+		text := "[ERROR] Tool result unavailable after an internal lifecycle failure; result is indeterminate and execution may have occurred."
+		if call.phase == toolCallAccepted && call.executionKnowledge == toolExecutionNotStarted {
+			text = "[ERROR] Tool skipped before execution because of an internal lifecycle failure."
+		} else if call.executionKnowledge != toolExecutionOutcomeObserved {
+			call.executionKnowledge = toolExecutionIndeterminate
+		}
+		rows = append(rows, llm.NewToolMessage(call.id, call.name, llm.TextContent(text), true))
+		call.phase = toolCallTerminal
+		call.terminalCount = 1
+		call.closure = "lifecycle_failure"
 	}
-	for i := start; i < len(b.calls); i++ {
-		b.markTerminal(i, expected, closure)
-	}
+	b.nextTerminal = len(b.calls)
+	return rows
 }
 
 func (b *toolBlockState) validateClosed() error {
 	if b == nil {
 		return nil
 	}
-	violations := append([]string(nil), b.violations...)
+	if b.nextTerminal != len(b.calls) {
+		return &toolBlockTransitionError{b.nextTerminal, "incomplete_block"}
+	}
 	for i, call := range b.calls {
-		if call.phase != toolCallTerminal || call.terminalCount != 1 || call.executionKnowledge == toolExecutionUnknown || call.executionKnowledge == toolExecutionAttemptStarted {
-			violations = append(violations, fmt.Sprintf("call[%d] remains phase=%q execution=%q terminal_count=%d", i, call.phase, call.executionKnowledge, call.terminalCount))
+		if call.phase != toolCallTerminal || call.terminalCount != 1 || call.executionKnowledge == toolExecutionUnknown || call.executionKnowledge == toolExecutionAttemptStarted || call.publication == toolPublicationPending || call.result != nil {
+			return &toolBlockTransitionError{i, "incomplete_block"}
 		}
 	}
-	if len(violations) == 0 {
-		return nil
-	}
-	return fmt.Errorf("%s", strings.Join(violations, "; "))
-}
-
-func (b *toolBlockState) call(index int) (*toolCallState, bool) {
-	if b == nil {
-		return nil, false
-	}
-	if index < 0 || index >= len(b.calls) {
-		b.addViolation("call index %d outside block length %d", index, len(b.calls))
-		return nil, false
-	}
-	return &b.calls[index], true
-}
-
-func (b *toolBlockState) addViolation(format string, args ...any) {
-	if b == nil {
-		return
-	}
-	b.violations = append(b.violations, fmt.Sprintf(format, args...))
+	return nil
 }

--- a/sdk/agent/tool_block_state_test.go
+++ b/sdk/agent/tool_block_state_test.go
@@ -13,18 +13,18 @@ import (
 )
 
 func TestToolBlockStateTracksExecutedAndUnstartedClosure(t *testing.T) {
-	block := newToolBlockState([]llm.ToolCall{{ID: "run"}, {ID: "skip"}})
+	block := terminalFixture(t, "run", "skip")
 	block.markRunning(0)
 	block.markAttemptReturned(0, false)
-	block.markTerminal(0, toolCallRunning, "handler_return")
-	block.markTerminal(1, toolCallAccepted, "turn_end")
+	acceptHistoryTerminal(t, block, 0, toolCallRunning, "handler_return")
+	acceptHistoryTerminal(t, block, 1, toolCallAccepted, "turn_end")
 	if err := block.validateClosed(); err != nil {
 		t.Fatal(err)
 	}
 }
 
 func TestToolBlockStateExecutionKnowledgeTransitions(t *testing.T) {
-	block := newToolBlockState([]llm.ToolCall{{ID: "observed"}, {ID: "indeterminate"}, {ID: "unstarted"}})
+	block := terminalFixture(t, "observed", "indeterminate", "unstarted")
 	if got := block.calls[0].executionKnowledge; got != toolExecutionNotStarted {
 		t.Fatalf("accepted execution=%q want %q", got, toolExecutionNotStarted)
 	}
@@ -33,11 +33,11 @@ func TestToolBlockStateExecutionKnowledgeTransitions(t *testing.T) {
 		t.Fatalf("running execution=%q want %q", got, toolExecutionAttemptStarted)
 	}
 	block.markAttemptReturned(0, false)
-	block.markTerminal(0, toolCallRunning, "handler_return")
+	acceptHistoryTerminal(t, block, 0, toolCallRunning, "handler_return")
 	block.markRunning(1)
 	block.markAttemptReturned(1, true)
-	block.markTerminal(1, toolCallRunning, "handler_return")
-	block.markTerminal(2, toolCallAccepted, "root_cancel_after_handler")
+	acceptHistoryTerminal(t, block, 1, toolCallRunning, "handler_return")
+	acceptHistoryTerminal(t, block, 2, toolCallAccepted, "root_cancel_after_handler")
 
 	if got := block.calls[0].executionKnowledge; got != toolExecutionOutcomeObserved {
 		t.Fatalf("observed execution=%q want %q", got, toolExecutionOutcomeObserved)
@@ -114,51 +114,13 @@ func TestToolBlockStateObservesOrdinaryAttemptOutcomes(t *testing.T) {
 	}
 }
 
-func TestToolBlockStateReportsInvariantViolations(t *testing.T) {
-	tests := []struct {
-		name string
-		run  func(*toolBlockState)
-		want string
-	}{
-		{name: "missing terminal", run: func(*toolBlockState) {}, want: "remains phase=\"accepted\""},
-		{name: "duplicate terminal", run: func(block *toolBlockState) {
-			block.markTerminal(0, toolCallAccepted, "first")
-			block.markTerminal(0, toolCallTerminal, "second")
-		}, want: "2 terminal transitions"},
-		{name: "wrong phase", run: func(block *toolBlockState) {
-			block.markTerminal(0, toolCallRunning, "handler_return")
-		}, want: "want \"running\""},
-		{name: "running without returned outcome", run: func(block *toolBlockState) {
-			block.markRunning(0)
-			block.markTerminal(0, toolCallRunning, "handler_return")
-		}, want: "want terminal execution knowledge"},
-		{name: "terminal unknown execution", run: func(block *toolBlockState) {
-			block.markTerminal(0, toolCallAccepted, "turn_end")
-			block.calls[0].executionKnowledge = toolExecutionUnknown
-		}, want: "execution=\"unknown\""},
-		{name: "out of range", run: func(block *toolBlockState) {
-			block.markRunning(1)
-			block.markTerminal(0, toolCallAccepted, "turn_end")
-		}, want: "outside block length"},
-	}
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			block := newToolBlockState([]llm.ToolCall{{ID: "call-1"}})
-			test.run(block)
-			err := block.validateClosed()
-			if err == nil || !strings.Contains(err.Error(), test.want) {
-				t.Fatalf("error=%v want substring %q", err, test.want)
-			}
-		})
-	}
-}
-
 func TestToolBlockStateRejectsAmbiguousAcceptedIDs(t *testing.T) {
-	block := newToolBlockState([]llm.ToolCall{{ID: ""}, {ID: "same"}, {ID: "same"}})
-	block.markTerminalRange(0, toolCallAccepted, "closed")
-	err := block.validateClosed()
-	if err == nil || !strings.Contains(err.Error(), "empty id") || !strings.Contains(err.Error(), "duplicates the id") || strings.Contains(err.Error(), "same") {
-		t.Fatalf("error=%v", err)
+	for _, calls := range [][]llm.ToolCall{{{ID: ""}}, {{ID: "private-id"}, {ID: "private-id"}}} {
+		block, err := newToolBlockState(calls)
+		var typed *toolBlockTransitionError
+		if block != nil || !errors.As(err, &typed) || strings.Contains(err.Error(), "private-id") {
+			t.Fatalf("invalid block=%v err=%v", block, err)
+		}
 	}
 }
 

--- a/sdk/agent/tool_result_projection.go
+++ b/sdk/agent/tool_result_projection.go
@@ -2,7 +2,7 @@ package agent
 
 import "github.com/timwhitez/agent-sdk-golang/sdk/llm"
 
-// toolResultProjection is local to one result, not a second terminal authority.
+// toolResultProjection is accepted by toolBlockState, not a second authority.
 // History commit and event publication keep their existing separate boundaries.
 // The loop guard intentionally has a shorter event view than its history view.
 type toolResultProjection struct {
@@ -10,10 +10,19 @@ type toolResultProjection struct {
 	visible  string
 	original string
 	metadata map[string]any
+	publish  bool
 }
 
 func projectToolResult(history llm.Message, metadata map[string]any, original string) toolResultProjection {
-	return toolResultProjection{history: history, visible: history.Content.PlainText(), original: original, metadata: metadata}
+	return toolResultProjection{history: history, visible: history.Content.PlainText(), original: original, metadata: metadata, publish: true}
+}
+
+func historyOnlyResults(messages []llm.Message) []toolResultProjection {
+	results := make([]toolResultProjection, len(messages))
+	for i, message := range messages {
+		results[i].history = message
+	}
+	return results
 }
 
 func (p toolResultProjection) event() ToolResultEvent {

--- a/sdk/agent/tool_terminal_authority_test.go
+++ b/sdk/agent/tool_terminal_authority_test.go
@@ -1,0 +1,407 @@
+package agent
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/timwhitez/agent-sdk-golang/sdk/llm"
+	"github.com/timwhitez/agent-sdk-golang/sdk/tools"
+)
+
+func terminalFixture(t *testing.T, ids ...string) *toolBlockState {
+	t.Helper()
+	calls := make([]llm.ToolCall, len(ids))
+	for i, id := range ids {
+		calls[i] = llm.ToolCall{ID: id, Function: llm.FunctionCall{Name: "private-tool"}}
+	}
+	b, err := newToolBlockState(calls)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return b
+}
+
+func TestTerminalDriverRejectsAndClosesRemainingCalls(t *testing.T) {
+	for _, mode := range []string{"start", "return", "commit", "second_commit", "duplicate_commit", "steering_tail"} {
+		t.Run(mode, func(t *testing.T) {
+			var ag *Agent
+			var block *toolBlockState
+			handled, providers, injected := 0, 0, false
+			steering := make(chan SteeringMsg, 1)
+			model := &frameScriptModel{invoke: func(llm.InvokeRequest) (*llm.Completion, error) {
+				providers++
+				if providers > 1 {
+					return &llm.Completion{Content: llm.TextContent("next")}, nil
+				}
+				return &llm.Completion{ToolCalls: []llm.ToolCall{
+					{ID: "a", Function: llm.FunctionCall{Name: "work", Arguments: "{}"}},
+					{ID: "b", Function: llm.FunctionCall{Name: "work", Arguments: "{}"}},
+					{ID: "c", Function: llm.FunctionCall{Name: "work", Arguments: "{}"}},
+				}}, nil
+			}}
+			var err error
+			ag, err = New(Config{LLM: model, Tools: []tools.Tool{{Name: "work", Handler: func(context.Context, json.RawMessage, *tools.Container) (llm.Content, error) {
+				handled++
+				if mode == "steering_tail" {
+					steering <- SteeringMsg{Content: "retained steering input"}
+				}
+				if mode == "return" {
+					block.calls[0].phase = toolCallAccepted
+					injected = true
+				}
+				return llm.TextContent("completed fixture effect"), nil
+			}}}, ToolResultTokenEstimator: func(text string) int {
+				if injected || block == nil {
+					return len(text)
+				}
+				index := 0
+				if mode == "second_commit" {
+					index = 1
+				}
+				if handled != index+1 {
+					return len(text)
+				}
+				if mode == "commit" || mode == "second_commit" {
+					block.calls[index].phase = toolCallAccepted
+					injected = true
+				}
+				if mode == "duplicate_commit" {
+					p := terminalProjection("a")
+					p.history.Content = llm.TextContent("already committed")
+					rows, commitErr := block.acceptResults(0, toolCallRunning, "first", []toolResultProjection{p})
+					if commitErr != nil {
+						t.Error(commitErr)
+					}
+					ag.appendMessages(rows) // inject a completed first commit before the attempted duplicate
+					injected = true
+				}
+				return len(text)
+			}, Warningf: func(string, ...any) {}})
+			if err != nil {
+				t.Fatal(err)
+			}
+			ag.toolBlockTestHook = func(b *toolBlockState) {
+				block = b
+				if mode == "steering_tail" {
+					b.calls[1].phase = toolCallRunning
+					injected = true
+				}
+				if mode == "start" {
+					b.calls[0].phase = toolCallRunning
+					injected = true
+				}
+			}
+			errorsSeen, resultEvents, accountEvents := 0, 0, 0
+			for envelope := range ag.QueryStreamEnvelopedWithSteering(context.Background(), llm.TextContent("private prompt"), steering) {
+				switch event := envelope.Event.(type) {
+				case ErrorEvent:
+					errorsSeen++
+					if event.Kind != "invalid_tool_call_block" || envelope.Origin != EventOriginSDKDriver || strings.Contains(event.Message, "private") {
+						t.Error("unsafe lifecycle failure diagnostic")
+					}
+				case ToolResultEvent:
+					resultEvents++
+				case AccountingEvent:
+					if event.ToolCallID != "" {
+						accountEvents++
+					}
+				}
+			}
+			wantHandled, wantEvents := 1, 0
+			if mode == "start" {
+				wantHandled = 0
+			}
+			if mode == "second_commit" {
+				wantHandled = 2
+				wantEvents = 1
+			}
+			if mode == "steering_tail" {
+				wantEvents = 1
+			}
+			if !injected || providers != 1 || handled != wantHandled || errorsSeen != 1 || resultEvents != wantEvents || accountEvents != wantEvents {
+				t.Fatalf("injected/provider/handler/errors/result/account=%v/%d/%d/%d/%d/%d", injected, providers, handled, errorsSeen, resultEvents, accountEvents)
+			}
+			var results []llm.Message
+			for _, message := range ag.Messages() {
+				if message.Role == llm.RoleTool {
+					results = append(results, message)
+				}
+			}
+			if len(results) != 3 {
+				t.Fatalf("terminal history count=%d", len(results))
+			}
+			if mode == "steering_tail" {
+				history := ag.Messages()
+				if history[len(history)-1].Role != llm.RoleUser || history[len(history)-1].Content.PlainText() != "retained steering input" {
+					t.Fatal("rejection lost consumed steering or appended it before closure")
+				}
+			}
+			for i, id := range []string{"a", "b", "c"} {
+				if results[i].ToolCallID != id || block.calls[i].terminalCount != 1 {
+					t.Error("lost/duplicate terminal identity")
+				}
+			}
+			if mode == "commit" && block.calls[0].executionKnowledge != toolExecutionOutcomeObserved {
+				t.Error("projection rejection erased observed return")
+			}
+			if mode == "return" && block.calls[0].executionKnowledge != toolExecutionIndeterminate {
+				t.Error("unconfirmed return not indeterminate")
+			}
+			if mode == "second_commit" && (results[0].IsError || !results[1].IsError || block.calls[1].executionKnowledge != toolExecutionOutcomeObserved) {
+				t.Error("abort rewrote prior terminal or erased observed return")
+			}
+			if mode == "duplicate_commit" && results[0].Content.PlainText() != "already committed" {
+				t.Error("duplicate rewrote first terminal")
+			}
+			if err := block.validateClosed(); err != nil {
+				t.Fatal(err)
+			}
+			if _, changed, _ := repairToolCallPairsDetailed(ag.Messages()); changed {
+				t.Fatal("abort left dangling topology")
+			}
+			ag.toolBlockTestHook = nil
+			for event := range ag.QueryStream(context.Background(), llm.TextContent("next")) {
+				if warning, ok := event.(WarnEvent); ok && warning.Kind == "tool_pairing_repaired" {
+					t.Error("next query required repair")
+				}
+			}
+			if providers != 2 {
+				t.Fatal("next query failed")
+			}
+		})
+	}
+}
+
+func terminalProjection(id string) toolResultProjection {
+	return projectToolResult(llm.Message{Role: llm.RoleTool, ToolCallID: id, ToolName: "resolved-alias", Content: llm.TextContent("visible")}, map[string]any{"private": "metadata"}, "private original")
+}
+
+func acceptHistoryTerminal(t *testing.T, b *toolBlockState, index int, phase toolCallPhase, reason string) {
+	t.Helper()
+	if _, err := b.acceptResults(index, phase, reason, historyOnlyResults([]llm.Message{{Role: llm.RoleTool, ToolCallID: b.calls[index].id}})); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestTerminalAcceptanceIsAtomicAndPublicationIsOneShot(t *testing.T) {
+	b := terminalFixture(t, "a", "b", "c")
+	proposals := []toolResultProjection{terminalProjection("a"), terminalProjection("wrong-private-id")}
+	before := append([]toolCallState(nil), b.calls...)
+	if _, err := b.acceptResults(0, toolCallAccepted, "guard", proposals); err == nil {
+		t.Fatal("bad batch accepted")
+	} else {
+		var typed *toolBlockTransitionError
+		if !errors.As(err, &typed) || strings.Contains(err.Error(), "private") {
+			t.Fatal("error is untyped or leaks data")
+		}
+	}
+	if !reflect.DeepEqual(before, b.calls) {
+		t.Fatal("batch partially accepted")
+	}
+	proposals[1] = terminalProjection("b")
+	history, err := b.acceptResults(0, toolCallAccepted, "guard", proposals)
+	if err != nil || len(history) != 2 {
+		t.Fatalf("history=%d err=%v", len(history), err)
+	}
+	if _, err = b.acceptResults(0, toolCallAccepted, "duplicate", proposals); err == nil {
+		t.Fatal("duplicate accepted")
+	}
+	if b.calls[0].terminalCount != 1 || b.calls[1].terminalCount != 1 {
+		t.Fatal("duplicate changed accepted state")
+	}
+	for i := 0; i < 2; i++ {
+		p, err := b.takePublication(i)
+		if err != nil || p.history.ToolCallID != history[i].ToolCallID || p.original != "private original" {
+			t.Fatal("wrong publication")
+		}
+		if b.calls[i].result != nil {
+			t.Fatal("claimed result retains raw payload")
+		}
+		if _, err := b.takePublication(i); err == nil {
+			t.Fatal("duplicate publication allowed")
+		}
+	}
+	tail := historyOnlyResults([]llm.Message{{Role: llm.RoleTool, ToolCallID: "c", Content: llm.TextContent("skipped")}})
+	if _, err := b.acceptResults(2, toolCallAccepted, "tail", tail); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := b.takePublication(2); err == nil {
+		t.Fatal("history-only tail published")
+	}
+	if err := b.validateClosed(); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := b.acceptResults(3, toolCallAccepted, "empty", nil); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := b.acceptResults(4, toolCallAccepted, "invalid-empty", nil); err == nil {
+		t.Fatal("invalid empty range accepted")
+	}
+}
+
+func TestTerminalAbortPreservesClosedAndExecutionKnowledge(t *testing.T) {
+	b := terminalFixture(t, "closed", "observed", "running", "unstarted")
+	if _, err := b.acceptResults(0, toolCallAccepted, "guard", []toolResultProjection{terminalProjection("closed")}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := b.takePublication(0); err != nil {
+		t.Fatal(err)
+	}
+	if err := b.markRunning(1); err != nil {
+		t.Fatal(err)
+	}
+	if err := b.markAttemptReturned(1, false); err != nil {
+		t.Fatal(err)
+	}
+	if err := b.markRunning(2); err != nil {
+		t.Fatal(err)
+	}
+	rows := b.abortOpen()
+	if len(rows) != 3 || rows[0].ToolCallID != "observed" || rows[1].ToolCallID != "running" || rows[2].ToolCallID != "unstarted" {
+		t.Fatal("abort lost ordinal identity or rewrote closed call")
+	}
+	if b.calls[1].executionKnowledge != toolExecutionOutcomeObserved || b.calls[2].executionKnowledge != toolExecutionIndeterminate || b.calls[3].executionKnowledge != toolExecutionNotStarted {
+		t.Fatal("abort conflated execution evidence")
+	}
+	for i, row := range rows {
+		if !row.IsError || (i < 2 && !strings.Contains(row.Content.PlainText(), "indeterminate")) {
+			t.Fatal("unsafe abort representation")
+		}
+	}
+	if len(b.abortOpen()) != 0 {
+		t.Fatal("abort not idempotent")
+	}
+	if err := b.validateClosed(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestTerminalRejectionsDoNotMutateAndAcceptedRecordIsOwned(t *testing.T) {
+	b := terminalFixture(t, "a", "b")
+	if _, err := b.acceptResults(1, toolCallAccepted, "wrong_order", []toolResultProjection{terminalProjection("b")}); err == nil || b.nextTerminal != 0 {
+		t.Fatal("out-of-order result accepted")
+	}
+	if err := b.markAttemptReturned(0, false); err == nil {
+		t.Fatal("return before start accepted")
+	}
+	if err := b.markRunning(0); err != nil {
+		t.Fatal(err)
+	}
+	if err := b.markRunning(0); err == nil {
+		t.Fatal("duplicate start accepted")
+	}
+	p := terminalProjection("a")
+	if _, err := b.acceptResults(0, toolCallRunning, "early", []toolResultProjection{p}); err == nil {
+		t.Fatal("unobserved return accepted")
+	}
+	if err := b.markAttemptReturned(0, false); err != nil {
+		t.Fatal(err)
+	}
+	for _, bad := range []llm.Message{{Role: llm.RoleUser, ToolCallID: "a"}, {Role: llm.RoleTool, ToolCallID: "private-wrong"}, {Role: llm.RoleTool, ToolCallID: "a", ToolCalls: []llm.ToolCall{{ID: "nested"}}}} {
+		candidate := p
+		candidate.history = bad
+		if _, err := b.acceptResults(0, toolCallRunning, "bad", []toolResultProjection{candidate}); err == nil {
+			t.Fatal("invalid result accepted")
+		}
+		if b.nextTerminal != 0 || b.calls[0].terminalCount != 0 || b.calls[0].result != nil {
+			t.Fatal("rejected proposal changed authority")
+		}
+	}
+	rows, err := b.acceptResults(0, toolCallRunning, "returned", []toolResultProjection{p})
+	if err != nil {
+		t.Fatal(err)
+	}
+	p.history.ToolCallID = "mutated"
+	p.metadata["private"] = "mutated"
+	rows[0].Content = llm.TextContent("mutated")
+	claimed, err := b.takePublication(0)
+	if err != nil || claimed.history.ToolCallID != "a" || claimed.history.Content.PlainText() != "visible" || claimed.metadata["private"] != "metadata" {
+		t.Fatal("accepted record aliases candidate or returned history")
+	}
+	if len(b.abortOpen()) != 1 {
+		t.Fatal("unstarted sibling lost")
+	}
+	if err := b.validateClosed(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestTerminalDriverPublicationRejectionKeepsGuardAndClosesTail(t *testing.T) {
+	var block *toolBlockState
+	providers, handled := 0, 0
+	model := &frameScriptModel{invoke: func(llm.InvokeRequest) (*llm.Completion, error) {
+		providers++
+		if providers > 1 {
+			return &llm.Completion{Content: llm.TextContent("next")}, nil
+		}
+		var calls []llm.ToolCall
+		for _, id := range []string{"a", "b", "c", "d"} {
+			calls = append(calls, llm.ToolCall{ID: id, Function: llm.FunctionCall{Name: "work", Arguments: "{}"}})
+		}
+		return &llm.Completion{ToolCalls: calls}, nil
+	}}
+	ag, err := New(Config{LLM: model, RepeatToolSignatureThreshold: 3, LoopGuardUserMessage: "guard reminder", Tools: []tools.Tool{{Name: "work", Handler: func(context.Context, json.RawMessage, *tools.Container) (llm.Content, error) {
+		handled++
+		return llm.TextContent("ok"), nil
+	}}}, Warningf: func(string, ...any) {}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	ag.toolBlockTestHook = func(b *toolBlockState) { block = b }
+	claimedEarly := false
+	ag.eventClock = func() time.Time {
+		if !claimedEarly && block != nil && block.calls[2].publication == toolPublicationPending {
+			claimedEarly = true
+			if _, err := block.takePublication(2); err != nil {
+				t.Error(err)
+			}
+		}
+		return time.Unix(0, 0)
+	}
+	errorsSeen, results, accounting := 0, 0, 0
+	for envelope := range ag.QueryStreamEnveloped(context.Background(), llm.TextContent("run")) {
+		switch event := envelope.Event.(type) {
+		case ErrorEvent:
+			errorsSeen++
+			if event.Kind != "invalid_tool_call_block" || envelope.Origin != EventOriginSDKDriver {
+				t.Error("wrong publication failure")
+			}
+		case ToolResultEvent:
+			results++
+		case AccountingEvent:
+			if event.ToolCallID != "" {
+				accounting++
+			}
+		}
+	}
+	if !claimedEarly || providers != 1 || handled != 2 || errorsSeen != 1 || results != 2 || accounting != 2 {
+		t.Fatalf("claimed/provider/handler/errors/results/accounting=%v/%d/%d/%d/%d/%d", claimedEarly, providers, handled, errorsSeen, results, accounting)
+	}
+	var rows []llm.Message
+	for _, m := range ag.Messages() {
+		if m.Role == llm.RoleTool {
+			rows = append(rows, m)
+		}
+	}
+	if len(rows) != 4 || !strings.Contains(rows[2].Content.PlainText(), "loop guard") || !strings.Contains(rows[3].Content.PlainText(), "skipped before execution") {
+		t.Fatal("publication rejection lost committed guard or open tail")
+	}
+	if block.calls[2].publication != toolPublicationClaimed || block.calls[2].result != nil || block.calls[3].executionKnowledge != toolExecutionNotStarted {
+		t.Fatal("claim/delivery/abort evidence conflated")
+	}
+	if _, changed, _ := repairToolCallPairsDetailed(ag.Messages()); changed {
+		t.Fatal("publication rejection left malformed history")
+	}
+	history := ag.Messages()
+	if history[len(history)-1].Content.PlainText() != "guard reminder" {
+		t.Fatal("guard reminder not preserved after closure")
+	}
+	if err := block.validateClosed(); err != nil {
+		t.Fatal(err)
+	}
+}


### PR DESCRIPTION
## Scope

Advances #84: replace append-after-the-fact ToolBlock shadow with sequential terminal acceptance and single-claim publication authority. Reuse the existing block and projection record, not a second closure ledger, scheduler, event queue or retry publisher.

Accepted ID/name are block-local (no arguments). Whole-batch identity/role/range/phase/execution/order checks precede state changes and the single history writer. Invalid candidates cannot partially commit or replace prior terminal results. History-only tails are never publishable. The publisher takes the accepted record by ordinal once and releases pending raw payload references; claim is not reported as delivery, and existing delivery-gated Accounting remains unchanged.

## Failure semantics

Internal rejection closes remaining calls through an idempotent block-owned abort path without re-entering the failed acceptance gate. Already terminal history is retained. Exactly accepted/not_started can be described as unexecuted; started/unconfirmed calls become indeterminate; observed return knowledge remains observed while its unusable result representation explicitly says indeterminate. Consumed steering/reminders are appended only after closure. One source-negative SDK lifecycle error terminates further provider/handler execution.

Normal cancellation, loop guard short event view and intermediate ordering, history-only tails, provider payload, Prompt, public API and persistence protocol remain compatible. No production parallelism. A handler that never returns and ignores cancellation remains outside a finite in-process completion guarantee.

The private test-only block hook enables deterministic Driver boundary corruption; it is not a public host API. Metadata retains the existing opaque-value ownership contract; no claim of deep-freezing arbitrary custom metadata or external side effects.

## Validation plan

Atomic rejection, out-of-order/duplicate terminal, duplicate start, wrong role/identity, history-only publication refusal, one-shot claim/release, idempotent abort, and real Driver start/return/commit/duplicate/publication rejection. Preserve prior terminal rows, observed execution, queued steering and next-query repair=0. Retain #114/#115 trajectory/golden tests. Full/vet/agent race, targeted x100, independent exact-head review/mutations and lifecycle benchmark required before merge.

Prerequisite #116 was separately reproduced on old main (11/1000 race failures); tests-only #117 was independently reviewed and merged as 0882db7673bf2b80e7c26a5ca71c6bd98b0dc723. This branch is rebased on that correction, not retry-to-green or a runtime backpressure-policy change.

Final head 875721998e11f81f77e367662fe6049aa1b25114: gofmt/diff-check, full/vet/agent race, combined authority/constructor/guard/outcome x100 and cancellation race x1000 passed. Logs /tmp/sdk-terminal-final2-{full,race}.log and /tmp/sdk-terminal-exact-{focused,cancel}.log. A synchronous post-precheck ID-corruption test initially reproduced unaccepted history residue; the new constructor-error path now reuses continuation discard and does not fabricate Tool Results. The normal ID precheck remains before history append; constructor itself is later.

Exact-head eight-call sequential lifecycle benchmark, five samples: median 3169 ns/op per eight-call block, 3616 B/op, 18 allocs/op. New lifecycle includes authority/claims and is not comparable to the old shadow-only benchmark. Harness-only cost, not model/provider/task scoring.

Independent exact-head APPROVE (pin194_review): full/vet/agent race, authority/outcome/projection/guard x100, cancellation race x1000 and constructor x100 passed. Eleven compiled mutations detected: partial acceptance, retained claimed payload, missing constructor discard, execution after rejected start, missing abort, lost steering, rewritten prior terminal, duplicate terminal, duplicate claim, published history-only tail, bypassed Accounting delivery gate. Mutation tree restored and retested, no unresolved findings. Logs /tmp/review118-{full,vet,race,focused,cancel,ctor100,restored}.log.

Goode preview at mainfa3f615 with this exact SDK head passed full/vet/app-ui-acp-subtask race. No live Provider or performance improvement claim; future concurrent Scheduler integration remains outside this sequential-owner PR.
