### PR TITLE
test: characterize logical request and envelope identity boundaries

### DIFF
--- a/agent_docs/testing.md
+++ b/agent_docs/testing.md
@@ -21,12 +21,13 @@ This document summarizes recommended test commands and current coverage focus.
 
 ## Coverage Map (Representative)
 - `frame_event_boundary_test.go` freezes one cross-boundary identity fixture:
-  five Provider invocations across four distinct logical request views (one
+  five SDK ChatModel.Invoke calls across four distinct request views (one
   transient retry), continuation and two completed Tool Blocks reusing a Call
   ID, but one QueryID and fourteen events on the existing sequence. Legacy and
   enveloped execution retain identical requests/history, explicit event-kind
   and origin goldens, clean final Tool Pair topology and metadata-only privacy.
-  This characterization does not add or prove Frame/attempt identity yet.
+  This characterization does not add or prove Frame/attempt identity yet, nor
+  count HTTP attempts or retries hidden inside a model/provider wrapper.
 - `compaction_publication_test.go` checks combined source-checked checkpoint and
   history publication: pre-I/O stale/pending/admission/runtime rejection,
   callback ownership, acknowledged commit after cancellation, writer isolation,

--- a/agent_docs/testing.md
+++ b/agent_docs/testing.md
@@ -20,6 +20,13 @@ This document summarizes recommended test commands and current coverage focus.
 - Anthropic provider: `go test ./sdk/llm/anthropic`
 
 ## Coverage Map (Representative)
+- `frame_event_boundary_test.go` freezes one cross-boundary identity fixture:
+  five Provider invocations across four distinct logical request views (one
+  transient retry), continuation and two completed Tool Blocks reusing a Call
+  ID, but one QueryID and fourteen events on the existing sequence. Legacy and
+  enveloped execution retain identical requests/history, explicit event-kind
+  and origin goldens, clean final Tool Pair topology and metadata-only privacy.
+  This characterization does not add or prove Frame/attempt identity yet.
 - `compaction_publication_test.go` checks combined source-checked checkpoint and
   history publication: pre-I/O stale/pending/admission/runtime rejection,
   callback ownership, acknowledged commit after cancellation, writer isolation,

--- a/sdk/agent/frame_event_boundary_test.go
+++ b/sdk/agent/frame_event_boundary_test.go
@@ -1,0 +1,112 @@
+package agent
+
+import (
+	"context"
+	"encoding/json"
+	"net"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/timwhitez/agent-sdk-golang/sdk/llm"
+	"github.com/timwhitez/agent-sdk-golang/sdk/tools"
+)
+
+// A transport retry is not another logical request; continuation and the next
+// post-tool request are. Existing envelope sequence counts events, not attempts.
+// Freeze that distinction before adding Frame/attempt identity metadata.
+func TestFrameEventBoundaryRetryContinuationAndLegacyParity(t *testing.T) {
+	var baselineRequests [][]byte
+	var baselineHistory []llm.Message
+	var baselineKinds []EventKind
+	wantKinds := []EventKind{EventKindWarning, EventKindAutoContinue, EventKindStepStart, EventKindToolCall, EventKindToolResult, EventKindAccounting, EventKindStepComplete, EventKindStepStart, EventKindToolCall, EventKindToolResult, EventKindAccounting, EventKindStepComplete, EventKindText, EventKindFinalResponse}
+	wantOrigins := []EventOrigin{EventOriginSDKDriver, EventOriginSDKDriver, EventOriginToolRuntime, EventOriginToolRuntime, EventOriginToolRuntime, EventOriginSDKDriver, EventOriginToolRuntime, EventOriginToolRuntime, EventOriginToolRuntime, EventOriginToolRuntime, EventOriginSDKDriver, EventOriginToolRuntime, EventOriginModel, EventOriginSDKDriver}
+	for _, enveloped := range []bool{false, true} {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		var requests [][]byte
+		handlers, warnings := 0, 0
+		model := &frameScriptModel{invoke: func(req llm.InvokeRequest) (*llm.Completion, error) {
+			encoded, err := json.Marshal(req)
+			if err != nil {
+				t.Error(err)
+				return nil, err
+			}
+			requests = append(requests, encoded)
+			switch len(requests) {
+			case 1:
+				return nil, &net.DNSError{Err: "fixture timeout", IsTimeout: true}
+			case 2:
+				return &llm.Completion{StopReason: "max_tokens", ToolCalls: []llm.ToolCall{{ID: "a", Function: llm.FunctionCall{Name: "work", Arguments: `{"text":`}}}}, nil
+			case 3:
+				return &llm.Completion{ToolCalls: []llm.ToolCall{{ID: "a", Function: llm.FunctionCall{Name: "work", Arguments: `"ok"}`}}}}, nil
+			case 4:
+				// Provider Call ID reuse across completed blocks is legal and
+				// cannot serve as a logical-request identity.
+				return &llm.Completion{ToolCalls: []llm.ToolCall{{ID: "a", Function: llm.FunctionCall{Name: "work", Arguments: `{"text":"ok"}`}}}}, nil
+			default:
+				return &llm.Completion{Content: llm.TextContent("done")}, nil
+			}
+		}}
+		fixed := time.Unix(100, 0)
+		ids := 0
+		ag, err := New(Config{LLM: model, InvokeRetryMaxAttempts: 2, Warningf: func(string, ...any) { warnings++ }, QueryIDGenerator: func() string { ids++; return "boundary-query" }, EventClock: func() time.Time { return fixed }, Tools: []tools.Tool{{Name: "work", Description: "PRIVATE_SCHEMA_FIXTURE", Schema: map[string]any{"type": "object", "properties": map[string]any{"text": map[string]any{"type": "string"}}}, Handler: func(_ context.Context, args json.RawMessage, _ *tools.Container) (llm.Content, error) {
+			handlers++
+			if string(args) != `{"text":"ok"}` {
+				t.Errorf("merged args=%s", args)
+			}
+			return llm.TextContent("PRIVATE_RESULT_FIXTURE"), nil
+		}}}})
+		if err != nil {
+			t.Fatal(err)
+		}
+		var kinds []EventKind
+		if enveloped {
+			for e := range ag.QueryStreamEnveloped(ctx, llm.TextContent("PRIVATE_PROMPT_FIXTURE")) {
+				kinds = append(kinds, e.Kind)
+				if e.QueryID != "boundary-query" || e.Sequence != uint64(len(kinds)) || !e.Timestamp.Equal(fixed) {
+					t.Errorf("envelope identity/order=%+v", e)
+				}
+				kind, origin := classifyEvent(e.Event)
+				if e.Kind != kind || e.Origin != origin {
+					t.Errorf("kind/origin=%s/%s", e.Kind, e.Origin)
+				}
+				if len(kinds) <= len(wantOrigins) && e.Origin != wantOrigins[len(kinds)-1] {
+					t.Errorf("origin golden at %d=%s", len(kinds), e.Origin)
+				}
+				metadata := e
+				metadata.Event = nil
+				encoded, err := json.Marshal(metadata)
+				if err != nil {
+					t.Fatal(err)
+				}
+				if strings.Contains(string(encoded), "PRIVATE_") {
+					t.Fatal("envelope metadata duplicated private request/result content")
+				}
+			}
+		} else {
+			for e := range ag.QueryStream(ctx, llm.TextContent("PRIVATE_PROMPT_FIXTURE")) {
+				kind, _ := classifyEvent(e)
+				kinds = append(kinds, kind)
+			}
+		}
+		if !reflect.DeepEqual(kinds, wantKinds) {
+			t.Fatalf("event golden=%v", kinds)
+		}
+		if len(requests) != 5 || handlers != 2 || warnings != 1 || ids != 1 {
+			t.Fatalf("enveloped=%v requests=%d handlers=%d warnings=%d ids=%d", enveloped, len(requests), handlers, warnings, ids)
+		}
+		if !reflect.DeepEqual(requests[0], requests[1]) || reflect.DeepEqual(requests[1], requests[2]) || reflect.DeepEqual(requests[2], requests[3]) || reflect.DeepEqual(requests[3], requests[4]) {
+			t.Fatal("retry/logical-request boundaries changed")
+		}
+		if !enveloped {
+			baselineRequests, baselineHistory, baselineKinds = requests, ag.Messages(), kinds
+		} else if !reflect.DeepEqual(requests, baselineRequests) || !reflect.DeepEqual(ag.Messages(), baselineHistory) || !reflect.DeepEqual(kinds, baselineKinds) {
+			t.Fatal("envelope observation changed the logical execution")
+		}
+		if _, changed, _ := repairToolCallPairsDetailed(ag.Messages()); changed {
+			t.Fatal("completed continuation history still needs repair")
+		}
+	}
+}

--- a/sdk/agent/frame_event_boundary_test.go
+++ b/sdk/agent/frame_event_boundary_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/timwhitez/agent-sdk-golang/sdk/tools"
 )
 
-// A transport retry is not another logical request; continuation and the next
+// An SDK invocation retry is not another logical request; continuation and the next
 // post-tool request are. Existing envelope sequence counts events, not attempts.
 // Freeze that distinction before adding Frame/attempt identity metadata.
 func TestFrameEventBoundaryRetryContinuationAndLegacyParity(t *testing.T) {
@@ -97,7 +97,11 @@ func TestFrameEventBoundaryRetryContinuationAndLegacyParity(t *testing.T) {
 		if len(requests) != 5 || handlers != 2 || warnings != 1 || ids != 1 {
 			t.Fatalf("enveloped=%v requests=%d handlers=%d warnings=%d ids=%d", enveloped, len(requests), handlers, warnings, ids)
 		}
-		if !reflect.DeepEqual(requests[0], requests[1]) || reflect.DeepEqual(requests[1], requests[2]) || reflect.DeepEqual(requests[2], requests[3]) || reflect.DeepEqual(requests[3], requests[4]) {
+		views := make(map[string]struct{})
+		for _, request := range requests {
+			views[string(request)] = struct{}{}
+		}
+		if !reflect.DeepEqual(requests[0], requests[1]) || len(views) != 4 {
 			t.Fatal("retry/logical-request boundaries changed")
 		}
 		if !enveloped {


### PR DESCRIPTION
## Scope

Characterization prerequisite for #83 Frame identity and #88 read-only event correlation. Issue #83 remains open; this PR does not add FrameID/attempt metadata or lineage.

One real SDK trajectory jointly freezes five ChatModel.Invoke calls across four distinct submitted request views: one silent SDK retry, one continuation, then two completed Tool Blocks reusing the same Call ID. Both legacy/enveloped APIs keep identical requests/history. Fourteen event kinds/origins, one QueryID allocation and the existing contiguous event sequence form the inline golden. Final history requires no Tool Pair repair. Envelope metadata (excluding the existing Event payload) must not duplicate private fixture prompt/schema/result content.

These counts are not HTTP attempts or hidden retries within a provider/model wrapper. StepID/Tool Call ID and event Sequence cannot be substituted for Frame/attempt identity. This adds no production code, fields, event sequence, provider wire payload, Prompt, persistence protocol, runtime concurrency or benchmark claim.

## Validation

Independent APPROVE exact head a68a0fb164819d50be79ec9378aade4d33491cb2, for characterization only: author/reviewer focused x100, full tests, vet and agent race passed. Review confirmed the combined test is not redundant with isolated retry/continuation tests; its distinct-request-set assertion was strengthened. Three independent mutations hit assertions: resetting event sequence per logical loop, reallocating QueryID per loop, and skipping SDK retry. Restored clean and retested. No unresolved findings.

Author evidence: /tmp/sdk83-boundaries-final-{focused,full,vet,race}.log. Independent: /tmp/review124-{full,vet,race,focused,restored}.log and /tmp/review124-mutation-{sequence,queryid,retry}.log. After merge, update the Goode SDK pin through independently reviewed integration and validate both main branches. Then implement actual identity/correlation on this frozen boundary; do not repeat characterization as a substitute for that feature.
