### PR TITLE
feat(llm): add pure cache target view and snapshot-bound validation

### DIFF
--- a/sdk/llm/cache_plan.go
+++ b/sdk/llm/cache_plan.go
@@ -28,8 +28,8 @@ const (
 )
 
 // CacheTarget identifies an object in a normalized, already-materialized
-// request. Only fields selected by Kind are meaningful. Fingerprints bind the
-// intent without retaining Prompt, Tool Result, or Tool Definition text.
+// request. Only fields selected by Kind are meaningful. CacheTargetView defines
+// logical ordinals and binds by an owned request snapshot, not a wire index.
 type CacheTarget struct {
 	Kind CacheTargetKind
 
@@ -37,6 +37,8 @@ type CacheTarget struct {
 	BlockOrdinal int
 	ToolIndex    int
 
+	// Reserved experimental field. CacheTargetView.Validate requires it empty;
+	// it does not generate or trust caller-supplied content fingerprints.
 	ExpectedObjectFingerprint string
 }
 
@@ -51,7 +53,9 @@ type CacheDirective struct {
 // Provider adapters do not consume this type until explicit validation and
 // capability-gated mapping are added.
 type CachePlan struct {
-	SchemaVersion      int
+	SchemaVersion int
+	// Reserved experimental field; unused by providers. CacheTargetView uses
+	// its retained request snapshot instead and requires this field empty.
 	RequestFingerprint string
 	Directives         []CacheDirective
 }

--- a/sdk/llm/cache_target_view.go
+++ b/sdk/llm/cache_target_view.go
@@ -1,0 +1,203 @@
+package llm
+
+import (
+	"fmt"
+	"reflect"
+	"strings"
+)
+
+// CacheTargetDescriptor locates a logical boundary, not a Provider wire index.
+// Source is text, content_block, tool_call, tool_result, or tool_definition.
+// SourceIndex is the
+// original Blocks/ToolCalls index, or -1 for Text and the outer tool result.
+// It contains no content, names, IDs, or content fingerprints.
+type CacheTargetDescriptor struct {
+	Target      CacheTarget
+	Source      string
+	SourceIndex int
+}
+
+// CacheTargetView owns one materialized logical request. Retain this view from
+// plan construction through validation; rebuilding it from a changed request
+// cannot establish that an older plan still names the intended objects.
+// It is not a model snapshot, persistence identity, or Provider capability.
+// Read-only methods may run concurrently; callers must own their input graphs.
+type CacheTargetView struct {
+	request *InvokeRequest
+	targets []CacheTargetDescriptor
+}
+
+// CachePlanValidationError exposes only a fixed reason and directive ordinal.
+// DirectiveIndex is -1 for a request/plan-wide failure. There is deliberately
+// no wrapped clone error, request content, or fingerprint in diagnostics.
+type CachePlanValidationError struct {
+	Reason         string
+	DirectiveIndex int
+}
+
+func (e *CachePlanValidationError) Error() string {
+	return fmt.Sprintf("cache plan: %s (directive %d)", e.Reason, e.DirectiveIndex)
+}
+
+func cachePlanError(reason string, index int) error {
+	return &CachePlanValidationError{Reason: reason, DirectiveIndex: index}
+}
+
+// NewCacheTargetView clones using the ordinary request ownership path. It does
+// not call a Provider, alter request/history, or generate a content hash.
+// Plan metadata is excluded from request identity. Exact Go-value equality is
+// intentionally conservative (including nil/empty and non-wire options).
+func NewCacheTargetView(request InvokeRequest) (*CacheTargetView, error) {
+	request.CachePlan = nil
+	owned, err := CloneInvokeRequest(request)
+	if err != nil {
+		return nil, cachePlanError("uncloneable_request", -1)
+	}
+	view := &CacheTargetView{request: &owned}
+	for i, message := range owned.Messages {
+		if message.Role != RoleSystem && message.Role != RoleUser && message.Role != RoleAssistant && message.Role != RoleTool {
+			continue
+		}
+		ordinal := 0
+		start := len(view.targets)
+		appendBlock := func(source string, index int) {
+			view.targets = append(view.targets, CacheTargetDescriptor{
+				Target: CacheTarget{Kind: CacheAfterMessageBlock, MessageIndex: i, BlockOrdinal: ordinal},
+				Source: source, SourceIndex: index,
+			})
+			ordinal++
+		}
+		if message.Role == RoleTool {
+			// A result is one logical outer block, even if its Provider content
+			// is flattened, nested, empty, or merged with adjacent results.
+			appendBlock("tool_result", -1)
+		} else {
+			if strings.TrimSpace(message.Content.Text) != "" {
+				appendBlock("text", -1)
+			}
+			for j, block := range message.Content.Blocks {
+				if IsProviderStateBlock(block) {
+					continue
+				}
+				// Only structurally visible supported shapes get targets. Empty,
+				// unknown, thinking and redacted-thinking blocks are not targets.
+				switch block.Type {
+				case "text":
+					if strings.TrimSpace(block.Text) == "" {
+						continue
+					}
+				case "image_url":
+					if block.ImageURL == nil || strings.TrimSpace(block.ImageURL.URL) == "" {
+						continue
+					}
+				case "document":
+					if block.Source == nil || block.Source.Data == "" || block.Source.MediaType == "" {
+						continue
+					}
+				default:
+					continue
+				}
+				appendBlock("content_block", j)
+			}
+			if message.Role == RoleAssistant {
+				for j := range message.ToolCalls {
+					appendBlock("tool_call", j)
+				}
+			}
+		}
+		if len(view.targets) > start {
+			last := view.targets[len(view.targets)-1]
+			// This is a logical message boundary. Provider mapping must still
+			// reject unsupported/hidden trailing wire blocks instead of guessing.
+			last.Target = CacheTarget{Kind: CacheAfterMessage, MessageIndex: i}
+			view.targets = append(view.targets, last)
+		}
+	}
+	for i := range owned.Tools {
+		view.targets = append(view.targets, CacheTargetDescriptor{
+			Target: CacheTarget{Kind: CacheAfterToolDefinition, ToolIndex: i},
+			Source: "tool_definition", SourceIndex: i,
+		})
+	}
+	return view, nil
+}
+
+// Targets returns an owned list. BlockOrdinal indexes visible logical blocks:
+// nonempty Text, addressable explicit Blocks, then assistant ToolCalls. Opaque
+// and hidden blocks do not consume ordinals. Tool messages expose only their
+// outer result, never nested content. Message boundaries alias the final logical
+// target for duplicate detection; this is not permission to drop wire blocks.
+func (view *CacheTargetView) Targets() []CacheTargetDescriptor {
+	if view == nil {
+		return nil
+	}
+	return append([]CacheTargetDescriptor(nil), view.targets...)
+}
+
+// Validate checks a plan against this retained view and the current request.
+// This is an opt-in pure check, not Provider admission: no client invokes it yet.
+// Nil plans require no check. Fingerprint fields from the experimental API are
+// unsupported here; the retained owned snapshot supplies the binding instead.
+// Both policies require valid structure; capability/TTL support and best-effort
+// downgrade remain the responsibility of a future Provider admission layer.
+func (view *CacheTargetView) Validate(request InvokeRequest, plan *CachePlan) error {
+	if plan == nil {
+		return nil
+	}
+	if view == nil || view.request == nil {
+		return cachePlanError("missing_view", -1)
+	}
+	request.CachePlan = nil
+	if !reflect.DeepEqual(*view.request, request) {
+		return cachePlanError("stale_request", -1)
+	}
+	if plan.SchemaVersion != CachePlanSchemaVersion {
+		return cachePlanError("unsupported_schema", -1)
+	}
+	if plan.RequestFingerprint != "" {
+		return cachePlanError("unsupported_fingerprint", -1)
+	}
+	// ponytail: linear target lookup; index only if measured large plans need it.
+	seen := make(map[CacheTargetDescriptor]bool, len(plan.Directives))
+	for i, directive := range plan.Directives {
+		if directive.Policy != CacheBestEffort && directive.Policy != CacheRequired {
+			return cachePlanError("invalid_policy", i)
+		}
+		if directive.TTL != CacheTTLProviderDefault && directive.TTL != CacheTTL5Minutes && directive.TTL != CacheTTL1Hour {
+			return cachePlanError("invalid_ttl", i)
+		}
+		if directive.Target.ExpectedObjectFingerprint != "" {
+			return cachePlanError("unsupported_fingerprint", i)
+		}
+		target := directive.Target
+		switch target.Kind {
+		case CacheAfterMessageBlock:
+			target.ToolIndex = 0
+		case CacheAfterMessage:
+			target.ToolIndex, target.BlockOrdinal = 0, 0
+		case CacheAfterToolDefinition:
+			target.MessageIndex, target.BlockOrdinal = 0, 0
+		default:
+			return cachePlanError("invalid_target", i)
+		}
+		found := false
+		for _, candidate := range view.targets {
+			if candidate.Target != target {
+				continue
+			}
+			// Canonicalize message/final-block aliases by their original source.
+			candidate.Target.Kind = ""
+			candidate.Target.BlockOrdinal = 0
+			if seen[candidate] {
+				return cachePlanError("duplicate_boundary", i)
+			}
+			seen[candidate] = true
+			found = true
+			break
+		}
+		if !found {
+			return cachePlanError("invalid_target", i)
+		}
+	}
+	return nil
+}

--- a/sdk/llm/cache_target_view_test.go
+++ b/sdk/llm/cache_target_view_test.go
@@ -1,0 +1,302 @@
+package llm_test
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"reflect"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/timwhitez/agent-sdk-golang/sdk/llm"
+)
+
+func cacheViewFixture(t *testing.T) llm.InvokeRequest {
+	t.Helper()
+	content, err := llm.WithProviderState(llm.Content{Text: "private-text", Blocks: []llm.ContentBlock{
+		{Type: "thinking", Thinking: "private-thinking", Signature: "private-signature"},
+		{Type: "text"}, {Type: "text", Text: "visible"},
+		{Type: "image_url", ImageURL: &llm.ImageURL{URL: "https://fixture.invalid/image"}},
+		{Type: "document", Source: &llm.DocSrc{Data: "private-document", MediaType: "application/pdf"}},
+		{Type: "redacted_thinking", Data: "private-redacted"}, {Type: "unknown", Text: "private-unknown"},
+		{Type: "image_url"}, {Type: "document"},
+	}}, []llm.ProviderState{{Provider: "fixture", Kind: "opaque", Data: json.RawMessage(`{"secret":"private-opaque"}`)}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	temperature := 0.5
+	return llm.InvokeRequest{
+		Messages: []llm.Message{
+			{Role: llm.RoleAssistant, Content: content, ToolCalls: []llm.ToolCall{{ID: "private-call", Function: llm.FunctionCall{Name: "private-tool", Arguments: `{}`}}}},
+			{Role: llm.RoleTool, ToolCallID: "private-call", Content: llm.TextContent("private-result")},
+			{Role: llm.RoleUser, Content: llm.TextContent(" \t ")},
+			{Role: "unknown", Content: llm.TextContent("ignored")},
+		},
+		Tools:       []llm.ToolDefinition{{Name: "private-tool", Parameters: map[string]any{"type": "object", "nested": map[string]any{"value": "private-schema"}}}},
+		Temperature: &temperature,
+		Responses:   &llm.ResponsesOptions{Include: []string{"private-include"}, OutputSchema: map[string]any{"type": "object"}},
+	}
+}
+
+func TestCacheTargetViewLogicalGoldenAndPrivacy(t *testing.T) {
+	request := cacheViewFixture(t)
+	view, err := llm.NewCacheTargetView(request)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var rows []string
+	for _, descriptor := range view.Targets() {
+		target := descriptor.Target
+		rows = append(rows, fmt.Sprintf("%s:%d:%d:%d:%s:%d", target.Kind, target.MessageIndex, target.BlockOrdinal, target.ToolIndex, descriptor.Source, descriptor.SourceIndex))
+	}
+	want := []string{
+		"after_message_block:0:0:0:text:-1", "after_message_block:0:1:0:content_block:2",
+		"after_message_block:0:2:0:content_block:3", "after_message_block:0:3:0:content_block:4",
+		"after_message_block:0:4:0:tool_call:0", "after_message:0:0:0:tool_call:0",
+		"after_message_block:1:0:0:tool_result:-1", "after_message:1:0:0:tool_result:-1",
+		"after_tool_definition:0:0:0:tool_definition:0",
+	}
+	if !reflect.DeepEqual(rows, want) {
+		t.Fatalf("logical target golden: %v", rows)
+	}
+	targets := view.Targets()
+	targets[0].Source = "caller-change"
+	if view.Targets()[0].Source != "text" {
+		t.Fatal("Targets exposed owned slice")
+	}
+	for _, value := range []any{view.Targets(), view} {
+		encoded, err := json.Marshal(value)
+		if err != nil || strings.Contains(string(encoded), "private-") {
+			t.Fatal("public JSON projection leaked request content")
+		}
+		if strings.Contains(fmt.Sprintf("%+v %#v", value, value), "private-") {
+			t.Fatal("default formatting leaked request content")
+		}
+	}
+	var nilView *llm.CacheTargetView
+	if nilView.Targets() != nil || nilView.Validate(request, nil) != nil {
+		t.Fatal("nil/no-plan compatibility")
+	}
+}
+
+func TestCacheTargetViewValidationAndAliases(t *testing.T) {
+	request := cacheViewFixture(t)
+	view, err := llm.NewCacheTargetView(request)
+	if err != nil {
+		t.Fatal(err)
+	}
+	planFor := func(target llm.CacheTarget) *llm.CachePlan {
+		return &llm.CachePlan{SchemaVersion: llm.CachePlanSchemaVersion, Directives: []llm.CacheDirective{{Target: target, Policy: llm.CacheRequired}}}
+	}
+	for _, descriptor := range view.Targets() {
+		if err := view.Validate(request, planFor(descriptor.Target)); err != nil {
+			t.Fatal(err)
+		}
+	}
+	base := planFor(view.Targets()[0].Target)
+	for _, test := range []struct {
+		name, reason string
+		index        int
+		change       func(*llm.CachePlan)
+	}{
+		{"schema", "unsupported_schema", -1, func(p *llm.CachePlan) { p.SchemaVersion++ }},
+		{"request-fingerprint", "unsupported_fingerprint", -1, func(p *llm.CachePlan) { p.RequestFingerprint = "private-fingerprint" }},
+		{"object-fingerprint", "unsupported_fingerprint", 0, func(p *llm.CachePlan) { p.Directives[0].Target.ExpectedObjectFingerprint = "private-object" }},
+		{"policy", "invalid_policy", 0, func(p *llm.CachePlan) { p.Directives[0].Policy = "private-policy" }},
+		{"ttl", "invalid_ttl", 0, func(p *llm.CachePlan) { p.Directives[0].TTL = "private-ttl" }},
+		{"kind", "invalid_target", 0, func(p *llm.CachePlan) { p.Directives[0].Target.Kind = "private-kind" }},
+		{"negative-message", "invalid_target", 0, func(p *llm.CachePlan) { p.Directives[0].Target.MessageIndex = -1 }},
+		{"missing-message", "invalid_target", 0, func(p *llm.CachePlan) { p.Directives[0].Target.MessageIndex = 99 }},
+		{"missing-block", "invalid_target", 0, func(p *llm.CachePlan) { p.Directives[0].Target.BlockOrdinal = 99 }},
+		{"empty-message", "invalid_target", 0, func(p *llm.CachePlan) {
+			p.Directives[0].Target = llm.CacheTarget{Kind: llm.CacheAfterMessage, MessageIndex: 2}
+		}},
+		{"missing-tool", "invalid_target", 0, func(p *llm.CachePlan) {
+			p.Directives[0].Target = llm.CacheTarget{Kind: llm.CacheAfterToolDefinition, ToolIndex: -1}
+		}},
+		{"duplicate", "duplicate_boundary", 1, func(p *llm.CachePlan) { p.Directives = append(p.Directives, p.Directives[0]) }},
+		{"alias-conflict", "duplicate_boundary", 1, func(p *llm.CachePlan) {
+			p.Directives[0].Target = llm.CacheTarget{Kind: llm.CacheAfterMessage, MessageIndex: 0}
+			p.Directives = append(p.Directives, llm.CacheDirective{Target: llm.CacheTarget{Kind: llm.CacheAfterMessageBlock, MessageIndex: 0, BlockOrdinal: 4}, Policy: llm.CacheBestEffort, TTL: llm.CacheTTL1Hour})
+		}},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			plan := llm.CloneCachePlan(base)
+			test.change(plan)
+			before := llm.CloneCachePlan(plan)
+			assertCacheViewError(t, view.Validate(request, plan), test.reason, test.index)
+			if !reflect.DeepEqual(plan, before) {
+				t.Fatal("validation mutated plan")
+			}
+		})
+	}
+	// Unselected index fields retain the existing CacheTarget contract.
+	base.Directives[0].Target.ToolIndex = -99
+	base.Directives[0].Policy = llm.CacheBestEffort
+	base.Directives[0].TTL = llm.CacheTTL5Minutes
+	if err := view.Validate(request, base); err != nil {
+		t.Fatal(err)
+	}
+	assertCacheViewError(t, (&llm.CacheTargetView{}).Validate(request, base), "missing_view", -1)
+}
+
+func assertCacheViewError(t *testing.T, err error, reason string, index int) {
+	t.Helper()
+	var typed *llm.CachePlanValidationError
+	if !errors.As(err, &typed) || typed.Reason != reason || typed.DirectiveIndex != index {
+		t.Fatalf("want %s/%d, got %v", reason, index, err)
+	}
+	if strings.Contains(err.Error(), "private-") || errors.Unwrap(err) != nil {
+		t.Fatal("diagnostic exposed caller content or wrapped error")
+	}
+}
+
+func TestCacheTargetViewOwnedSnapshotAndStaleRequest(t *testing.T) {
+	for _, mutate := range []struct {
+		name string
+		fn   func(*llm.InvokeRequest)
+	}{
+		{"text", func(r *llm.InvokeRequest) { r.Messages[0].Content.Text = "changed" }},
+		{"block-pointer", func(r *llm.InvokeRequest) { r.Messages[0].Content.Blocks[3].ImageURL.URL = "changed" }},
+		{"tool-schema", func(r *llm.InvokeRequest) { r.Tools[0].Parameters["nested"].(map[string]any)["value"] = "changed" }},
+		{"call", func(r *llm.InvokeRequest) { r.Messages[0].ToolCalls[0].ID = "changed" }},
+		{"result-reorder", func(r *llm.InvokeRequest) { r.Messages[0], r.Messages[1] = r.Messages[1], r.Messages[0] }},
+		{"compaction", func(r *llm.InvokeRequest) { r.Messages = r.Messages[2:] }},
+		{"temperature", func(r *llm.InvokeRequest) { *r.Temperature = 0.1 }},
+		{"options", func(r *llm.InvokeRequest) { r.DisableThinking = true }},
+		{"responses-slice", func(r *llm.InvokeRequest) { r.Responses.Include[0] = "changed" }},
+		{"responses-schema", func(r *llm.InvokeRequest) { r.Responses.OutputSchema["type"] = "changed" }},
+	} {
+		t.Run(mutate.name, func(t *testing.T) {
+			request := cacheViewFixture(t)
+			original, err := llm.CloneInvokeRequest(request)
+			if err != nil {
+				t.Fatal(err)
+			}
+			view, err := llm.NewCacheTargetView(request)
+			if err != nil {
+				t.Fatal(err)
+			}
+			plan := &llm.CachePlan{SchemaVersion: llm.CachePlanSchemaVersion}
+			request.CachePlan = &llm.CachePlan{RequestFingerprint: "not-request-identity"}
+			if err := view.Validate(request, plan); err != nil {
+				t.Fatal(err)
+			}
+			mutate.fn(&request)
+			assertCacheViewError(t, view.Validate(request, plan), "stale_request", -1)
+			if err := view.Validate(original, plan); err != nil {
+				t.Fatal("source mutation changed snapshot", err)
+			}
+		})
+	}
+	request := cacheViewFixture(t)
+	request.Tools[0].Parameters["private-secret"] = func() {}
+	view, err := llm.NewCacheTargetView(request)
+	assertCacheViewError(t, err, "uncloneable_request", -1)
+	if view != nil {
+		t.Fatal("failed construction returned a view")
+	}
+}
+
+func TestCacheTargetViewConservativeEmptyIdentity(t *testing.T) {
+	view, err := llm.NewCacheTargetView(llm.InvokeRequest{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	plan := &llm.CachePlan{SchemaVersion: llm.CachePlanSchemaVersion}
+	if err := view.Validate(llm.InvokeRequest{}, plan); err != nil {
+		t.Fatal(err)
+	}
+	for _, request := range []llm.InvokeRequest{
+		{Messages: []llm.Message{}}, {Tools: []llm.ToolDefinition{}}, {Responses: &llm.ResponsesOptions{}},
+	} {
+		assertCacheViewError(t, view.Validate(request, plan), "stale_request", -1)
+	}
+	// Per-result boundaries retain their identity even when legal result order changes.
+	request := llm.InvokeRequest{Messages: []llm.Message{
+		{Role: llm.RoleAssistant, ToolCalls: []llm.ToolCall{{ID: "a"}, {ID: "b"}}},
+		{Role: llm.RoleTool, ToolCallID: "a"}, {Role: llm.RoleTool, ToolCallID: "b"},
+	}, Tools: []llm.ToolDefinition{{Name: "a"}, {Name: "b"}}}
+	view, err = llm.NewCacheTargetView(request)
+	if err != nil {
+		t.Fatal(err)
+	}
+	request.Messages[1], request.Messages[2] = request.Messages[2], request.Messages[1]
+	assertCacheViewError(t, view.Validate(request, plan), "stale_request", -1)
+	request.Messages[1], request.Messages[2] = request.Messages[2], request.Messages[1]
+	request.Tools[0], request.Tools[1] = request.Tools[1], request.Tools[0]
+	assertCacheViewError(t, view.Validate(request, plan), "stale_request", -1)
+}
+
+func TestCacheTargetViewConcurrentReads(t *testing.T) {
+	request := cacheViewFixture(t)
+	view, err := llm.NewCacheTargetView(request)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var wg sync.WaitGroup
+	for i := 0; i < 8; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < 20; j++ {
+				plan := &llm.CachePlan{SchemaVersion: llm.CachePlanSchemaVersion, Directives: []llm.CacheDirective{{Target: view.Targets()[0].Target, Policy: llm.CacheRequired}}}
+				if err := view.Validate(request, plan); err != nil {
+					t.Error(err)
+				}
+			}
+		}()
+	}
+	wg.Wait()
+}
+
+func BenchmarkCacheTargetView(b *testing.B) {
+	for _, count := range []int{1, 32, 256} {
+		b.Run(fmt.Sprint(count), func(b *testing.B) {
+			request := llm.InvokeRequest{Messages: make([]llm.Message, count)}
+			for i := range request.Messages {
+				request.Messages[i] = llm.Message{Role: llm.RoleUser, Content: llm.TextContent(strings.Repeat("x", 1024))}
+			}
+			b.Run("snapshot", func(b *testing.B) {
+				b.ReportAllocs()
+				for i := 0; i < b.N; i++ {
+					if _, err := llm.NewCacheTargetView(request); err != nil {
+						b.Fatal(err)
+					}
+				}
+			})
+			view, err := llm.NewCacheTargetView(request)
+			if err != nil {
+				b.Fatal(err)
+			}
+			plan := &llm.CachePlan{SchemaVersion: llm.CachePlanSchemaVersion, Directives: []llm.CacheDirective{{Target: llm.CacheTarget{Kind: llm.CacheAfterMessage, MessageIndex: count - 1}, Policy: llm.CacheRequired}}}
+			b.Run("validate-last-boundary", func(b *testing.B) {
+				b.ReportAllocs()
+				for i := 0; i < b.N; i++ {
+					if err := view.Validate(request, plan); err != nil {
+						b.Fatal(err)
+					}
+				}
+			})
+		})
+	}
+}
+
+func ExampleCacheTargetView() {
+	request := llm.InvokeRequest{Messages: []llm.Message{{Role: llm.RoleUser, Content: llm.TextContent("hello")}}}
+	view, err := llm.NewCacheTargetView(request)
+	if err != nil {
+		panic(err)
+	}
+	plan := &llm.CachePlan{SchemaVersion: llm.CachePlanSchemaVersion, Directives: []llm.CacheDirective{{
+		Target: view.Targets()[0].Target, Policy: llm.CacheRequired,
+	}}}
+	// Retain the original view. A new view after editing would not detect staleness.
+	fmt.Println(view.Validate(request, plan))
+	request.Messages[0].Content.Text = "changed"
+	fmt.Println(view.Validate(request, plan))
+	// Output:
+	// <nil>
+	// cache plan: stale_request (directive -1)
+}


### PR DESCRIPTION
## Scope

Related to #89 (multi-phase, remains open). Builds on merged #127 characterization instead of repeating it.

New opt-in pure CacheTargetView owns a CloneInvokeRequest snapshot, exposes content-free logical source coordinates, and validates a plan against the retained snapshot and current request. No production provider/Agent caller is added. No wire, prompt, history, model selection, scheduling or persistence change.

Binding uses conservative exact in-memory Go-value equality, not new content fingerprints or commit gates. Existing experimental fingerprint fields remain source-compatible but are explicitly unsupported by this checker. The caller must retain the original view; rebuilding a view after an edit cannot prove an old plan's provenance. This is not a session revision, concrete-model snapshot or TOCTOU-safe send API.

## Contract

- Ordinals: nonempty Text, addressable visible explicit blocks, assistant ToolCalls. Opaque/thinking/redacted/empty/unknown blocks are not targets. Original source indexes are retained, not confused with Provider wire offsets.
- Tool messages expose one outer result boundary, not nested content blocks. Message boundaries alias the final logical target for duplicate detection; adapters must still reject unprovable wire mappings, including hidden trailing blocks.
- Validates schema, current snapshot equality, kind/indices, policy/TTL syntax and duplicate/conflicting boundary aliases. Fixed typed reason+ordinal errors do not wrap content-bearing clone errors.
- Nil plan needs no validation. Nil/zero view with a plan fails. Returned metadata is owned; immutable snapshot supports concurrent reads with caller-owned input graphs.

## Validation

Author exact df7c7c7577f32b5f563dc6fa5c7c47bf56fbfccf: focused100, full/vet/LLM+provider+Agent race passed. Golden logical coordinates, stale text/options/schema/pointer/reorder/compaction, nil-empty identity, clone failure, privacy, unchanged inputs, duplicate aliases, concurrent reads and runnable example included. Existing HTTP wire goldens remain authoritative for inert plan compatibility. Independent exact-head review in progress before merge.

Benchmark (three samples, median) measures only snapshot construction / one last-boundary validation for 1, 32, 256 one-KiB messages: snapshot432.9/11988/100428ns,512/16880/138992B,5/10/13alloc; validation587.1/5721/45753ns,192B/2alloc. Strings remain shared immutable Go values. No speedup, provider/model performance or worst-case input claim. Logs /tmp/sdk-cache-view-exact-*.log.

Non-goals: capability support, required/best-effort network admission, provider breakpoint/TTL limits, explicit mapping, diagnostics event delivery or Goode generator. Passing this checker does not establish Provider acceptance, full tool-history validity, caching support or cache hit.
