### PR TITLE
feat(llm): resolve cache intent against concrete client capabilities

### DIFF
--- a/sdk/llm/anthropic/client.go
+++ b/sdk/llm/anthropic/client.go
@@ -73,6 +73,12 @@ func (c *Client) warnf(format string, args ...any) {
 
 func (c *Client) Provider() string { return "anthropic" }
 
+// PromptCacheCapabilities reports explicit CachePlan mapping, not legacy
+// Message.Cache/MaxCachedToolDefinitions. Those legacy controls remain separate.
+func (c *Client) PromptCacheCapabilities() llm.PromptCacheCapabilities {
+	return llm.PromptCacheCapabilities{UsageTelemetry: true}
+}
+
 func (c *Client) Model() string { return c.ModelName }
 
 func (c *Client) Invoke(ctx context.Context, req llm.InvokeRequest) (*llm.Completion, error) {

--- a/sdk/llm/cache_decision.go
+++ b/sdk/llm/cache_decision.go
@@ -1,0 +1,122 @@
+package llm
+
+import "reflect"
+
+// CacheDirectiveDecision is bounded, content-free metadata for one original
+// directive. Accepted means eligible under reported capabilities, not mapped,
+// sent, or cached. Reason is accepted, unsupported_target, unsupported_ttl, or
+// breakpoint_limit. No content, names, IDs, hashes or Provider strings are kept.
+type CacheDirectiveDecision struct {
+	DirectiveIndex int
+	Accepted       bool
+	Reason         string
+}
+
+// CachePlanDecision owns a filtered plan and decisions in original order.
+// It is not send authorization: retain the original view and revalidate at the
+// actual owned-request/serializer boundary. A mutable model handle or capability
+// report is not a concrete-model snapshot or proof of exact wire mapping.
+type CachePlanDecision struct {
+	Plan         *CachePlan
+	Directives   []CacheDirectiveDecision
+	Capabilities PromptCacheCapabilities
+}
+
+// Decide validates against the retained view, queries the actual model's
+// optional capability interface once, and allocates logical breakpoints.
+// It never invokes the model, changes request/history, or guesses from names.
+// No production provider invokes this opt-in helper yet.
+//
+// Invalid/stale plans fail for both policies. Required directives reserve
+// capacity first; remaining best-effort directives are kept in input order.
+// Unsupported required directives or required overflow reject the entire plan
+// with a fixed CachePlanValidationError, never a partially accepted result.
+func (view *CacheTargetView) Decide(request InvokeRequest, plan *CachePlan, model ChatModel) (*CachePlanDecision, error) {
+	// Capability callbacks must not be able to rewrite the validated plan via
+	// aliases to the caller's input graph.
+	plan = CloneCachePlan(plan)
+	if err := view.Validate(request, plan); err != nil {
+		return nil, err
+	}
+	if plan == nil {
+		return &CachePlanDecision{}, nil
+	}
+	result := &CachePlanDecision{Plan: plan}
+	if len(plan.Directives) == 0 {
+		return result, nil
+	}
+	value := reflect.ValueOf(model)
+	if !value.IsValid() || (value.Kind() == reflect.Pointer && value.IsNil()) {
+		return nil, cachePlanError("missing_model", -1)
+	}
+	if provider, ok := model.(PromptCacheCapabilityProvider); ok {
+		result.Capabilities = provider.PromptCacheCapabilities().Clone()
+	}
+	caps := result.Capabilities
+	if caps.MaxBreakpoints < 0 {
+		return nil, cachePlanError("invalid_capabilities", -1)
+	}
+	for _, ttl := range caps.SupportedTTLs {
+		if ttl != CacheTTLProviderDefault && ttl != CacheTTL5Minutes && ttl != CacheTTL1Hour {
+			return nil, cachePlanError("invalid_capabilities", -1)
+		}
+	}
+	result.Directives = make([]CacheDirectiveDecision, len(plan.Directives))
+	required := 0
+	for i, directive := range plan.Directives {
+		reason := "accepted"
+		supported := false
+		switch directive.Target.Kind {
+		case CacheAfterMessage:
+			supported = caps.ExplicitMessageBoundary
+		case CacheAfterMessageBlock:
+			supported = caps.ExplicitContentBlock
+		case CacheAfterToolDefinition:
+			supported = caps.ExplicitToolDefinition
+		}
+		if !supported {
+			reason = "unsupported_target"
+		} else if directive.TTL != CacheTTLProviderDefault {
+			ttlSupported := false
+			for _, ttl := range caps.SupportedTTLs {
+				if ttl == directive.TTL {
+					ttlSupported = true
+					break
+				}
+			}
+			if !ttlSupported {
+				reason = "unsupported_ttl"
+			}
+		}
+		if directive.Policy == CacheRequired {
+			if reason != "accepted" {
+				return nil, cachePlanError(reason, i)
+			}
+			required++
+			if required > caps.MaxBreakpoints {
+				return nil, cachePlanError("breakpoint_limit", i)
+			}
+		}
+		result.Directives[i] = CacheDirectiveDecision{DirectiveIndex: i, Reason: reason}
+	}
+	remaining := caps.MaxBreakpoints - required
+	// Filter the owned slice, preserving nil/empty ownership and original order.
+	directives := result.Plan.Directives
+	result.Plan.Directives = result.Plan.Directives[:0]
+	for i, directive := range directives {
+		decision := &result.Directives[i]
+		if decision.Reason != "accepted" {
+			continue
+		}
+		if directive.Policy == CacheBestEffort {
+			if remaining == 0 {
+				decision.Reason = "breakpoint_limit"
+				continue
+			}
+			remaining--
+		}
+		decision.Accepted = true
+		result.Plan.Directives = append(result.Plan.Directives, directive)
+	}
+	return result, nil
+}

--- a/sdk/llm/cache_decision_test.go
+++ b/sdk/llm/cache_decision_test.go
@@ -1,0 +1,221 @@
+package llm_test
+
+import (
+	"context"
+	"encoding/json"
+	"reflect"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/timwhitez/agent-sdk-golang/sdk/llm"
+	"github.com/timwhitez/agent-sdk-golang/sdk/llm/anthropic"
+	"github.com/timwhitez/agent-sdk-golang/sdk/llm/openai"
+)
+
+type cacheDecisionNoCapabilities struct{}
+
+func (cacheDecisionNoCapabilities) Provider() string { panic("must not infer capabilities from names") }
+func (cacheDecisionNoCapabilities) Model() string    { panic("must not infer capabilities from names") }
+func (cacheDecisionNoCapabilities) Invoke(context.Context, llm.InvokeRequest) (*llm.Completion, error) {
+	panic("decision must not invoke model")
+}
+
+type cacheDecisionModel struct {
+	cacheDecisionNoCapabilities
+	caps   llm.PromptCacheCapabilities
+	reads  atomic.Int32
+	onRead func()
+}
+
+func (m *cacheDecisionModel) PromptCacheCapabilities() llm.PromptCacheCapabilities {
+	m.reads.Add(1)
+	if m.onRead != nil {
+		m.onRead()
+	}
+	return m.caps
+}
+
+func cacheDecisionFixture(t *testing.T) (llm.InvokeRequest, *llm.CacheTargetView, *llm.CachePlan) {
+	t.Helper()
+	request := llm.InvokeRequest{Messages: []llm.Message{
+		{Role: llm.RoleUser, Content: llm.TextContent("private-zero")},
+		{Role: llm.RoleUser, Content: llm.TextContent("private-one")},
+		{Role: llm.RoleUser, Content: llm.TextContent("private-two")},
+	}, Tools: []llm.ToolDefinition{{Name: "private-tool"}}}
+	view, err := llm.NewCacheTargetView(request)
+	if err != nil {
+		t.Fatal(err)
+	}
+	plan := &llm.CachePlan{SchemaVersion: llm.CachePlanSchemaVersion}
+	for i := range request.Messages {
+		plan.Directives = append(plan.Directives, llm.CacheDirective{Target: llm.CacheTarget{Kind: llm.CacheAfterMessage, MessageIndex: i}, Policy: llm.CacheBestEffort})
+	}
+	plan.Directives[2].Policy = llm.CacheRequired
+	return request, view, plan
+}
+
+func TestCacheDecisionRequiredReservationGoldenAndOwnership(t *testing.T) {
+	request, view, plan := cacheDecisionFixture(t)
+	before := llm.CloneCachePlan(plan)
+	model := &cacheDecisionModel{caps: llm.PromptCacheCapabilities{ExplicitMessageBoundary: true, MaxBreakpoints: 2, SupportedTTLs: []llm.CacheTTL{llm.CacheTTL1Hour}}}
+	result, err := view.Decide(request, plan, model)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := []llm.CacheDirectiveDecision{{DirectiveIndex: 0, Accepted: true, Reason: "accepted"}, {DirectiveIndex: 1, Reason: "breakpoint_limit"}, {DirectiveIndex: 2, Accepted: true, Reason: "accepted"}}
+	if !reflect.DeepEqual(result.Directives, want) || !reflect.DeepEqual(result.Plan.Directives, []llm.CacheDirective{before.Directives[0], before.Directives[2]}) {
+		t.Fatalf("decision golden mismatch: %+v", result)
+	}
+	if model.reads.Load() != 1 || !reflect.DeepEqual(plan, before) {
+		t.Fatal("capability reads or input mutation")
+	}
+	encoded, err := json.Marshal(result)
+	if err != nil || strings.Contains(string(encoded), "private-") {
+		t.Fatal("decision leaked content")
+	}
+	result.Plan.Directives[0].Target.MessageIndex = 99
+	result.Capabilities.SupportedTTLs[0] = "changed"
+	if !reflect.DeepEqual(plan, before) || model.caps.SupportedTTLs[0] != llm.CacheTTL1Hour {
+		t.Fatal("result aliases caller/model storage")
+	}
+	// A capability callback holding the original plan cannot rewrite validated intent.
+	model.onRead = func() { plan.Directives[0].Target.MessageIndex = 99 }
+	result, err = view.Decide(request, plan, model)
+	if err != nil || result.Plan.Directives[0].Target.MessageIndex != 0 {
+		t.Fatal("callback changed owned plan", err)
+	}
+}
+
+func TestCacheDecisionPolicyMatrix(t *testing.T) {
+	for _, test := range []struct {
+		name   string
+		kind   llm.CacheTargetKind
+		ttl    llm.CacheTTL
+		caps   llm.PromptCacheCapabilities
+		reason string
+	}{
+		{"unknown", llm.CacheAfterMessage, "", llm.PromptCacheCapabilities{}, "unsupported_target"},
+		{"message", llm.CacheAfterMessage, "", llm.PromptCacheCapabilities{ExplicitMessageBoundary: true, MaxBreakpoints: 1}, "accepted"},
+		{"block", llm.CacheAfterMessageBlock, "", llm.PromptCacheCapabilities{ExplicitContentBlock: true, MaxBreakpoints: 1}, "accepted"},
+		{"definition", llm.CacheAfterToolDefinition, "", llm.PromptCacheCapabilities{ExplicitToolDefinition: true, MaxBreakpoints: 1}, "accepted"},
+		{"wrong-target-flag", llm.CacheAfterMessageBlock, "", llm.PromptCacheCapabilities{ExplicitMessageBoundary: true, MaxBreakpoints: 1}, "unsupported_target"},
+		{"ttl", llm.CacheAfterMessage, llm.CacheTTL5Minutes, llm.PromptCacheCapabilities{ExplicitMessageBoundary: true, MaxBreakpoints: 1}, "unsupported_ttl"},
+		{"ttl-supported", llm.CacheAfterMessage, llm.CacheTTL1Hour, llm.PromptCacheCapabilities{ExplicitMessageBoundary: true, MaxBreakpoints: 1, SupportedTTLs: []llm.CacheTTL{llm.CacheTTL1Hour}}, "accepted"},
+		{"zero-limit", llm.CacheAfterMessage, "", llm.PromptCacheCapabilities{ExplicitMessageBoundary: true}, "breakpoint_limit"},
+	} {
+		for _, policy := range []llm.CacheDirectivePolicy{llm.CacheRequired, llm.CacheBestEffort} {
+			t.Run(test.name+"/"+string(policy), func(t *testing.T) {
+				request, view, plan := cacheDecisionFixture(t)
+				plan.Directives = []llm.CacheDirective{{Target: llm.CacheTarget{Kind: test.kind}, TTL: test.ttl, Policy: policy}}
+				model := &cacheDecisionModel{caps: test.caps}
+				result, err := view.Decide(request, plan, model)
+				if test.reason != "accepted" && policy == llm.CacheRequired {
+					assertCacheViewError(t, err, test.reason, 0)
+					if result != nil {
+						t.Fatal("required failure returned partial plan")
+					}
+					return
+				}
+				if err != nil {
+					t.Fatal(err)
+				}
+				accepted := test.reason == "accepted"
+				if len(result.Directives) != 1 || result.Directives[0].Reason != test.reason || result.Directives[0].Accepted != accepted || (len(result.Plan.Directives) == 1) != accepted {
+					t.Fatalf("unexpected decision: %+v", result)
+				}
+			})
+		}
+	}
+}
+
+func TestCacheDecisionFailuresAndNoCapabilityGuessing(t *testing.T) {
+	request, view, plan := cacheDecisionFixture(t)
+	model := &cacheDecisionModel{caps: llm.PromptCacheCapabilities{ExplicitMessageBoundary: true, MaxBreakpoints: 1}}
+	for i := range plan.Directives {
+		plan.Directives[i].Policy = llm.CacheRequired
+	}
+	result, err := view.Decide(request, plan, model)
+	assertCacheViewError(t, err, "breakpoint_limit", 1)
+	if result != nil {
+		t.Fatal("overflow returned partial plan")
+	}
+	for _, caps := range []llm.PromptCacheCapabilities{{MaxBreakpoints: -1}, {SupportedTTLs: []llm.CacheTTL{"private-invalid-ttl"}}} {
+		model.caps = caps
+		_, err := view.Decide(request, plan, model)
+		assertCacheViewError(t, err, "invalid_capabilities", -1)
+	}
+	_, err = view.Decide(request, plan, cacheDecisionNoCapabilities{})
+	assertCacheViewError(t, err, "unsupported_target", 0)
+	var nilModel *cacheDecisionModel
+	_, err = view.Decide(request, plan, nilModel)
+	assertCacheViewError(t, err, "missing_model", -1)
+	model.reads.Store(0)
+	request.Messages[0].Content.Text = "changed"
+	_, err = view.Decide(request, plan, model)
+	assertCacheViewError(t, err, "stale_request", -1)
+	if model.reads.Load() != 0 {
+		t.Fatal("stale request reached capability callback")
+	}
+	var nilView *llm.CacheTargetView
+	result, err = nilView.Decide(request, nil, nil)
+	if err != nil || result.Plan != nil || result.Directives != nil {
+		t.Fatal("nil plan compatibility")
+	}
+}
+
+func TestCacheDecisionBuiltinCapabilitiesAreConservative(t *testing.T) {
+	for _, model := range []llm.ChatModel{&anthropic.Client{}, &openai.ChatClient{}, &openai.ResponsesClient{}} {
+		provider, ok := model.(llm.PromptCacheCapabilityProvider)
+		if !ok || !reflect.DeepEqual(provider.PromptCacheCapabilities(), llm.PromptCacheCapabilities{UsageTelemetry: true}) {
+			t.Fatal("builtin claims unimplemented explicit control")
+		}
+		request, view, plan := cacheDecisionFixture(t)
+		_, err := view.Decide(request, plan, model)
+		assertCacheViewError(t, err, "unsupported_target", 2)
+		plan.Directives[2].Policy = llm.CacheBestEffort
+		result, err := view.Decide(request, plan, model)
+		if err != nil || len(result.Plan.Directives) != 0 || len(result.Directives) != 3 {
+			t.Fatal("builtin best-effort projection", err)
+		}
+	}
+}
+
+func TestCacheDecisionConcurrentReadOnly(t *testing.T) {
+	request, view, plan := cacheDecisionFixture(t)
+	model := &cacheDecisionModel{caps: llm.PromptCacheCapabilities{ExplicitMessageBoundary: true, MaxBreakpoints: 3}}
+	var wg sync.WaitGroup
+	for i := 0; i < 8; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < 20; j++ {
+				if _, err := view.Decide(request, plan, model); err != nil {
+					t.Error(err)
+				}
+			}
+		}()
+	}
+	wg.Wait()
+	if model.reads.Load() != 160 {
+		t.Fatal("capability snapshot count")
+	}
+}
+
+func BenchmarkCacheDecision(b *testing.B) {
+	request := llm.InvokeRequest{Messages: []llm.Message{{Role: llm.RoleUser, Content: llm.TextContent(strings.Repeat("x", 1024))}}}
+	view, err := llm.NewCacheTargetView(request)
+	if err != nil {
+		b.Fatal(err)
+	}
+	plan := &llm.CachePlan{SchemaVersion: llm.CachePlanSchemaVersion, Directives: []llm.CacheDirective{{Target: llm.CacheTarget{Kind: llm.CacheAfterMessage}, Policy: llm.CacheRequired}}}
+	model := &cacheDecisionModel{caps: llm.PromptCacheCapabilities{ExplicitMessageBoundary: true, MaxBreakpoints: 1}}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, err := view.Decide(request, plan, model); err != nil {
+			b.Fatal(err)
+		}
+	}
+}

--- a/sdk/llm/cache_plan.go
+++ b/sdk/llm/cache_plan.go
@@ -81,8 +81,12 @@ type PromptCacheCapabilities struct {
 	ExplicitContentBlock    bool
 	ExplicitToolDefinition  bool
 	SupportedTTLs           []CacheTTL
-	MaxBreakpoints          int
-	UsageTelemetry          bool
+	// MaxBreakpoints bounds explicit logical directives; zero permits none.
+	// Provider-default TTL needs no SupportedTTLs entry. Explicit TTLs do.
+	MaxBreakpoints int
+	// UsageTelemetry means the client can normalize optional cache usage;
+	// it does not promise that a particular response contains it.
+	UsageTelemetry bool
 }
 
 // Clone returns an owned capability snapshot.

--- a/sdk/llm/openai/chat.go
+++ b/sdk/llm/openai/chat.go
@@ -87,6 +87,12 @@ func (c *ChatClient) Provider() string { return openAIProviderLabel(c.ProviderLa
 
 func (c *ChatClient) Model() string { return c.ModelName }
 
+// PromptCacheCapabilities reports explicit CachePlan controls, not implicit
+// provider caching. This client currently only normalizes optional usage.
+func (c *ChatClient) PromptCacheCapabilities() llm.PromptCacheCapabilities {
+	return llm.PromptCacheCapabilities{UsageTelemetry: true}
+}
+
 func (c *ChatClient) Invoke(ctx context.Context, req llm.InvokeRequest) (*llm.Completion, error) {
 	local := *c
 	local.Extra = cloneMap(c.Extra)

--- a/sdk/llm/openai/responses.go
+++ b/sdk/llm/openai/responses.go
@@ -55,6 +55,12 @@ func (c *ResponsesClient) Provider() string { return openAIProviderLabel(c.Provi
 
 func (c *ResponsesClient) Model() string { return c.ModelName }
 
+// PromptCacheCapabilities does not promise implicit provider cache hits or
+// explicit CachePlan mapping; only optional usage normalization exists today.
+func (c *ResponsesClient) PromptCacheCapabilities() llm.PromptCacheCapabilities {
+	return llm.PromptCacheCapabilities{UsageTelemetry: true}
+}
+
 func (c *ResponsesClient) Invoke(ctx context.Context, req llm.InvokeRequest) (*llm.Completion, error) {
 	local := *c
 	local.Extra = cloneMap(c.Extra)


### PR DESCRIPTION
## Scope

Related to #89; multi-phase Issue remains open. Reuses the #128 retained CacheTargetView and existing capability interface. Adds opt-in Decide: fixed typed per-directive decisions and an owned filtered plan. It queries the supplied actual ChatModel's optional capability method once, never Provider()/Model() names or network methods.

Required directives reserve capacity first. Unsupported target/TTL or required overflow returns a fixed validation error and no partial decision. Remaining best-effort directives are deterministically retained in original order or marked skipped. Invalid/stale plans fail for either policy. Zero MaxBreakpoints means no explicit directives; default TTL uses the client default, explicit TTLs need a reported entry. Negative capacity/unknown reported TTL fails safely without returning arbitrary client strings.

Anthropic, OpenAI Chat and Responses now report the truth: optional cache-usage normalization exists, explicit CachePlan mapping does not. Legacy Message.Cache/MaxCachedToolDefinitions/implicit caching are not advertised as new explicit controls.

No provider invokes this helper automatically. No wire, prompt, persistence, Frame/event sequence, scheduling, hash gate or existing public struct layout change. Accepted means capability eligibility only, not mapped/sent/cached. The original view still must be bound to the owned request at actual sending; this helper is not a send authorization or concrete-model snapshot.

## Validation

Focused100 passed. Tests cover all target flags, TTL/default policy, required priority, overflow/no partial result, unknown clients, stale/no callback, nil/typed-nil model, conservative builtins, content-free outputs, clone isolation, callback input mutation and read-only concurrency. Existing nil/empty/inert-plan HTTP wire goldens unchanged.

Author exact head3d5144da8211dbc3fd3c2ffabbfaf944abd973a9: full/vet/LLM-provider-Agent race passed locally. Benchmark three-sample median730.0ns/op,448B/op,6allocs/op for one directive/one one-KiB message using a retained view and fake capability client (including its atomic query counter, excluding initial view creation); not provider/model latency or a speedup claim. Logs /tmp/sdk-cache-decision-{full,vet,race,bench}.log. Independent exact-head review required before merge; no live provider/cache-hit claim.
