### PR TITLE
fix: fence manual compaction history publication

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -117,6 +117,11 @@ agent_docs/          Detailed architecture/provider/tool/build/test documentatio
   concrete-model snapshotting or proof of mutable handler closure identity.
 
 ### Execution APIs
+- Public manual/preflight compaction shares query admission. Conflicting calls
+  return `ErrAgentBusy`; hosts must not run emergency fallback for this error.
+  Through checkpoint publication, manual compaction rejects checked history
+  replacement (including System updates). Callbacks can still read history and
+  queue configuration updates without a history lock held across host code.
 - `ReplaceHistoryChecked` / `ClearHistoryChecked` return
   `ErrActiveHistoryMutation` when an active query's non-system messages or
   protected tool/continuation tail would change. Legal system-context updates

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -84,6 +84,12 @@ agent_docs/          Detailed architecture/provider/tool/build/test documentatio
   concrete-model snapshotting or proof of mutable handler closure identity.
 
 ### Execution APIs
+- Public manual/preflight compaction shares query admission. Conflicting calls
+  return `ErrAgentBusy`; hosts must not run emergency fallback for this error.
+  Manual compaction rejects all external history replacement until checkpoint
+  publication completes. Callback reads and queued configuration updates remain
+  supported. Public checkpoint-only commit followed by host publication is still
+  a separate two-phase boundary, not covered by this manual-pipeline fence.
 - `ReplaceHistoryChecked` / `ClearHistoryChecked` return
   `ErrActiveHistoryMutation` when an active query's non-system messages or
   protected tool/continuation tail would change. Legal system-context updates

--- a/agent_docs/architecture.md
+++ b/agent_docs/architecture.md
@@ -600,9 +600,16 @@ reset ephemeral tracking or clean result dumps. Idle behavior remains unchanged.
 Continuation updates locate the current assistant by complete JSON identity
 under that mutex, rather than an index captured before System prefix changes.
 `llm.OpenToolCallBlockStart` is shared with compaction protection and is a
-conservative locator, not a second full Tool Pair validator. These public-query
-mutation guarantees do not claim to serialize independent manual compaction or
-freeze mutable runtime dependency handles.
+conservative locator, not a second full Tool Pair validator. Public manual
+compaction now shares query admission: CompactPipelineNow owns the boundary
+through snapshot, calculation, checkpoint and publication. CompactNow and
+CompactLocalNow reuse it; conflicting queries/manual calls return ErrAgentBusy,
+and all external history replacements (including System updates) are rejected.
+No history mutex is held across model or host callbacks. Query-owned automatic
+compaction retains its existing private lifecycle. Hosts must not treat busy as
+permission for emergency fallback. Public checkpoint-only commit followed by
+host history replacement still has a separate publication boundary; this does
+not add an atomic host transaction or freeze mutable runtime dependency handles.
 
 ## Runtime Compaction Configuration Updates
 

--- a/agent_docs/testing.md
+++ b/agent_docs/testing.md
@@ -20,6 +20,11 @@ This document summarizes recommended test commands and current coverage focus.
 - Anthropic provider: `go test ./sdk/llm/anthropic`
 
 ## Coverage Map (Representative)
+- `manual_publication_test.go` covers independent manual-compaction ownership
+  through checkpoint/apply, query and nested manual admission, checked mutation
+  rejection, callback read/config-update safety and error/cancellation release.
+  Public checkpoint-only commits remain separate from host history publication;
+  this is not a new atomic host commit-and-publish API.
 - `history_mutation_test.go` covers checked/legacy Clear and Replace during
   provider-pending and handler-active phases, actual next-request System updates,
   rejection without history/cleanup side effects, reused completed IDs,

--- a/sdk/agent/agent.go
+++ b/sdk/agent/agent.go
@@ -512,7 +512,7 @@ func (a *Agent) Messages() []llm.Message {
 // active-query mutation is reported through Warningf; it is not deferred.
 func (a *Agent) ClearHistory() {
 	if err := a.ClearHistoryChecked(); err != nil {
-		a.warnf("warning: ClearHistory rejected during an active query; use ClearHistoryChecked or wait for query completion")
+		a.warnf("warning: ClearHistory rejected during an active query or manual compaction; use ClearHistoryChecked or wait for completion")
 	}
 }
 
@@ -522,7 +522,7 @@ func (a *Agent) ClearHistory() {
 // owners should use ReplaceHistoryChecked and propagate its error instead.
 func (a *Agent) ReplaceHistory(messages []llm.Message) {
 	if err := a.ReplaceHistoryChecked(messages); err != nil {
-		a.warnf("warning: ReplaceHistory rejected during an active query; use ReplaceHistoryChecked or preserve the active message structure")
+		a.warnf("warning: ReplaceHistory rejected during an active query or manual compaction; use ReplaceHistoryChecked and handle publication conflicts")
 	}
 }
 
@@ -4343,7 +4343,7 @@ func (a *Agent) CompactPipelineNow(ctx context.Context, req compaction.PipelineR
 	}
 	a.applyPendingCompaction(nil)
 	if !a.compactionInFlight.CompareAndSwap(false, true) {
-		return compaction.Result{Compacted: false}, fmt.Errorf("compaction already in progress")
+		return compaction.Result{Compacted: false}, fmt.Errorf("%w: compaction already in progress", ErrAgentBusy)
 	}
 	defer a.releaseCompactionInFlight()
 

--- a/sdk/agent/agent.go
+++ b/sdk/agent/agent.go
@@ -252,9 +252,12 @@ type Agent struct {
 	// whose caller has already gone away.
 	// turnActive is acquired synchronously before the turn goroutine starts,
 	// preventing overlapping submissions from mutating shared turn state.
-	turnActive      atomic.Bool
-	turnCancelMu    sync.Mutex
-	turnCancelByOut map[*eventOutput]*turnBackpressure
+	turnActive atomic.Bool
+	// manualCompactionActive is protected by mu. Manual compaction shares
+	// turnActive admission but rejects even System-only history replacement.
+	manualCompactionActive bool
+	turnCancelMu           sync.Mutex
+	turnCancelByOut        map[*eventOutput]*turnBackpressure
 }
 
 // turnBackpressure carries the per-turn state emitEvent needs on the slow path:
@@ -4310,7 +4313,26 @@ func (a *Agent) CompactNow(ctx context.Context) (compaction.Result, error) {
 // CompactPipelineNow applies the canonical compaction pipeline synchronously.
 // Hosts use this for preflight so they do not duplicate local-versus-summary
 // decisions outside the SDK.
+// It returns ErrAgentBusy instead of overlapping an active query or another
+// public compaction. Hosts must not turn this rejection into a local fallback.
 func (a *Agent) CompactPipelineNow(ctx context.Context, req compaction.PipelineRequest) (compaction.Result, error) {
+	if ctx != nil && ctx.Err() != nil {
+		return compaction.Result{}, ctx.Err()
+	}
+	a.mu.Lock()
+	if !a.turnActive.CompareAndSwap(false, true) {
+		a.mu.Unlock()
+		return compaction.Result{}, ErrAgentBusy
+	}
+	a.manualCompactionActive = true
+	a.mu.Unlock()
+	defer func() {
+		a.mu.Lock()
+		a.manualCompactionActive = false
+		a.turnActive.Store(false)
+		a.mu.Unlock()
+	}()
+
 	releaseCompactionRuntime, err := a.beginCompactionRuntimeUse(ctx)
 	if err != nil {
 		return compaction.Result{Compacted: false}, err

--- a/sdk/agent/history_mutation.go
+++ b/sdk/agent/history_mutation.go
@@ -9,8 +9,9 @@ import (
 )
 
 // ErrActiveHistoryMutation means a replacement could invalidate the active
-// query's conversation or unfinished tool block. No mutation was applied.
-var ErrActiveHistoryMutation = errors.New("agent: history replacement would invalidate an active query")
+// query's conversation or an independent manual compaction publication.
+// No mutation was applied.
+var ErrActiveHistoryMutation = errors.New("agent: history replacement would invalidate an active query or manual compaction")
 
 var errAssistantHistoryChanged = errors.New("agent: current assistant history changed before continuation finalization")
 
@@ -18,10 +19,12 @@ var errAssistantHistoryChanged = errors.New("agent: current assistant history ch
 // system-context update during a query. Non-system messages must retain their
 // full JSON identity and any open tool/continuation tail must remain unchanged.
 // System updates affect the next logical request, not its captured predecessor.
+// An independent manual compaction rejects all replacements until publication
+// completes, including System-only updates and callback attempts.
 func (a *Agent) ReplaceHistoryChecked(messages []llm.Message) error {
 	a.mu.Lock()
 	owned := llm.CloneMessages(messages)
-	if a.turnActive.Load() && !activeHistoryReplacementSafe(a.messages, owned) {
+	if a.manualCompactionActive || (a.turnActive.Load() && !activeHistoryReplacementSafe(a.messages, owned)) {
 		a.mu.Unlock()
 		return ErrActiveHistoryMutation
 	}

--- a/sdk/agent/manual_publication_test.go
+++ b/sdk/agent/manual_publication_test.go
@@ -129,6 +129,21 @@ func TestManualCompactionCannotEnterActiveQuery(t *testing.T) {
 	drainCompactionUpdateTurn(t, stream)
 }
 
+func TestManualCompactionClassifiesLingeringAutomaticWorkAsBusy(t *testing.T) {
+	ag := newCompactionUpdateAgent(t, &countingCompactionModel{}, 100000)
+	// A canceled turn can finish while a context-ignoring automatic summary
+	// still holds compactionInFlight. The host must not enter fallback.
+	ag.compactionInFlight.Store(true)
+	res, err := ag.CompactNow(context.Background())
+	if !errors.Is(err, ErrAgentBusy) || res.Compacted {
+		t.Fatalf("result=%v error=%v", res.Compacted, err)
+	}
+	ag.compactionInFlight.Store(false)
+	if err := ag.ClearHistoryChecked(); err != nil {
+		t.Fatalf("manual ownership leaked: %v", err)
+	}
+}
+
 func TestCanceledManualSummaryReleasesAdmission(t *testing.T) {
 	model := &blockingCompactionUpdateModel{started: make(chan struct{}), release: make(chan struct{})}
 	ag := newCompactionUpdateAgent(t, model, 100000)

--- a/sdk/agent/manual_publication_test.go
+++ b/sdk/agent/manual_publication_test.go
@@ -1,0 +1,201 @@
+package agent
+
+import (
+	"context"
+	"errors"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/timwhitez/agent-sdk-golang/sdk/agent/compaction"
+	"github.com/timwhitez/agent-sdk-golang/sdk/llm"
+)
+
+// Measures admission plus existing runtime-use overhead with compaction disabled,
+// not summary/provider latency or a claimed improvement over the old path.
+func BenchmarkManualCompactionAdmission(b *testing.B) {
+	ag, err := New(Config{LLM: &countingCompactionModel{}, Compaction: &compaction.Config{Enabled: false}})
+	if err != nil {
+		b.Fatal(err)
+	}
+	ctx := context.Background()
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, err := ag.CompactNow(ctx); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func TestManualCompactionOwnsHistoryThroughCheckpointPublication(t *testing.T) {
+	entered, release := make(chan struct{}), make(chan struct{})
+	original := []llm.Message{llm.NewSystemMessage("base"), llm.NewUserMessage("old request"), llm.NewAssistantMessage("old answer", nil)}
+	var checkpoint []llm.Message
+	var ag *Agent
+	var callbackMutation error
+	var err error
+	ag, err = New(Config{
+		LLM: &countingCompactionModel{}, InitialMessages: original,
+		Compaction: &compaction.Config{Enabled: true, CheckpointWriter: compaction.CompactionCheckpointWriterFunc(func(context.Context, compaction.CompactionCheckpoint) error { return nil })},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	ag.compactor.Config.CheckpointWriter = compaction.CompactionCheckpointWriterFunc(func(_ context.Context, cp compaction.CompactionCheckpoint) error {
+		checkpoint = llm.CloneMessages(cp.Messages)
+		// Reentrant callbacks may read history and queue runtime updates, but
+		// must not mutate the history whose checkpoint they are publishing.
+		_ = ag.Messages()
+		callbackMutation = ag.ClearHistoryChecked()
+		ag.UpdateCompactionConfig(&compaction.Config{Enabled: false})
+		close(entered)
+		<-release
+		return nil
+	})
+	done := make(chan error, 1)
+	go func() { _, err := ag.CompactNow(context.Background()); done <- err }()
+	select {
+	case <-entered:
+	case <-time.After(5 * time.Second):
+		close(release)
+		t.Fatal("checkpoint callback blocked")
+	}
+	for _, candidate := range [][]llm.Message{nil, {llm.NewUserMessage("new history")}, append([]llm.Message{llm.NewSystemMessage("new system")}, original[1:]...)} {
+		if err := ag.ReplaceHistoryChecked(candidate); !errors.Is(err, ErrActiveHistoryMutation) {
+			t.Errorf("replacement error=%v", err)
+		}
+	}
+	if !errors.Is(callbackMutation, ErrActiveHistoryMutation) {
+		t.Errorf("callback mutation=%v", callbackMutation)
+	}
+	for _, compact := range []func() (compaction.Result, error){
+		func() (compaction.Result, error) { return ag.CompactNow(context.Background()) },
+		func() (compaction.Result, error) { return ag.CompactLocalNow(context.Background(), 100) },
+		func() (compaction.Result, error) {
+			return ag.CompactPipelineNow(context.Background(), compaction.PipelineRequest{Trigger: "preflight"})
+		},
+	} {
+		res, err := compact()
+		if !errors.Is(err, ErrAgentBusy) || res.Compacted {
+			t.Errorf("nested compaction=%v error=%v", res.Compacted, err)
+		}
+	}
+	events := ag.QueryStream(context.Background(), llm.TextContent("must not enter history"))
+	busy := 0
+	for event := range events {
+		if e, ok := event.(ErrorEvent); ok && e.Kind == "agent_busy" {
+			busy++
+		} else {
+			t.Errorf("unexpected event %T", event)
+		}
+	}
+	if busy != 1 || !reflect.DeepEqual(ag.Messages(), original) {
+		t.Error("busy admission mutated history")
+	}
+	close(release)
+	if err := <-done; err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(ag.Messages(), checkpoint) {
+		t.Fatal("published history differs from committed checkpoint")
+	}
+	if ag.hasCompactor {
+		t.Fatal("queued runtime update was not released")
+	}
+	if err := ag.ReplaceHistoryChecked(original); err != nil {
+		t.Fatalf("ownership leaked: %v", err)
+	}
+	drainCompactionUpdateTurn(t, ag.QueryStream(context.Background(), llm.TextContent("after release")))
+}
+
+func TestManualCompactionCannotEnterActiveQuery(t *testing.T) {
+	model := &blockingCompactionUpdateModel{started: make(chan struct{}), release: make(chan struct{})}
+	ag := newCompactionUpdateAgent(t, model, 100000)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	stream := ag.QueryStream(ctx, llm.TextContent("active"))
+	select {
+	case <-model.started:
+	case <-time.After(5 * time.Second):
+		t.Fatal("query not started")
+	}
+	before := ag.Messages()
+	res, err := ag.CompactNow(context.Background())
+	if !errors.Is(err, ErrAgentBusy) || res.Compacted || model.calls.Load() != 1 || !reflect.DeepEqual(before, ag.Messages()) {
+		t.Errorf("active compaction=%v err=%v calls=%d", res.Compacted, err, model.calls.Load())
+	}
+	cancel()
+	drainCompactionUpdateTurn(t, stream)
+}
+
+func TestCanceledManualSummaryReleasesAdmission(t *testing.T) {
+	model := &blockingCompactionUpdateModel{started: make(chan struct{}), release: make(chan struct{})}
+	ag := newCompactionUpdateAgent(t, model, 100000)
+	if err := ag.ReplaceHistoryChecked([]llm.Message{llm.NewUserMessage("compact")}); err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	done := make(chan error, 1)
+	go func() { _, err := ag.CompactNow(ctx); done <- err }()
+	select {
+	case <-model.started:
+	case <-time.After(5 * time.Second):
+		t.Fatal("summary not started")
+	}
+	if err := ag.ClearHistoryChecked(); !errors.Is(err, ErrActiveHistoryMutation) {
+		t.Errorf("active manual clear=%v", err)
+	}
+	cancel()
+	select {
+	case err := <-done:
+		if !errors.Is(err, context.Canceled) {
+			t.Errorf("cancel error=%v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("summary did not cancel")
+	}
+	if err := ag.ClearHistoryChecked(); err != nil {
+		t.Fatalf("ownership leaked: %v", err)
+	}
+	ag.UpdateCompactionConfig(&compaction.Config{Enabled: false})
+	close(model.release)
+	drainCompactionUpdateTurn(t, ag.QueryStream(context.Background(), llm.TextContent("next")))
+}
+
+func TestManualCompactionReleasesAdmissionAfterEarlyExit(t *testing.T) {
+	for _, mode := range []string{"disabled", "canceled", "checkpoint_failure"} {
+		t.Run(mode, func(t *testing.T) {
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			cfg := &compaction.Config{Enabled: mode != "disabled"}
+			failure := errors.New("checkpoint failure")
+			if mode == "checkpoint_failure" {
+				cfg.CheckpointWriter = compaction.CompactionCheckpointWriterFunc(func(context.Context, compaction.CompactionCheckpoint) error { return failure })
+			}
+			ag, err := New(Config{LLM: &countingCompactionModel{}, Compaction: cfg, InitialMessages: []llm.Message{llm.NewUserMessage("original")}})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if mode == "canceled" {
+				cancel()
+			}
+			_, err = ag.CompactNow(ctx)
+			if mode == "checkpoint_failure" && !errors.Is(err, failure) {
+				t.Fatalf("error=%v", err)
+			}
+			if mode == "canceled" && !errors.Is(err, context.Canceled) {
+				t.Fatalf("error=%v", err)
+			}
+			if mode == "disabled" && err != nil {
+				t.Fatal(err)
+			}
+			if err := ag.ClearHistoryChecked(); err != nil {
+				t.Fatalf("ownership leaked: %v", err)
+			}
+			ag.UpdateCompactionConfig(&compaction.Config{Enabled: false})
+			drainCompactionUpdateTurn(t, ag.QueryStream(context.Background(), llm.TextContent("after exit")))
+		})
+	}
+}

--- a/sdk/agent/turn_concurrency.go
+++ b/sdk/agent/turn_concurrency.go
@@ -2,7 +2,6 @@ package agent
 
 import "errors"
 
-// ErrAgentBusy reports that a second turn was submitted while this Agent still
-// owns an active turn. Agent history, compaction, steering, and cancellation
-// state form one turn-scoped state machine and are not shared concurrently.
-var ErrAgentBusy = errors.New("agent: another query is already in progress")
+// ErrAgentBusy reports a conflicting query or public manual compaction.
+// Query-owned automatic compaction stays within its existing private lifecycle.
+var ErrAgentBusy = errors.New("agent: another query or manual compaction is already in progress")


### PR DESCRIPTION
## Scope

Addresses #121 (SDK half); advances the manual/preflight safety prerequisite of #86. Issue #121 must remain open until paired Goode busy/no-fallback handling, correct pin, independent review and merged-main validation are delivered.

- CompactPipelineNow reuses query admission through snapshot/calculation/checkpoint/apply. CompactNow/CompactLocalNow inherit it. No mutex is held across model/host callbacks.
- Conflicting query/manual admission returns ErrAgentBusy; lingering automatic compaction conflicts preserve that identity. Query-owned automatic compaction remains on existing private paths.
- All external checked Clear/Replace calls, including System-only changes, are rejected while independent manual publication owns history. Legacy void wrappers visibly warn. Existing safe active-query System updates remain allowed.
- Reuses runtime-use/config barriers; callbacks may read Messages and queue configuration updates. All error/cancellation/no-op exits release admission.

No new Controller/Scheduler, Prompt/serializer/schema change, production parallelism or atomic host checkpoint-plus-publication API. Public CommitCompactionCheckpoint followed by host replacement remains a separate boundary, not claimed solved here.

## Tests and review

Independent reviewer APPROVE exact head 9fcfa25d7e27752fabcf86a4c504fc00011383bf; no blocking findings. Author/reviewer full/vet/agent-compaction-llm race and core x100 passed. Five independent mutations detected: removed manual replacement protection, lost typed busy, missing ownership release, conflict falsely succeeded and protection released before checkpoint. Restored clean and retested. Evidence: /tmp/review122-{full,vet,race,focused,restored}.log and /tmp/review122-mutation-*.log.

Deterministic latest-main regression and independent caller audit reproduced accepted history replacement being overwritten by a stale manual checkpoint. New tests cover blocked checkpoint replacement/query/nested manual calls, callback read/config update safety, reverse active-query admission, cancellation during summary, early-exit release and lingering automatic conflict classification.

BenchmarkManualCompactionAdmission (disabled compaction) five-sample median 155.5 ns/op, 40 B/op, 2 allocations at initial implementation. Measures admission and runtime-use overhead, not provider/summary latency or a baseline speedup.

Compatibility: overlapping public query/manual calls now fail explicitly. Busy and checked-mutation diagnostic strings mention manual compaction; callers should use errors.Is/typed Event.Kind, not parse text. Paired Goode change prevents busy/root-canceled errors from entering emergency fallback. No hosted CI/live-provider success claimed.
