### PR TITLE
feat: correlate query events with frame and SDK invocation identity

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -117,6 +117,10 @@ agent_docs/          Detailed architecture/provider/tool/build/test documentatio
   concrete-model snapshotting or proof of mutable handler closure identity.
 
 ### Execution APIs
+- Envelope producer sites can attach opaque `FrameID` and `InvokeAttempt`.
+  Attempts count Agent calls to its captured model, not inner HTTP retries.
+  Unknown/unannotated contexts stay absent; this is not complete continuation
+  provenance, a failure attribution or a concrete-model snapshot contract.
 - `CommitCompactionHistory(ctx, expected, candidate, result)` publishes a
   host-computed compaction under one SDK admission/runtime boundary. Reuse the
   exact source snapshot used to compute the candidate; stale content/pending

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -84,6 +84,10 @@ agent_docs/          Detailed architecture/provider/tool/build/test documentatio
   concrete-model snapshotting or proof of mutable handler closure identity.
 
 ### Execution APIs
+- Envelope producer sites can attach opaque `FrameID` and `InvokeAttempt`.
+  Attempts count Agent calls to its captured model, not inner HTTP retries.
+  Unknown/unannotated contexts stay absent; this is not complete continuation
+  provenance, a failure attribution or a concrete-model snapshot contract.
 - `CommitCompactionHistory(ctx, expected, candidate, result)` publishes a
   host-computed compaction under one SDK admission/runtime boundary. Reuse the
   exact source snapshot used to compute the candidate; stale content/pending

--- a/agent_docs/architecture.md
+++ b/agent_docs/architecture.md
@@ -634,6 +634,36 @@ candidate computation or recovery snapshot write. Source-content equality is
 not session/runtime revision binding, and external writers or legacy independent
 checkpoint-only calls remain outside the lease. No persistence schema changes.
 
+## Frame Correlation
+
+Each materialized Query Driver request owns an opaque, content-free Frame ID
+derived from the existing QueryID and logical-loop ordinal. It is not a hash of
+Prompt, tools, model names or results; consumers must treat the ID as opaque.
+The Frame's request/model/resolver snapshot is unchanged by correlation.
+
+EventEnvelope has optional FrameID/InvokeAttempt fields at explicit producer
+sites: model output/usage, accepted tool lifecycle and its accounting, known
+continuation/final/error paths. InvokeAttempt counts actual Agent entries into
+the captured ChatModel.Invoke/InvokeStream, not a model wrapper's inner calls,
+HTTP attempts or provider-reported retry counters. Retrying a logical request
+keeps its Frame ID; a new Driver iteration gets a new ID. Waiting/canceling
+between attempts has no current invocation association, while retained partial
+usage keeps the completed invocation's association.
+
+Correlation values are copied into the envelope at emission. No ambient
+current-frame state, replacement eventOutput, second event sequence, altered
+backpressure owner, Provider request field/header or session persistence field
+is introduced. Compaction, host steering and other unannotated producers remain
+uncorrelated rather than inheriting a guessed Frame. This is a finalizing/
+execution context, not proof that aggregated continuation content has only one
+source, nor a complete lineage graph, invocation trace or failure attribution.
+
+Compatibility: these are additive public EventEnvelope fields, omitted in JSON
+when unavailable. Existing required v1 fields and legacy typed Event payloads
+remain unchanged. External unkeyed Go struct literals must migrate to keyed
+literals; strict JSON decoders need to allow the new optional fields. This is
+not a claim that all public envelope wire representations are byte-identical.
+
 ## Runtime Compaction Configuration Updates
 
 `UpdateCompactionConfig` is non-blocking. If the current compaction runtime is in

--- a/agent_docs/testing.md
+++ b/agent_docs/testing.md
@@ -26,8 +26,13 @@ This document summarizes recommended test commands and current coverage focus.
   ID, but one QueryID and fourteen events on the existing sequence. Legacy and
   enveloped execution retain identical requests/history, explicit event-kind
   and origin goldens, clean final Tool Pair topology and metadata-only privacy.
-  This characterization does not add or prove Frame/attempt identity yet, nor
-  count HTTP attempts or retries hidden inside a model/provider wrapper.
+  It now also asserts the explicit Frame/SDK-invocation mapping without counting
+  HTTP attempts or retries hidden inside a model/provider wrapper.
+- `frame_correlation_test.go` covers streaming SDK retries versus provider retry
+  reports, pre-admission/backoff cancellation, retained usage's original attempt,
+  concurrent unscoped host/compaction events, terminal eviction/backpressure
+  ownership and absent-correlation JSON compatibility. The emission benchmark
+  measures metadata/channel overhead, not Frame construction or Provider cost.
 - `compaction_publication_test.go` checks combined source-checked checkpoint and
   history publication: pre-I/O stale/pending/admission/runtime rejection,
   callback ownership, acknowledged commit after cancellation, writer isolation,

--- a/sdk/agent/agent.go
+++ b/sdk/agent/agent.go
@@ -651,7 +651,7 @@ func (a *Agent) queryStreamWithSteering(ctx context.Context, input llm.Content, 
 		criticalDroppedThisTurn := func() uint64 {
 			return dropsSince(a.criticalEventDropCount.Load(), out.criticalDropStart)
 		}
-		emitFinal := func(content, responseID string) {
+		emitFinal := func(content, responseID string, correlations ...eventCorrelation) {
 			a.emitEvent(out, FinalResponseEvent{
 				Content:               content,
 				ResponseID:            responseID,
@@ -659,9 +659,9 @@ func (a *Agent) queryStreamWithSteering(ctx context.Context, input llm.Content, 
 				StallRecoveries:       streamIdleRecoveryTotal,
 				DroppedEvents:         droppedThisTurn(),
 				DroppedCriticalEvents: criticalDroppedThisTurn(),
-			})
+			}, correlations...)
 		}
-		emitPartialFinal := func(content, responseID, reason string) {
+		emitPartialFinal := func(content, responseID, reason string, correlations ...eventCorrelation) {
 			a.emitEvent(out, FinalResponseEvent{
 				Content:               content,
 				ResponseID:            responseID,
@@ -670,14 +670,14 @@ func (a *Agent) queryStreamWithSteering(ctx context.Context, input llm.Content, 
 				StallRecoveries:       streamIdleRecoveryTotal,
 				DroppedEvents:         droppedThisTurn(),
 				DroppedCriticalEvents: criticalDroppedThisTurn(),
-			})
+			}, correlations...)
 		}
-		emitErr := func(e ErrorEvent, origin EventOrigin) {
+		emitErr := func(e ErrorEvent, origin EventOrigin, correlations ...eventCorrelation) {
 			e.StallRecoveries = streamIdleRecoveryTotal
-			a.emitEventFrom(out, e, origin)
+			a.emitEventFrom(out, e, origin, correlations...)
 		}
-		emitSDKErr := func(e ErrorEvent) {
-			emitErr(e, EventOriginSDKDriver)
+		emitSDKErr := func(e ErrorEvent, correlations ...eventCorrelation) {
+			emitErr(e, EventOriginSDKDriver, correlations...)
 		}
 		emitCompactionErr := func(e ErrorEvent) {
 			origin := EventOriginCompaction
@@ -687,6 +687,7 @@ func (a *Agent) queryStreamWithSteering(ctx context.Context, input llm.Content, 
 			emitErr(e, origin)
 		}
 		var activeToolBlock *toolBlockState
+		var activeToolBlockCorrelation eventCorrelation
 		var pendingBlockMessages []llm.Message
 		blockFailed := false
 		commitToolHistory := func(messages []llm.Message) { a.appendMessages(messages) }
@@ -701,7 +702,7 @@ func (a *Agent) queryStreamWithSteering(ctx context.Context, input llm.Content, 
 				if errors.As(err, &transition) {
 					message += ": " + transition.Error()
 				}
-				emitSDKErr(ErrorEvent{Kind: "invalid_tool_call_block", Message: message})
+				emitSDKErr(ErrorEvent{Kind: "invalid_tool_call_block", Message: message}, activeToolBlockCorrelation)
 			}
 			return false
 		}
@@ -720,7 +721,7 @@ func (a *Agent) queryStreamWithSteering(ctx context.Context, input llm.Content, 
 			if err != nil {
 				return failToolBlock(err)
 			}
-			a.emitToolResultWithAccounting(out, result, duration)
+			a.emitToolResultWithAccounting(out, result, duration, activeToolBlockCorrelation)
 			return true
 		}
 		finishToolBlock := func() bool {
@@ -797,7 +798,7 @@ func (a *Agent) queryStreamWithSteering(ctx context.Context, input llm.Content, 
 				// until done, steering, or turn termination closes the subloop.
 				DisableThinking: requireDoneRecoveryDisableThinkingActive,
 			}
-			frame, frameErr := newExecutionFrame(a.llm, request, a.toolMap, a.toolMapNormalized)
+			frame, frameErr := newExecutionFrame(fmt.Sprintf("%s/frame/%d", out.queryID, iter+1), a.llm, request, a.toolMap, a.toolMapNormalized)
 			frameFailure := ""
 			if frameErr != nil {
 				// Clone errors may contain schema data. Keep diagnostics structural.
@@ -821,7 +822,9 @@ func (a *Agent) queryStreamWithSteering(ctx context.Context, input llm.Content, 
 				emitSDKErr(ErrorEvent{Kind: "invalid_request", Message: frameFailure + "; rebuild the Agent with consistent, cloneable tool definitions"})
 				return
 			}
-			comp, streamedText, err := a.invokeModelCompletionWithRetryAndSteering(ctx, frame.model, frame.request, out, steeringCh)
+			invocation := &frameInvocation{frameID: frame.id}
+			comp, streamedText, err := a.invokeModelCompletionWithRetryAndSteering(ctx, frame.model, frame.request, out, steeringCh, invocation)
+			correlation := invocation.correlation()
 			if err != nil {
 				// Check for steering interrupt - handle specially
 				var steerErr *llm.SteeringInterruptError
@@ -845,7 +848,7 @@ func (a *Agent) queryStreamWithSteering(ctx context.Context, input llm.Content, 
 					// The provider already billed what it produced before the
 					// interrupt. This path continues the loop instead of ending
 					// the turn, so the tokens are only recorded here.
-					a.emitPartialUsage(out, comp)
+					a.emitPartialUsage(out, comp, invocation.completionCorrelation())
 					if msg := strings.TrimSpace(steerErr.Message); msg != "" {
 						a.mu.Lock()
 						a.messages = append(a.messages, llm.NewUserMessage(msg))
@@ -880,7 +883,7 @@ func (a *Agent) queryStreamWithSteering(ctx context.Context, input llm.Content, 
 						// Same as the steering path: the stalled response was
 						// already billed, and the recovery continues the loop
 						// rather than ending the turn, so emit it here.
-						a.emitPartialUsage(out, comp)
+						a.emitPartialUsage(out, comp, invocation.completionCorrelation())
 						a.mu.Lock()
 						a.messages = append(a.messages, messageorigin.NewInternalUserMessage(messageorigin.KindStreamIdleRecovery, streamIdleRecoveryText))
 						a.mu.Unlock()
@@ -914,12 +917,12 @@ func (a *Agent) queryStreamWithSteering(ctx context.Context, input llm.Content, 
 				// error, and the partial completion carries that usage. Emit it
 				// before the terminal error or the tokens never reach the
 				// accounting journal, which silently under-counts the ledger.
-				a.emitPartialUsage(out, comp)
+				a.emitPartialUsage(out, comp, invocation.completionCorrelation())
 				origin := EventOriginProvider
 				if ctx.Err() != nil {
 					origin = EventOriginSDKDriver
 				}
-				emitErr(a.errEvent(err), origin)
+				emitErr(a.errEvent(err), origin, correlation)
 				return
 			}
 			streamIdleRecoveries = 0
@@ -961,7 +964,7 @@ func (a *Agent) queryStreamWithSteering(ctx context.Context, input llm.Content, 
 			}
 
 			if comp.Usage != nil {
-				a.emitUsageWithAccounting(out, *comp.Usage, responseID)
+				a.emitUsageWithAccounting(out, *comp.Usage, responseID, correlation)
 			}
 			if first, second, duplicate := duplicateToolCallIDPositions(comp.ToolCalls); duplicate {
 				if cont.hasPending() {
@@ -973,16 +976,16 @@ func (a *Agent) queryStreamWithSteering(ctx context.Context, input llm.Content, 
 					Provider: a.llm.Provider(),
 					Kind:     "invalid_tool_call_block",
 					Message:  fmt.Sprintf("provider returned duplicate tool_call_id values at positions %d and %d; no tools were executed", first+1, second+1),
-				}, EventOriginSDKDriver)
+				}, EventOriginSDKDriver, correlation)
 				return
 			}
 
 			if comp.Thinking != "" {
-				a.emitEvent(out, ThinkingEvent{Content: comp.Thinking})
+				a.emitEvent(out, ThinkingEvent{Content: comp.Thinking}, correlation)
 			}
 			if !streamedText {
 				if txt := comp.PlainText(); txt != "" {
-					a.emitEvent(out, TextEvent{Content: txt})
+					a.emitEvent(out, TextEvent{Content: txt}, correlation)
 				}
 			}
 
@@ -1053,7 +1056,7 @@ func (a *Agent) queryStreamWithSteering(ctx context.Context, input llm.Content, 
 				a.emitEvent(out, WarnEvent{
 					Message: fmt.Sprintf("continuing truncated tool-call arguments (%d/%d)", turn, cont.maxTurns),
 					Kind:    "continuation",
-				})
+				}, correlation)
 				reminder := messageorigin.NewInternalUserMessage(messageorigin.KindToolCallContinuation, messageorigin.ResponseTruncatedContinuationText)
 				if a.hasCompactor {
 					if err := a.checkAndCompactWithGrowth(ctx, comp, out, additionalSinceCompletion(), pendingMessageTokens(reminder)); err != nil {
@@ -1064,7 +1067,7 @@ func (a *Agent) queryStreamWithSteering(ctx context.Context, input llm.Content, 
 				a.mu.Lock()
 				a.messages = append(a.messages, reminder)
 				a.mu.Unlock()
-				a.emitAutoContinue(out, "max_tokens", responseID)
+				a.emitAutoContinue(out, "max_tokens", responseID, correlation)
 				continue
 			}
 
@@ -1106,7 +1109,7 @@ func (a *Agent) queryStreamWithSteering(ctx context.Context, input llm.Content, 
 					a.emitEvent(out, WarnEvent{
 						Message: fmt.Sprintf("tool-call merge remained invalid; requesting continuation (%d/%d)", turn, cont.maxTurns),
 						Kind:    "continuation",
-					})
+					}, correlation)
 					reminder := messageorigin.NewInternalUserMessage(messageorigin.KindToolCallContinuation, messageorigin.ResponseTruncatedContinuationText)
 					if a.hasCompactor {
 						if err := a.checkAndCompactWithGrowth(ctx, comp, out, additionalSinceCompletion(), pendingMessageTokens(reminder)); err != nil {
@@ -1117,7 +1120,7 @@ func (a *Agent) queryStreamWithSteering(ctx context.Context, input llm.Content, 
 					a.mu.Lock()
 					a.messages = append(a.messages, reminder)
 					a.mu.Unlock()
-					a.emitAutoContinue(out, "max_tokens", responseID)
+					a.emitAutoContinue(out, "max_tokens", responseID, correlation)
 					continue
 				}
 				// Valid merged tool calls — clean up partials and update.
@@ -1177,7 +1180,7 @@ func (a *Agent) queryStreamWithSteering(ctx context.Context, input llm.Content, 
 					a.mu.Lock()
 					a.messages = append(a.messages, reminder)
 					a.mu.Unlock()
-					a.emitAutoContinue(out, "max_tokens", responseID)
+					a.emitAutoContinue(out, "max_tokens", responseID, correlation)
 					continue
 				}
 				if !a.requireDone {
@@ -1206,7 +1209,7 @@ func (a *Agent) queryStreamWithSteering(ctx context.Context, input llm.Content, 
 						_ = a.checkAndCompact(ctx, comp, out)
 					}
 					clearPendingTextContinuation()
-					emitFinal(combinedText, responseID)
+					emitFinal(combinedText, responseID, correlation)
 					return
 				}
 				// require done tool: only enforce when tools have actually been
@@ -1219,7 +1222,7 @@ func (a *Agent) queryStreamWithSteering(ctx context.Context, input llm.Content, 
 							_ = a.checkAndCompact(ctx, comp, out)
 						}
 						clearPendingTextContinuation()
-						emitFinal(combinedText, responseID)
+						emitFinal(combinedText, responseID, correlation)
 						return
 					}
 					// Tools were used earlier; enforce done-tool completion.
@@ -1258,7 +1261,7 @@ func (a *Agent) queryStreamWithSteering(ctx context.Context, input llm.Content, 
 						}
 						clearPendingTextContinuation()
 						requireDoneRecoveryDisableThinkingActive = false
-						emitPartialFinal(finalContent, finalResponseID, "require_done_safety")
+						emitPartialFinal(finalContent, finalResponseID, "require_done_safety", correlation)
 						return
 					}
 					forceRequireDoneToolChoice = true
@@ -1287,6 +1290,7 @@ func (a *Agent) queryStreamWithSteering(ctx context.Context, input llm.Content, 
 			// interleaved with user text, and the malformed history would stay
 			// in place and fail every later turn — so these are only appended
 			// once every tool_use in the block has a matching tool_result.
+			activeToolBlockCorrelation = correlation
 			activeToolBlock, err = newToolBlockState(comp.ToolCalls)
 			if err != nil {
 				// No block was accepted. Defensively discard the staged assistant
@@ -1464,19 +1468,19 @@ func (a *Agent) queryStreamWithSteering(ctx context.Context, input llm.Content, 
 							})
 							repeatGuard.exhausted = true
 						}
-						a.emitEvent(out, StepStartEvent{StepID: tc.ID, Title: resolvedName, StepNumber: step})
+						a.emitEvent(out, StepStartEvent{StepID: tc.ID, Title: resolvedName, StepNumber: step}, correlation)
 						a.emitEvent(out, ToolCallEvent{
 							Tool: resolvedName, Args: norm.Display, ArgsJSON: norm.Normalized,
 							ArgsMeta: norm.Meta, ToolCallID: tc.ID, DisplayName: resolvedName,
-						})
+						}, correlation)
 						if !publishToolResult(idx, 0) {
 							return
 						}
-						a.emitEvent(out, StepCompleteEvent{StepID: tc.ID, Status: "error"})
+						a.emitEvent(out, StepCompleteEvent{StepID: tc.ID, Status: "error"}, correlation)
 						continue
 					}
 				}
-				a.emitEvent(out, StepStartEvent{StepID: tc.ID, Title: resolvedName, StepNumber: step})
+				a.emitEvent(out, StepStartEvent{StepID: tc.ID, Title: resolvedName, StepNumber: step}, correlation)
 				argsMap := norm.Display
 				if argsMap == nil {
 					argsMap = map[string]any{"__raw": execArgs}
@@ -1488,7 +1492,7 @@ func (a *Agent) queryStreamWithSteering(ctx context.Context, input llm.Content, 
 					ArgsMeta:    norm.Meta,
 					ToolCallID:  tc.ID,
 					DisplayName: resolvedName,
-				})
+				}, correlation)
 				if evidenceTool {
 					decision := progressLedger.preflight(evidenceReq, a.compactionGeneration.Load())
 					if decision.suppress {
@@ -1503,7 +1507,7 @@ func (a *Agent) queryStreamWithSteering(ctx context.Context, input llm.Content, 
 						if !publishToolResult(idx, 0) {
 							return
 						}
-						a.emitEvent(out, StepCompleteEvent{StepID: tc.ID, Status: "completed"})
+						a.emitEvent(out, StepCompleteEvent{StepID: tc.ID, Status: "completed"}, correlation)
 						if decision.recovery {
 							reminder := evidenceRecoveryMessage(evidenceReq)
 							// Deferred until the tool-call block is closed; see
@@ -1584,7 +1588,7 @@ func (a *Agent) queryStreamWithSteering(ctx context.Context, input llm.Content, 
 					if !publishToolResult(idx, time.Since(start)) {
 						return
 					}
-					a.emitEvent(out, StepCompleteEvent{StepID: tc.ID, Status: status, DurationMS: time.Since(start).Milliseconds()})
+					a.emitEvent(out, StepCompleteEvent{StepID: tc.ID, Status: status, DurationMS: time.Since(start).Milliseconds()}, correlation)
 					if err := ctx.Err(); err != nil {
 						if !closeToolResults(idx+1, toolCallAccepted, "root_cancel_after_task_complete", historyOnlyResults(skippedToolResults(comp.ToolCalls[idx+1:], toolSkippedByCancellationText))...) {
 							return
@@ -1618,7 +1622,7 @@ func (a *Agent) queryStreamWithSteering(ctx context.Context, input llm.Content, 
 					if !finishToolBlock() {
 						return
 					}
-					emitFinal(finalContent, finalResponseID)
+					emitFinal(finalContent, finalResponseID, correlation)
 					return
 				}
 
@@ -1639,7 +1643,7 @@ func (a *Agent) queryStreamWithSteering(ctx context.Context, input llm.Content, 
 				if !publishToolResult(idx, time.Since(start)) {
 					return
 				}
-				a.emitEvent(out, StepCompleteEvent{StepID: tc.ID, Status: status, DurationMS: time.Since(start).Milliseconds()})
+				a.emitEvent(out, StepCompleteEvent{StepID: tc.ID, Status: status, DurationMS: time.Since(start).Milliseconds()}, correlation)
 				if rootCancelErr == nil {
 					rootCancelErr = ctx.Err()
 				}
@@ -2144,7 +2148,12 @@ func (a *Agent) invokeCompletionWithSteering(ctx context.Context, req llm.Invoke
 	return a.invokeModelCompletionWithSteering(ctx, a.llm, req, out, steeringCh)
 }
 
-func (a *Agent) invokeModelCompletionWithSteering(ctx context.Context, model llm.ChatModel, req llm.InvokeRequest, out *eventOutput, steeringCh <-chan SteeringMsg) (*llm.Completion, bool, error) {
+func (a *Agent) invokeModelCompletionWithSteering(ctx context.Context, model llm.ChatModel, req llm.InvokeRequest, out *eventOutput, steeringCh <-chan SteeringMsg, scopes ...*frameInvocation) (*llm.Completion, bool, error) {
+	var scope *frameInvocation
+	if len(scopes) == 1 {
+		scope = scopes[0]
+	}
+	scope.resetAttempt()
 	if model == nil {
 		return nil, false, fmt.Errorf("agent: nil llm")
 	}
@@ -2197,6 +2206,7 @@ func (a *Agent) invokeModelCompletionWithSteering(ctx context.Context, model llm
 			}
 			return comp, streamedText, fallbackErr
 		}
+		correlation := scope.enter()
 		ch, err := sm.InvokeStream(invokeCtx, req)
 		if err != nil {
 			return finishProviderStage(nil, false, err)
@@ -2266,20 +2276,20 @@ func (a *Agent) invokeModelCompletionWithSteering(ctx context.Context, model llm
 				if strings.TrimSpace(e.Delta) != "" || e.Delta == "\n" {
 					text.WriteString(e.Delta)
 					streamedText = true
-					a.emitEvent(out, TextDeltaEvent{Delta: e.Delta})
+					a.emitEvent(out, TextDeltaEvent{Delta: e.Delta}, correlation)
 				} else {
 					// preserve whitespace as-is
 					text.WriteString(e.Delta)
 					if e.Delta != "" {
 						streamedText = true
-						a.emitEvent(out, TextDeltaEvent{Delta: e.Delta})
+						a.emitEvent(out, TextDeltaEvent{Delta: e.Delta}, correlation)
 					}
 				}
 			case llm.StreamThinkingDeltaEvent:
 				thinkingBlocks.apply(e)
 				if e.Delta != "" {
 					thinking.WriteString(e.Delta)
-					a.emitEvent(out, ThinkingDeltaEvent{Delta: e.Delta})
+					a.emitEvent(out, ThinkingDeltaEvent{Delta: e.Delta}, correlation)
 				}
 			case llm.StreamToolCallDeltaEvent:
 				acc.apply(e)
@@ -2307,7 +2317,7 @@ func (a *Agent) invokeModelCompletionWithSteering(ctx context.Context, model llm
 				if e.RetryAfter > 0 {
 					msg = fmt.Sprintf("%s in %s", msg, e.RetryAfter.Round(time.Second))
 				}
-				a.emitEvent(out, WarnEvent{Kind: "rate_limit_retry", Message: msg})
+				a.emitEvent(out, WarnEvent{Kind: "rate_limit_retry", Message: msg}, correlation)
 			case llm.StreamErrorEvent:
 				return e.AsError()
 			case llm.StreamDoneEvent:
@@ -2402,6 +2412,7 @@ func (a *Agent) invokeModelCompletionWithSteering(ctx context.Context, model llm
 		finishStage()
 		return nil, false, err
 	}
+	scope.enter()
 	comp, err := model.Invoke(invokeCtx, req)
 	stageInterruptedForSteering := finishStage()
 	if ctx.Err() == nil && stageInterruptedForSteering {
@@ -2430,13 +2441,13 @@ func (a *Agent) invokeCompletionWithRetryAndSteering(ctx context.Context, req ll
 	return a.invokeModelCompletionWithRetryAndSteering(ctx, a.llm, req, out, steeringCh)
 }
 
-func (a *Agent) invokeModelCompletionWithRetryAndSteering(ctx context.Context, model llm.ChatModel, req llm.InvokeRequest, out *eventOutput, steeringCh <-chan SteeringMsg) (*llm.Completion, bool, error) {
+func (a *Agent) invokeModelCompletionWithRetryAndSteering(ctx context.Context, model llm.ChatModel, req llm.InvokeRequest, out *eventOutput, steeringCh <-chan SteeringMsg, scopes ...*frameInvocation) (*llm.Completion, bool, error) {
 	maxAttempts := defaultInvokeRetryMax
 	if a != nil && a.invokeRetryMax > 0 {
 		maxAttempts = a.invokeRetryMax
 	}
 	if maxAttempts <= 1 {
-		return a.invokeModelCompletionWithSteering(ctx, model, req, out, steeringCh)
+		return a.invokeModelCompletionWithSteering(ctx, model, req, out, steeringCh, scopes...)
 	}
 
 	var lastComp *llm.Completion
@@ -2446,7 +2457,7 @@ func (a *Agent) invokeModelCompletionWithRetryAndSteering(ctx context.Context, m
 		if err := ctx.Err(); err != nil {
 			return lastComp, lastStreamed, err
 		}
-		comp, streamedText, err := a.invokeModelCompletionWithSteering(ctx, model, req, out, steeringCh)
+		comp, streamedText, err := a.invokeModelCompletionWithSteering(ctx, model, req, out, steeringCh, scopes...)
 		if err == nil {
 			return comp, streamedText, nil
 		}
@@ -2470,6 +2481,11 @@ func (a *Agent) invokeModelCompletionWithRetryAndSteering(ctx context.Context, m
 		delay, retry := a.transientInvokeRetryDelay(err, comp, streamedText, attempt)
 		if !retry {
 			break
+		}
+		// A cancellation while waiting for another retry is not a failure
+		// inside the preceding, already completed model invocation.
+		if len(scopes) == 1 {
+			scopes[0].resetAttempt()
 		}
 		if delay > 0 {
 			a.warnf("agent invoke transient failure (attempt %d/%d): %v; retrying in %s", attempt, maxAttempts, err, delay)
@@ -2781,7 +2797,7 @@ func (a *Agent) executeToolSafely(ctx context.Context, tool tools.Tool, raw stri
 // normal success path (terminal stream error, steering interrupt, idle-timeout
 // recovery, context cancellation). The provider already billed the tokens it
 // produced, so skipping this leaves the accounting journal under-counted.
-func (a *Agent) emitPartialUsage(out *eventOutput, comp *llm.Completion) {
+func (a *Agent) emitPartialUsage(out *eventOutput, comp *llm.Completion, correlations ...eventCorrelation) {
 	if comp == nil || comp.Usage == nil {
 		return
 	}
@@ -2789,23 +2805,23 @@ func (a *Agent) emitPartialUsage(out *eventOutput, comp *llm.Completion) {
 	if usage == nil {
 		return
 	}
-	a.emitUsageWithAccounting(out, *usage, strings.TrimSpace(comp.ResponseID))
+	a.emitUsageWithAccounting(out, *usage, strings.TrimSpace(comp.ResponseID), correlations...)
 }
 
-func (a *Agent) emitUsageWithAccounting(out *eventOutput, usage llm.Usage, responseID string) {
-	if !a.emitEvent(out, UsageEvent{Usage: usage, ResponseID: responseID}) {
+func (a *Agent) emitUsageWithAccounting(out *eventOutput, usage llm.Usage, responseID string, correlations ...eventCorrelation) {
+	if !a.emitEvent(out, UsageEvent{Usage: usage, ResponseID: responseID}, correlations...) {
 		return
 	}
 	a.emitAccounting(out, AccountingEvent{
 		Payload:         sdkaccounting.ProjectUsage(usage, a.accountingEstimator),
 		CorrelationKind: "response",
 		ResponseID:      strings.TrimSpace(responseID),
-	})
+	}, correlations...)
 }
 
-func (a *Agent) emitToolResultWithAccounting(out *eventOutput, result toolResultProjection, duration time.Duration) {
+func (a *Agent) emitToolResultWithAccounting(out *eventOutput, result toolResultProjection, duration time.Duration, correlations ...eventCorrelation) {
 	event := result.event()
-	if !a.emitEvent(out, event) {
+	if !a.emitEvent(out, event, correlations...) {
 		return
 	}
 	a.emitAccounting(out, AccountingEvent{
@@ -2819,7 +2835,7 @@ func (a *Agent) emitToolResultWithAccounting(out *eventOutput, result toolResult
 		CorrelationKind: "tool_call",
 		ToolCallID:      strings.TrimSpace(event.ToolCallID),
 		DurationMS:      duration.Milliseconds(),
-	})
+	}, correlations...)
 }
 
 func (a *Agent) emitCompactionWithAccounting(out *eventOutput, event CompactionEvent) {
@@ -2832,23 +2848,31 @@ func (a *Agent) emitCompactionWithAccounting(out *eventOutput, event CompactionE
 	})
 }
 
-func (a *Agent) emitAccounting(out *eventOutput, event AccountingEvent) {
+func (a *Agent) emitAccounting(out *eventOutput, event AccountingEvent, correlations ...eventCorrelation) {
 	event.Sequence = a.accountingSequence.Add(1)
-	a.emitEvent(out, event)
+	a.emitEvent(out, event, correlations...)
 }
 
-func (a *Agent) emitEvent(out *eventOutput, ev Event) bool {
+func (a *Agent) emitEvent(out *eventOutput, ev Event, correlations ...eventCorrelation) bool {
 	if out == nil {
 		return false
 	}
-	return a.emitEnvelope(out, ev, out.next(ev))
+	envelope := out.next(ev)
+	if len(correlations) == 1 && correlations[0].frameID != "" {
+		envelope.FrameID, envelope.InvokeAttempt = correlations[0].frameID, correlations[0].attempt
+	}
+	return a.emitEnvelope(out, ev, envelope)
 }
 
-func (a *Agent) emitEventFrom(out *eventOutput, ev Event, origin EventOrigin) bool {
+func (a *Agent) emitEventFrom(out *eventOutput, ev Event, origin EventOrigin, correlations ...eventCorrelation) bool {
 	if out == nil {
 		return false
 	}
-	return a.emitEnvelope(out, ev, out.nextFrom(ev, origin))
+	envelope := out.nextFrom(ev, origin)
+	if len(correlations) == 1 && correlations[0].frameID != "" {
+		envelope.FrameID, envelope.InvokeAttempt = correlations[0].frameID, correlations[0].attempt
+	}
+	return a.emitEnvelope(out, ev, envelope)
 }
 
 func (a *Agent) emitEnvelope(out *eventOutput, ev Event, envelope EventEnvelope) bool {
@@ -3190,8 +3214,8 @@ func (a *Agent) logDroppedEvent(ev Event, reason string) {
 	}
 }
 
-func (a *Agent) emitAutoContinue(out *eventOutput, reason string, responseID string) {
-	a.emitEvent(out, AutoContinueEvent{Reason: reason, ResponseID: strings.TrimSpace(responseID)})
+func (a *Agent) emitAutoContinue(out *eventOutput, reason string, responseID string, correlations ...eventCorrelation) {
+	a.emitEvent(out, AutoContinueEvent{Reason: reason, ResponseID: strings.TrimSpace(responseID)}, correlations...)
 }
 
 // lastResultForSignatureIsRecycled reports whether the most recent tool result

--- a/sdk/agent/event_envelope.go
+++ b/sdk/agent/event_envelope.go
@@ -49,6 +49,12 @@ const (
 type EventEnvelope struct {
 	SchemaVersion int
 	QueryID       string
+	// FrameID identifies the explicitly correlated execution context, not the
+	// sole provenance of aggregated continuation content. Empty means unknown.
+	FrameID string `json:"FrameID,omitempty"`
+	// InvokeAttempt counts SDK ChatModel entries within that logical frame;
+	// zero means no invocation correlation. It does not count hidden HTTP retries.
+	InvokeAttempt uint64 `json:"InvokeAttempt,omitempty"`
 	Sequence      uint64
 	Origin        EventOrigin
 	Kind          EventKind

--- a/sdk/agent/execution_frame.go
+++ b/sdk/agent/execution_frame.go
@@ -11,15 +11,17 @@ import (
 // For continued tool calls it is the finalizing request's dispatch snapshot;
 // the merged arguments may originate from multiple earlier requests.
 // Model/Handler values retain runtime handles, not immutable closure state or
-// a dynamic model wrapper's concrete target. Nothing here is persisted/emitted.
+// a dynamic model wrapper's concrete target. Only the opaque id is correlated
+// in event metadata; request/model/resolver content is not emitted here.
 type executionFrame struct {
+	id         string
 	model      llm.ChatModel
 	request    llm.InvokeRequest
 	exact      map[string]tools.Tool
 	normalized map[string]tools.Tool
 }
 
-func newExecutionFrame(model llm.ChatModel, request llm.InvokeRequest, exact, normalized map[string]tools.Tool) (*executionFrame, error) {
+func newExecutionFrame(id string, model llm.ChatModel, request llm.InvokeRequest, exact, normalized map[string]tools.Tool) (*executionFrame, error) {
 	owned, err := llm.CloneInvokeRequest(request)
 	if err != nil {
 		return nil, err
@@ -47,7 +49,52 @@ func newExecutionFrame(model llm.ChatModel, request llm.InvokeRequest, exact, no
 	if err != nil {
 		return nil, err
 	}
-	return &executionFrame{model: model, request: owned, exact: ownedExact, normalized: ownedNormalized}, nil
+	return &executionFrame{id: id, model: model, request: owned, exact: ownedExact, normalized: ownedNormalized}, nil
+}
+
+// eventCorrelation is copied at the producer, never read from ambient output
+// state. The original eventOutput remains the sequence/backpressure owner.
+type eventCorrelation struct {
+	frameID string
+	attempt uint64
+}
+
+// frameInvocation is query-driver-local bookkeeping, separate from immutable
+// executionFrame state. Only actual ChatModel entries advance the counter.
+type frameInvocation struct {
+	frameID string
+	entries uint64
+	current uint64
+}
+
+func (s *frameInvocation) resetAttempt() {
+	if s != nil {
+		s.current = 0
+	}
+}
+func (s *frameInvocation) enter() eventCorrelation {
+	if s == nil {
+		return eventCorrelation{}
+	}
+	s.entries++
+	s.current = s.entries
+	return s.correlation()
+}
+func (s *frameInvocation) correlation() eventCorrelation {
+	if s == nil || s.frameID == "" {
+		return eventCorrelation{}
+	}
+	return eventCorrelation{frameID: s.frameID, attempt: s.current}
+}
+
+// A completion retained across retry backoff belongs to the last actual model
+// entry even when no invocation is currently active. Use only with that returned
+// completion, not to attribute a backoff/cancellation error to the old attempt.
+func (s *frameInvocation) completionCorrelation() eventCorrelation {
+	if s == nil || s.frameID == "" {
+		return eventCorrelation{}
+	}
+	return eventCorrelation{frameID: s.frameID, attempt: s.entries}
 }
 
 // validBindings checks structural agreement, not mutable closure identity.

--- a/sdk/agent/execution_frame_test.go
+++ b/sdk/agent/execution_frame_test.go
@@ -37,7 +37,7 @@ func TestExecutionFrameOwnsRequestAndResolverSchemas(t *testing.T) {
 	}}
 	exact := map[string]tools.Tool{tool.Name: tool}
 	normalized := buildNormalizedToolMap(exact, []tools.Tool{tool})
-	frame, err := newExecutionFrame(model, request, exact, normalized)
+	frame, err := newExecutionFrame("fixture", model, request, exact, normalized)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -80,7 +80,7 @@ func TestExecutionFrameBindings(t *testing.T) {
 		t.Fatal(err)
 	}
 	request := llm.InvokeRequest{Tools: []llm.ToolDefinition{a.tools[0].Definition()}}
-	frame, err := newExecutionFrame(a.llm, request, a.toolMap, a.toolMapNormalized)
+	frame, err := newExecutionFrame("fixture", a.llm, request, a.toolMap, a.toolMapNormalized)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -413,7 +413,7 @@ func BenchmarkExecutionFrameSnapshot(b *testing.B) {
 	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		if _, err := newExecutionFrame(a.llm, request, a.toolMap, a.toolMapNormalized); err != nil {
+		if _, err := newExecutionFrame("fixture", a.llm, request, a.toolMap, a.toolMapNormalized); err != nil {
 			b.Fatal(err)
 		}
 	}
@@ -438,7 +438,7 @@ func BenchmarkExecutionFrameAdmissionScaling(b *testing.B) {
 			b.ReportAllocs()
 			b.ResetTimer()
 			for i := 0; i < b.N; i++ {
-				frame, err := newExecutionFrame(a.llm, request, a.toolMap, a.toolMapNormalized)
+				frame, err := newExecutionFrame("fixture", a.llm, request, a.toolMap, a.toolMapNormalized)
 				if err != nil || !frame.validBindings() {
 					b.Fatal("invalid fixture frame")
 				}

--- a/sdk/agent/frame_correlation_test.go
+++ b/sdk/agent/frame_correlation_test.go
@@ -1,0 +1,257 @@
+package agent
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/timwhitez/agent-sdk-golang/sdk/llm"
+	"github.com/timwhitez/agent-sdk-golang/sdk/tools"
+)
+
+func TestFailedFrameMaterializationHasNoInvocationCorrelation(t *testing.T) {
+	calls := 0
+	model := &frameScriptModel{invoke: func(llm.InvokeRequest) (*llm.Completion, error) { calls++; return &llm.Completion{}, nil }}
+	ag, err := New(Config{LLM: model, QueryIDGenerator: func() string { return "failed-frame" }, Warningf: func(string, ...any) {}, Tools: []tools.Tool{{Name: "work", Schema: map[string]any{"type": "object"}}}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	ag.tools[0].Schema["PRIVATE_SCHEMA_FAILURE"] = make(chan int)
+	count := 0
+	for e := range ag.QueryStreamEnveloped(context.Background(), llm.TextContent("run")) {
+		count++
+		failure, ok := e.Event.(ErrorEvent)
+		if !ok || failure.Kind != "invalid_request" || e.FrameID != "" || e.InvokeAttempt != 0 || e.Origin != EventOriginSDKDriver || strings.Contains(failure.Message, "PRIVATE_") {
+			t.Errorf("invalid-frame event=%+v", e)
+		}
+	}
+	if count != 1 || calls != 0 {
+		t.Fatalf("events=%d model calls=%d", count, calls)
+	}
+}
+
+func BenchmarkEventEnvelopeFrameCorrelation(b *testing.B) {
+	for _, scoped := range []bool{false, true} {
+		name := "absent"
+		if scoped {
+			name = "explicit"
+		}
+		b.Run(name, func(b *testing.B) {
+			ag, err := New(Config{LLM: envelopeFinalModel{}})
+			if err != nil {
+				b.Fatal(err)
+			}
+			out := newEventOutput(1, true, "query", func() time.Time { return time.Unix(100, 0) })
+			correlation := eventCorrelation{frameID: "query/frame/1", attempt: 2}
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				if scoped {
+					ag.emitEvent(out, TextEvent{Content: "fixture"}, correlation)
+				} else {
+					ag.emitEvent(out, TextEvent{Content: "fixture"})
+				}
+				<-out.enveloped
+			}
+		})
+	}
+}
+
+type correlatedStreamModel struct{ calls int }
+
+func (*correlatedStreamModel) Provider() string { return "fixture" }
+func (*correlatedStreamModel) Model() string    { return "stream" }
+func (*correlatedStreamModel) Invoke(context.Context, llm.InvokeRequest) (*llm.Completion, error) {
+	return nil, errors.New("unexpected buffered invocation")
+}
+func (m *correlatedStreamModel) InvokeStream(context.Context, llm.InvokeRequest) (<-chan llm.StreamEvent, error) {
+	m.calls++
+	if m.calls == 1 {
+		return nil, &net.DNSError{Err: "fixture", IsTimeout: true}
+	}
+	ch := make(chan llm.StreamEvent, 5)
+	ch <- llm.StreamRetryEvent{Attempt: 7, MaxRetries: 9, Message: "provider-reported retry"}
+	ch <- llm.StreamThinkingDeltaEvent{Delta: "synthetic thinking fixture"}
+	ch <- llm.StreamTextDeltaEvent{Delta: "done"}
+	ch <- llm.StreamUsageEvent{Usage: llm.Usage{PromptTokens: 10, CompletionTokens: 2, TotalTokens: 12, PromptTokensValid: true, PromptTokensSource: llm.PromptTokensSourceProvider, PromptTokensSemantics: llm.PromptTokensSemanticsTotalInputV1}}
+	ch <- llm.StreamDoneEvent{StopReason: "stop"}
+	close(ch)
+	return ch, nil
+}
+
+func TestStreamFrameCorrelationCountsSDKEntriesNotProviderRetryReports(t *testing.T) {
+	m := &correlatedStreamModel{}
+	ag, err := New(Config{LLM: m, InvokeRetryMaxAttempts: 2, QueryIDGenerator: func() string { return "stream-query" }, Warningf: func(string, ...any) {}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	seen := map[EventKind]int{}
+	for e := range ag.QueryStreamEnveloped(context.Background(), llm.TextContent("run")) {
+		seen[e.Kind]++
+		if e.FrameID != "stream-query/frame/1" || e.InvokeAttempt != 2 {
+			t.Errorf("kind=%s frame=%s attempt=%d", e.Kind, e.FrameID, e.InvokeAttempt)
+		}
+	}
+	if m.calls != 2 || seen[EventKindTextDelta] != 1 || seen[EventKindThinkingDelta] != 1 || seen[EventKindUsage] != 1 || seen[EventKindWarning] != 1 || seen[EventKindFinalResponse] != 1 {
+		t.Fatalf("SDK calls=%d kinds=%v", m.calls, seen)
+	}
+}
+
+func TestFrameCorrelationDoesNotInventAnInvocationOnCancellation(t *testing.T) {
+	for _, beforeAdmission := range []bool{false, true} {
+		ctx, cancel := context.WithCancel(context.Background())
+		calls := 0
+		model := &frameScriptModel{invoke: func(llm.InvokeRequest) (*llm.Completion, error) {
+			calls++
+			return nil, &net.DNSError{Err: "fixture", IsTimeout: true}
+		}}
+		ag, err := New(Config{LLM: model, InvokeRetryMaxAttempts: 2, QueryIDGenerator: func() string { return "cancel-query" }, Warningf: func(string, ...any) { cancel() }})
+		if err != nil {
+			cancel()
+			t.Fatal(err)
+		}
+		if beforeAdmission {
+			cancel()
+		}
+		for e := range ag.QueryStreamEnveloped(ctx, llm.TextContent("run")) {
+			failure, ok := e.Event.(ErrorEvent)
+			if !ok || failure.Kind != "canceled" || e.InvokeAttempt != 0 {
+				t.Errorf("cancel event=%+v", e)
+			}
+			wantFrame := "cancel-query/frame/1"
+			if beforeAdmission {
+				wantFrame = ""
+			}
+			if e.FrameID != wantFrame {
+				t.Errorf("frame=%s want=%s", e.FrameID, wantFrame)
+			}
+		}
+		cancel()
+		wantCalls := 1
+		if beforeAdmission {
+			wantCalls = 0
+		}
+		if calls != wantCalls {
+			t.Fatalf("calls=%d want=%d", calls, wantCalls)
+		}
+	}
+}
+
+func TestBackoffCancellationKeepsRetainedUsageOnItsActualInvoke(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	calls := 0
+	model := &frameScriptModel{invoke: func(llm.InvokeRequest) (*llm.Completion, error) {
+		calls++
+		return &llm.Completion{ResponseID: "partial", Usage: &llm.Usage{PromptTokens: 10, CompletionTokens: 2, TotalTokens: 12, PromptTokensValid: true, PromptTokensSource: llm.PromptTokensSourceProvider, PromptTokensSemantics: llm.PromptTokensSemanticsTotalInputV1}}, &net.DNSError{Err: "fixture", IsTimeout: true}
+	}}
+	ag, err := New(Config{LLM: model, InvokeRetryMaxAttempts: 2, QueryIDGenerator: func() string { return "usage-query" }, Warningf: func(string, ...any) { cancel() }})
+	if err != nil {
+		t.Fatal(err)
+	}
+	seen := map[EventKind]int{}
+	for e := range ag.QueryStreamEnveloped(ctx, llm.TextContent("run")) {
+		seen[e.Kind]++
+		if e.FrameID != "usage-query/frame/1" {
+			t.Errorf("frame=%s", e.FrameID)
+		}
+		switch e.Kind {
+		case EventKindUsage, EventKindAccounting:
+			if e.InvokeAttempt != 1 {
+				t.Errorf("retained usage mislabeled attempt=%d", e.InvokeAttempt)
+			}
+		case EventKindError:
+			if e.InvokeAttempt != 0 {
+				t.Error("backoff cancel blamed the finished invocation")
+			}
+		default:
+			t.Errorf("unexpected event %s", e.Kind)
+		}
+	}
+	if calls != 1 || seen[EventKindUsage] != 1 || seen[EventKindAccounting] != 1 || seen[EventKindError] != 1 {
+		t.Fatalf("calls=%d events=%v", calls, seen)
+	}
+}
+
+func TestExplicitFrameCorrelationDoesNotLeakIntoConcurrentUnscopedEvents(t *testing.T) {
+	ag, err := New(Config{LLM: envelopeFinalModel{}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	out := newEventOutput(200, true, "query", time.Now)
+	var wg sync.WaitGroup
+	for i := 0; i < 50; i++ {
+		wg.Add(2)
+		go func() {
+			defer wg.Done()
+			ag.emitEvent(out, TextEvent{Content: "text"}, eventCorrelation{frameID: "explicit", attempt: 3})
+		}()
+		go func() { defer wg.Done(); ag.emitEvent(out, WarnEvent{Kind: "host_observation"}) }()
+	}
+	wg.Wait()
+	ag.emitCompactionWithAccounting(out, CompactionEvent{})
+	ag.emitEvent(out, SteeringReceivedEvent{})
+	out.close()
+	seen := map[uint64]bool{}
+	for e := range out.enveloped {
+		if seen[e.Sequence] {
+			t.Error("duplicate sequence")
+		}
+		seen[e.Sequence] = true
+		if e.Kind == EventKindText {
+			if e.FrameID != "explicit" || e.InvokeAttempt != 3 {
+				t.Error("explicit correlation lost")
+			}
+		} else if e.FrameID != "" || e.InvokeAttempt != 0 {
+			t.Error("unscoped event inherited an ambient frame")
+		}
+	}
+	if len(seen) != 103 {
+		t.Fatalf("events=%d", len(seen))
+	}
+}
+
+func TestAbsentFrameCorrelationKeepsLegacyEnvelopeJSONShape(t *testing.T) {
+	ag, err := New(Config{LLM: envelopeFinalModel{}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	out := newEventOutput(2, true, "query", func() time.Time { return time.Unix(100, 0) })
+	ag.emitEvent(out, TextEvent{Content: "fixture"}, eventCorrelation{attempt: 99})
+	e := <-out.enveloped
+	if e.FrameID != "" || e.InvokeAttempt != 0 {
+		t.Fatal("orphan attempt correlation invented")
+	}
+	encoded, err := json.Marshal(e)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(encoded), "FrameID") || strings.Contains(string(encoded), "InvokeAttempt") {
+		t.Fatal("unavailable correlation changed old envelope JSON fields")
+	}
+}
+
+func TestFrameCorrelationRetainsOriginalTerminalBackpressureOwner(t *testing.T) {
+	ag, err := New(Config{LLM: envelopeFinalModel{}, EventSendTimeout: time.Millisecond})
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	out := newEventOutput(1, true, "query", time.Now)
+	unregister := ag.registerTurnCancellation(out, ctx)
+	defer unregister()
+	ag.emitEvent(out, TextEvent{Content: "evictable"}, eventCorrelation{frameID: "old", attempt: 1})
+	if !ag.emitEvent(out, FinalResponseEvent{Content: "done"}, eventCorrelation{frameID: "final", attempt: 2}) {
+		t.Fatal("terminal lost")
+	}
+	e := <-out.enveloped
+	if e.FrameID != "final" || e.InvokeAttempt != 2 || e.Sequence != 2 || e.Kind != EventKindFinalResponse || ag.eventDropCount.Load() != 1 || ag.turnBackpressureState(out) == nil {
+		t.Fatalf("terminal metadata or owner changed: %+v drops=%d", e, ag.eventDropCount.Load())
+	}
+}

--- a/sdk/agent/frame_event_boundary_test.go
+++ b/sdk/agent/frame_event_boundary_test.go
@@ -3,6 +3,7 @@ package agent
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"net"
 	"reflect"
 	"strings"
@@ -22,6 +23,7 @@ func TestFrameEventBoundaryRetryContinuationAndLegacyParity(t *testing.T) {
 	var baselineKinds []EventKind
 	wantKinds := []EventKind{EventKindWarning, EventKindAutoContinue, EventKindStepStart, EventKindToolCall, EventKindToolResult, EventKindAccounting, EventKindStepComplete, EventKindStepStart, EventKindToolCall, EventKindToolResult, EventKindAccounting, EventKindStepComplete, EventKindText, EventKindFinalResponse}
 	wantOrigins := []EventOrigin{EventOriginSDKDriver, EventOriginSDKDriver, EventOriginToolRuntime, EventOriginToolRuntime, EventOriginToolRuntime, EventOriginSDKDriver, EventOriginToolRuntime, EventOriginToolRuntime, EventOriginToolRuntime, EventOriginToolRuntime, EventOriginSDKDriver, EventOriginToolRuntime, EventOriginModel, EventOriginSDKDriver}
+	wantFrames := []int{1, 1, 2, 2, 2, 2, 2, 3, 3, 3, 3, 3, 4, 4}
 	for _, enveloped := range []bool{false, true} {
 		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer cancel()
@@ -74,6 +76,16 @@ func TestFrameEventBoundaryRetryContinuationAndLegacyParity(t *testing.T) {
 				}
 				if len(kinds) <= len(wantOrigins) && e.Origin != wantOrigins[len(kinds)-1] {
 					t.Errorf("origin golden at %d=%s", len(kinds), e.Origin)
+				}
+				if len(kinds) <= len(wantFrames) {
+					frame := wantFrames[len(kinds)-1]
+					attempt := uint64(1)
+					if frame == 1 {
+						attempt = 2
+					}
+					if e.FrameID != fmt.Sprintf("boundary-query/frame/%d", frame) || e.InvokeAttempt != attempt {
+						t.Errorf("correlation at event%d: frame=%s attempt=%d", len(kinds), e.FrameID, e.InvokeAttempt)
+					}
 				}
 				metadata := e
 				metadata.Event = nil


### PR DESCRIPTION
## Scope

Advances #83/#88 from reviewed characterization into actual read-only identity. Both multi-phase Issues remain open.

- Each materialized Query Driver request owns a content-free Frame ID derived from the existing QueryID and logical iteration. SDK retries reuse it; later logical requests get new IDs, regardless of repeated Tool Call IDs.
- Optional EventEnvelope FrameID/InvokeAttempt values are copied from explicit producer contexts. Attempts count Agent entries into the captured ChatModel.Invoke/InvokeStream, not HTTP or provider-reported retries.
- Original eventOutput, event sequence, cancellation/backpressure owner, typed payload and delivery/accounting gates remain intact. No ambient current-frame lookup; compaction/host/unannotated producers remain uncorrelated.
- Retained partial usage keeps its actual completed invocation association when backoff cancellation has no current invocation association. This review finding has a dedicated real-query regression.

This is execution/finalizing context, not sole provenance of aggregated continuation content, complete lineage, an exhaustive invocation trace, concrete-model snapshotting or failure attribution. No Provider InvokeRequest field/header or session persistence change.

Compatibility: additive public EventEnvelope fields; absent correlation omits them in JSON. External unkeyed struct literals and strict JSON decoders must be updated. Existing required v1 fields and legacy typed Event payloads are preserved; correlated envelope JSON is intentionally extended.

## Validation

Independent APPROVE exact head f16072cbf01ae1555d22162a908b8859277e04ad: author/reviewer focused x100/full/vet/agent+llm race passed; failed-materialization fixture x100 passed. Four independent mutations detected constant Frame IDs, missing retry-attempt increment, lost retained-usage attempt during backoff cancellation and ambient correlation on unscoped events. Restored clean and retested. No unresolved findings. Goode preliminary full/vet/app-ui-acp-subtask-session-cmd race passed with an isolated candidate-SDK modfile.

Independent evidence: /tmp/review125-{full,vet,race,focused,materialize100,restored}.log and /tmp/review125-mutation-*.log.

Tests cover the existing 14-event golden's Frame/attempt mapping, SDK streaming retry versus provider retry report7, pre-admission/backoff cancellation, retained usage attempt1 versus cancellation attempt0, concurrent unscoped host/compaction/steering, original terminal eviction owner and drop counts, failed materialization, absent-correlation JSON and metadata privacy.

Emission-only benchmark five-sample medians: uncorrelated110.0ns/op and explicit114.3ns/op, both16B/op/1allocation. Not Frame construction, Provider latency, model quality or an end-to-end speedup. Logs /tmp/sdk83-correlation-{exact-focused,exact-full,exact-vet,exact-race,bench}.log.

After SDK approval/merge, update and independently review the exact Goode pin, then validate fresh main. No hosted CI/live-provider coverage claimed.
