### PR TITLE
feat(llm): enforce bound cache intent before provider network I/O

### DIFF
--- a/agent_docs/providers.md
+++ b/agent_docs/providers.md
@@ -6,13 +6,17 @@ stream normalization, and response metadata behavior.
 ## Shared LLM Contracts
 - `InvokeRequest.CachePlan` is experimental in-memory intent, owned by
   `CloneInvokeRequest` and the private execution frame, and excluded from JSON.
-  Built-in serializers still ignore it: fingerprint/target validation,
-  required/best-effort policy and capability-gated wire mapping are not enabled.
+  Bind nonempty plans with `CacheTargetView.Bind`. Built-in buffered/streaming
+  entrypoints clone and validate that original binding before network I/O:
+  stale/unbound/unsupported Required plans fail; Best-effort skips produce bounded
+  `Completion.Diagnostics` and warning-sink metadata. Explicit wire mapping is
+  still unavailable; nil/empty plans preserve the legacy path.
   Legacy `Message.Cache` behavior is unchanged; do not use the new field as a
   cache-control guarantee. No Agent Config or host plan generator is added.
-  Adding this exported field preserves keyed literals but external unkeyed
-  `InvokeRequest` literals must be updated. Message/Completion layouts and
-  session JSON are unchanged.
+  `CachePlan` now includes a private binding and `ResponsesClient` supports the
+  existing `WarningSinkSetter` pattern. External unkeyed literals need updating;
+  JSON cannot restore a valid binding. Message/Completion layouts and session
+  JSON remain unchanged. No content fingerprints or Git-hash gates are added.
 - Provider-neutral interfaces: `ChatModel`, `StreamingChatModel` (`sdk/llm/model.go:8`, `sdk/llm/model.go:17`)
 - Unified request envelope: `InvokeRequest` (messages, tools, tool choice, temperature, responses options) (`sdk/llm/model.go:82`)
 - Unified stream event union: text/thinking/tool-call deltas, usage, done, response metadata, errors (`sdk/llm/model.go:24`, `sdk/llm/model.go:28`, `sdk/llm/model.go:33`, `sdk/llm/model.go:39`, `sdk/llm/model.go:50`, `sdk/llm/model.go:55`, `sdk/llm/model.go:62`, `sdk/llm/model.go:70`)

--- a/agent_docs/providers.md
+++ b/agent_docs/providers.md
@@ -13,8 +13,10 @@ stream normalization, and response metadata behavior.
   still unavailable; nil/empty plans preserve the legacy path.
   Legacy `Message.Cache` behavior is unchanged; do not use the new field as a
   cache-control guarantee. No Agent Config or host plan generator is added.
-  `CachePlan` now includes a private binding and `ResponsesClient` supports the
-  existing `WarningSinkSetter` pattern. External unkeyed literals need updating;
+  `CachePlan` now includes a private binding. Responses diagnostics use its
+  construction-time `Warningf` (or the default logger), not automatic shared
+  `WarningSinkSetter` mutation during child Agent creation. Configure it before
+  concurrent use. External unkeyed literals need updating;
   JSON cannot restore a valid binding. Message/Completion layouts and session
   JSON remain unchanged. No content fingerprints or Git-hash gates are added.
 - Provider-neutral interfaces: `ChatModel`, `StreamingChatModel` (`sdk/llm/model.go:8`, `sdk/llm/model.go:17`)

--- a/sdk/llm/anthropic/client.go
+++ b/sdk/llm/anthropic/client.go
@@ -82,6 +82,10 @@ func (c *Client) PromptCacheCapabilities() llm.PromptCacheCapabilities {
 func (c *Client) Model() string { return c.ModelName }
 
 func (c *Client) Invoke(ctx context.Context, req llm.InvokeRequest) (*llm.Completion, error) {
+	req, cacheDiagnostics, err := llm.AdmitCachePlan(ctx, req, c, c.warnf)
+	if err != nil {
+		return nil, err
+	}
 	client := redirectSafeHTTPClient(c.httpClient())
 	baseURL := strings.TrimRight(c.baseURL(), "/")
 	endpoint := anthropicEndpoint(baseURL, "messages")
@@ -102,7 +106,7 @@ func (c *Client) Invoke(ctx context.Context, req llm.InvokeRequest) (*llm.Comple
 	localBeta := append([]string(nil), c.Beta...)
 	localThinking := c.configuredThinking()
 	usedFinalDowngradeRetry := false
-	diagnostics := []llm.Diagnostic{}
+	diagnostics := cacheDiagnostics
 
 	for attempt := 0; attempt < maxRetries+1; attempt++ {
 		if err := ctx.Err(); err != nil {
@@ -656,6 +660,10 @@ type requestPayload struct {
 // InvokeStream implements true SSE streaming for Anthropic messages.
 // It emits text deltas, thinking deltas, and basic tool_use deltas (best-effort).
 func (c *Client) InvokeStream(ctx context.Context, req llm.InvokeRequest) (<-chan llm.StreamEvent, error) {
+	req, _, err := llm.AdmitCachePlan(ctx, req, c, c.warnf)
+	if err != nil {
+		return nil, err
+	}
 	out := make(chan llm.StreamEvent, 128)
 	go func() {
 		defer close(out)

--- a/sdk/llm/cache_admission.go
+++ b/sdk/llm/cache_admission.go
@@ -1,0 +1,81 @@
+package llm
+
+import (
+	"context"
+	"fmt"
+)
+
+// Bind creates an owned plan tied to this original immutable request view.
+// Cloning a request/plan preserves the binding. Mutating a clone's request
+// requires a fresh plan for that new request, not silently rebinding the old one.
+func (view *CacheTargetView) Bind(directives []CacheDirective) (*CachePlan, error) {
+	if view == nil || view.request == nil {
+		return nil, cachePlanError("missing_view", -1)
+	}
+	plan := CloneCachePlan(&CachePlan{SchemaVersion: CachePlanSchemaVersion, Directives: directives})
+	if err := view.Validate(*view.request, plan); err != nil {
+		return nil, err
+	}
+	// The exported view value can be overwritten wholesale by its owner even
+	// though its fields are private. Keep an unreachable copy of that value.
+	binding := *view
+	plan.view = &binding
+	return plan, nil
+}
+
+// AdmitCachePlan is the shared before-network boundary for built-in clients.
+// Nil/empty plans preserve the legacy path. Nonempty plans require an original
+// view binding and an owned request clone; no view is rebuilt during admission.
+// The returned request is isolated from caller mutation before asynchronous
+// streaming or retry. Callers must exclusively own input graphs during this call.
+//
+// Current clients have no explicit mapper: required intent fails, best-effort
+// intent is skipped with bounded diagnostics while legacy cache flags remain.
+// An accepted directive fails as unmapped rather than silently reaching a client
+// whose serializer cannot implement it. Future mappers must extend this boundary.
+// Warning callbacks see fixed metadata only; buffered clients also return these
+// diagnostics in Completion.Diagnostics. No new event or invocation path is used.
+func AdmitCachePlan(ctx context.Context, request InvokeRequest, model ChatModel, warnf func(string, ...any)) (InvokeRequest, []Diagnostic, error) {
+	if request.CachePlan == nil || len(request.CachePlan.Directives) == 0 {
+		return request, nil, nil
+	}
+	if err := ctx.Err(); err != nil {
+		return InvokeRequest{}, nil, err
+	}
+	owned, err := CloneInvokeRequest(request)
+	if err != nil {
+		return InvokeRequest{}, nil, cachePlanError("uncloneable_request", -1)
+	}
+	if owned.CachePlan.view == nil {
+		return InvokeRequest{}, nil, cachePlanError("unbound_plan", -1)
+	}
+	decision, err := owned.CachePlan.view.Decide(owned, owned.CachePlan, model)
+	if ctxErr := ctx.Err(); ctxErr != nil {
+		return InvokeRequest{}, nil, ctxErr
+	}
+	if err != nil {
+		return InvokeRequest{}, nil, err
+	}
+	if len(decision.Plan.Directives) != 0 {
+		return InvokeRequest{}, nil, cachePlanError("unmapped_plan", -1)
+	}
+	const diagnosticLimit = 32
+	count := len(decision.Directives)
+	if count > diagnosticLimit {
+		count = diagnosticLimit
+	}
+	diagnostics := make([]Diagnostic, 0, count+1)
+	for _, d := range decision.Directives[:count] {
+		diagnostics = append(diagnostics, Diagnostic{Kind: "cache_plan_skipped", Message: fmt.Sprintf("directive %d: %s", d.DirectiveIndex, d.Reason)})
+	}
+	if count < len(decision.Directives) {
+		diagnostics = append(diagnostics, Diagnostic{Kind: "cache_plan_skipped_summary", Message: fmt.Sprintf("%d additional directives skipped", len(decision.Directives)-count)})
+	}
+	owned.CachePlan = nil
+	if warnf != nil {
+		for _, d := range diagnostics {
+			warnf("%s: %s", d.Kind, d.Message)
+		}
+	}
+	return owned, diagnostics, nil
+}

--- a/sdk/llm/cache_admission_test.go
+++ b/sdk/llm/cache_admission_test.go
@@ -362,6 +362,12 @@ func BenchmarkCacheAdmission(b *testing.B) {
 }
 
 func TestResponsesCacheWarningSinkRemainsConstructionScoped(t *testing.T) {
+	// Agent.New scans its default dump directory. Isolate this fixture from
+	// unrelated processes creating/removing indexes in the shared system temp dir.
+	temporary := t.TempDir()
+	t.Setenv("TMPDIR", temporary)
+	t.Setenv("TMP", temporary)
+	t.Setenv("TEMP", temporary)
 	var configured, child atomic.Int32
 	model := admissionModel("responses", func(r *http.Request) (*http.Response, error) {
 		return &http.Response{StatusCode: 401, Header: make(http.Header), Body: io.NopCloser(strings.NewReader(`{"error":{"message":"fixture"}}`)), Request: r}, nil
@@ -384,6 +390,6 @@ func TestResponsesCacheWarningSinkRemainsConstructionScoped(t *testing.T) {
 	}
 	workers.Wait()
 	if configured.Load() != 80 || child.Load() != 0 {
-		t.Fatal("shared child construction replaced the fixed client diagnostic sink")
+		t.Fatalf("shared child construction sink: configured=%d child=%d", configured.Load(), child.Load())
 	}
 }

--- a/sdk/llm/cache_admission_test.go
+++ b/sdk/llm/cache_admission_test.go
@@ -10,10 +10,12 @@ import (
 	"net/http"
 	"reflect"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
 
+	"github.com/timwhitez/agent-sdk-golang/sdk/agent"
 	"github.com/timwhitez/agent-sdk-golang/sdk/llm"
 	"github.com/timwhitez/agent-sdk-golang/sdk/llm/anthropic"
 	"github.com/timwhitez/agent-sdk-golang/sdk/llm/openai"
@@ -28,11 +30,13 @@ func admissionModel(provider string, transport cacheWireTransport, warning func(
 	case "chat":
 		model = &openai.ChatClient{HTTPClient: client, BaseURL: "https://fixture.invalid", APIKey: "private-key", ModelName: "fixture", MaxRetries: 1}
 	case "responses":
-		model = &openai.ResponsesClient{HTTPClient: client, BaseURL: "https://fixture.invalid", APIKey: "private-key", ModelName: "fixture", MaxRetries: 1}
+		model = &openai.ResponsesClient{HTTPClient: client, BaseURL: "https://fixture.invalid", APIKey: "private-key", ModelName: "fixture", MaxRetries: 1, Warningf: warning}
 	default:
 		panic("unknown fixture provider")
 	}
-	model.(llm.WarningSinkSetter).SetWarningf(warning)
+	if setter, ok := model.(llm.WarningSinkSetter); ok {
+		setter.SetWarningf(warning)
+	}
 	return model
 }
 
@@ -76,13 +80,16 @@ func callAdmissionModel(ctx context.Context, model llm.StreamingChatModel, reque
 func TestCacheAdmissionRejectsBeforeNetwork(t *testing.T) {
 	for _, provider := range []string{"anthropic", "chat", "responses"} {
 		for _, stream := range []bool{false, true} {
-			for _, failure := range []string{"required", "unbound", "stale", "stale-best-effort", "clone-stale", "uncloneable", "view-overwrite", "view-clear", "schema", "canceled"} {
+			for _, failure := range []string{"required", "unbound", "stale", "stale-best-effort", "clone-stale", "uncloneable", "view-overwrite", "view-overwrite-best-effort", "view-clear", "schema", "canceled"} {
 				t.Run(fmt.Sprintf("%s/%v/%s", provider, stream, failure), func(t *testing.T) {
 					request := admissionRequest(t, llm.CacheRequired)
 					reason := "unsupported_target"
 					index := 0
 					switch failure {
-					case "view-overwrite", "view-clear":
+					case "view-overwrite", "view-overwrite-best-effort", "view-clear":
+						if failure == "view-overwrite-best-effort" {
+							request.CachePlan.Directives[0].Policy = llm.CacheBestEffort
+						}
 						view, err := llm.NewCacheTargetView(request)
 						if err != nil {
 							t.Fatal(err)
@@ -91,7 +98,7 @@ func TestCacheAdmissionRejectsBeforeNetwork(t *testing.T) {
 						if err != nil {
 							t.Fatal(err)
 						}
-						if failure == "view-overwrite" {
+						if failure != "view-clear" {
 							request.Messages[1].Content.Text = "private-rebound"
 							fresh, err := llm.NewCacheTargetView(request)
 							if err != nil {
@@ -351,5 +358,32 @@ func BenchmarkCacheAdmission(b *testing.B) {
 		if _, _, err := llm.AdmitCachePlan(context.Background(), request, model, nil); err != nil {
 			b.Fatal(err)
 		}
+	}
+}
+
+func TestResponsesCacheWarningSinkRemainsConstructionScoped(t *testing.T) {
+	var configured, child atomic.Int32
+	model := admissionModel("responses", func(r *http.Request) (*http.Response, error) {
+		return &http.Response{StatusCode: 401, Header: make(http.Header), Body: io.NopCloser(strings.NewReader(`{"error":{"message":"fixture"}}`)), Request: r}, nil
+	}, func(string, ...any) { configured.Add(1) })
+	request := admissionRequest(t, llm.CacheBestEffort)
+	var workers sync.WaitGroup
+	for i := 0; i < 8; i++ {
+		workers.Add(1)
+		go func() {
+			defer workers.Done()
+			for j := 0; j < 10; j++ {
+				if _, err := agent.New(agent.Config{LLM: model, Warningf: func(string, ...any) { child.Add(1) }}); err != nil {
+					t.Error(err)
+				}
+				if _, err := model.Invoke(context.Background(), request); err == nil {
+					t.Error("expected fixture rejection")
+				}
+			}
+		}()
+	}
+	workers.Wait()
+	if configured.Load() != 80 || child.Load() != 0 {
+		t.Fatal("shared child construction replaced the fixed client diagnostic sink")
 	}
 }

--- a/sdk/llm/cache_admission_test.go
+++ b/sdk/llm/cache_admission_test.go
@@ -1,0 +1,355 @@
+package llm_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"reflect"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/timwhitez/agent-sdk-golang/sdk/llm"
+	"github.com/timwhitez/agent-sdk-golang/sdk/llm/anthropic"
+	"github.com/timwhitez/agent-sdk-golang/sdk/llm/openai"
+)
+
+func admissionModel(provider string, transport cacheWireTransport, warning func(string, ...any)) llm.StreamingChatModel {
+	client := &http.Client{Transport: transport}
+	var model llm.StreamingChatModel
+	switch provider {
+	case "anthropic":
+		model = &anthropic.Client{HTTPClient: client, BaseURL: "https://fixture.invalid", APIKey: "private-key", ModelName: "fixture", MaxTokens: 64, MaxRetries: 1}
+	case "chat":
+		model = &openai.ChatClient{HTTPClient: client, BaseURL: "https://fixture.invalid", APIKey: "private-key", ModelName: "fixture", MaxRetries: 1}
+	case "responses":
+		model = &openai.ResponsesClient{HTTPClient: client, BaseURL: "https://fixture.invalid", APIKey: "private-key", ModelName: "fixture", MaxRetries: 1}
+	default:
+		panic("unknown fixture provider")
+	}
+	model.(llm.WarningSinkSetter).SetWarningf(warning)
+	return model
+}
+
+func admissionRequest(t *testing.T, policy llm.CacheDirectivePolicy) llm.InvokeRequest {
+	t.Helper()
+	request := llm.InvokeRequest{Messages: []llm.Message{{Role: llm.RoleSystem, Content: llm.TextContent("system"), Cache: true}, {Role: llm.RoleUser, Content: llm.TextContent("hello")}}}
+	view, err := llm.NewCacheTargetView(request)
+	if err != nil {
+		t.Fatal(err)
+	}
+	request.CachePlan, err = view.Bind([]llm.CacheDirective{{Target: llm.CacheTarget{Kind: llm.CacheAfterMessage, MessageIndex: 1}, Policy: policy}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return request
+}
+
+func callAdmissionModel(ctx context.Context, model llm.StreamingChatModel, request llm.InvokeRequest, stream bool) (*llm.Completion, error) {
+	if !stream {
+		return model.Invoke(ctx, request)
+	}
+	events, err := model.InvokeStream(ctx, request)
+	if err != nil {
+		return nil, err
+	}
+	completion := &llm.Completion{}
+	for event := range events {
+		switch e := event.(type) {
+		case llm.StreamErrorEvent:
+			err = e.Err
+			if err == nil {
+				err = errors.New("stream failure")
+			}
+		case llm.StreamTextDeltaEvent:
+			completion.Content.Text += e.Delta
+		}
+	}
+	return completion, err
+}
+
+func TestCacheAdmissionRejectsBeforeNetwork(t *testing.T) {
+	for _, provider := range []string{"anthropic", "chat", "responses"} {
+		for _, stream := range []bool{false, true} {
+			for _, failure := range []string{"required", "unbound", "stale", "stale-best-effort", "clone-stale", "uncloneable", "view-overwrite", "view-clear", "schema", "canceled"} {
+				t.Run(fmt.Sprintf("%s/%v/%s", provider, stream, failure), func(t *testing.T) {
+					request := admissionRequest(t, llm.CacheRequired)
+					reason := "unsupported_target"
+					index := 0
+					switch failure {
+					case "view-overwrite", "view-clear":
+						view, err := llm.NewCacheTargetView(request)
+						if err != nil {
+							t.Fatal(err)
+						}
+						request.CachePlan, err = view.Bind(request.CachePlan.Directives)
+						if err != nil {
+							t.Fatal(err)
+						}
+						if failure == "view-overwrite" {
+							request.Messages[1].Content.Text = "private-rebound"
+							fresh, err := llm.NewCacheTargetView(request)
+							if err != nil {
+								t.Fatal(err)
+							}
+							*view = *fresh
+							reason, index = "stale_request", -1
+						} else {
+							*view = llm.CacheTargetView{}
+						}
+					case "unbound":
+						request.CachePlan = &llm.CachePlan{RequestFingerprint: "private-fingerprint", Directives: request.CachePlan.Directives}
+						reason, index = "unbound_plan", -1
+					case "uncloneable":
+						request.Tools = []llm.ToolDefinition{{Name: "private-tool", Parameters: map[string]any{"private-secret": func() {}}}}
+						reason, index = "uncloneable_request", -1
+					case "stale", "stale-best-effort", "clone-stale":
+						if failure == "stale-best-effort" {
+							request.CachePlan.Directives[0].Policy = llm.CacheBestEffort
+						}
+						if failure == "clone-stale" {
+							var err error
+							request, err = llm.CloneInvokeRequest(request)
+							if err != nil {
+								t.Fatal(err)
+							}
+						}
+						request.Messages[1].Content.Text = "private-changed"
+						reason, index = "stale_request", -1
+					case "schema":
+						request.CachePlan.SchemaVersion++
+						reason, index = "unsupported_schema", -1
+					}
+					var calls atomic.Int32
+					model := admissionModel(provider, func(r *http.Request) (*http.Response, error) { calls.Add(1); return nil, errors.New("must not send") }, func(string, ...any) { t.Error("rejected intent emitted skip warning") })
+					ctx, cancel := context.WithCancel(context.Background())
+					defer cancel()
+					if failure == "canceled" {
+						cancel()
+					}
+					_, err := callAdmissionModel(ctx, model, request, stream)
+					if failure == "canceled" {
+						if !errors.Is(err, context.Canceled) {
+							t.Fatal(err)
+						}
+					} else {
+						assertCacheViewError(t, err, reason, index)
+					}
+					if calls.Load() != 0 {
+						t.Fatal("rejected request reached HTTP")
+					}
+				})
+			}
+		}
+	}
+}
+
+var admissionSuccess = map[string]string{
+	"anthropic": `{"id":"fixture","type":"message","role":"assistant","content":[{"type":"text","text":"ok"}],"stop_reason":"end_turn","usage":{"input_tokens":1,"output_tokens":1}}`,
+	"chat":      `{"choices":[{"message":{"role":"assistant","content":"ok"},"finish_reason":"stop"}],"usage":{"prompt_tokens":1,"completion_tokens":1,"total_tokens":2}}`,
+	"responses": `{"id":"r","status":"completed","output":[{"type":"message","role":"assistant","content":[{"type":"output_text","text":"ok"}]}],"usage":{"input_tokens":1,"output_tokens":1,"total_tokens":2}}`,
+}
+
+func admissionSSE(provider string) string {
+	switch provider {
+	case "anthropic":
+		return "event: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"ok\"}}\n\nevent: message_stop\ndata: {\"type\":\"message_stop\"}\n\n"
+	case "chat":
+		return "data: {\"choices\":[{\"delta\":{\"content\":\"ok\"},\"finish_reason\":\"stop\"}]}\n\ndata: [DONE]\n\n"
+	default:
+		return "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"delta\":\"ok\"}\n\nevent: response.completed\ndata: {\"type\":\"response.completed\",\"response\":" + admissionSuccess[provider] + "}\n\n"
+	}
+}
+
+func TestCacheAdmissionBestEffortWireDiagnosticsAndIsolation(t *testing.T) {
+	for _, provider := range []string{"anthropic", "chat", "responses"} {
+		for _, stream := range []bool{false, true} {
+			for _, status := range []int{200, 401} {
+				t.Run(fmt.Sprintf("%s/%v/%d", provider, stream, status), func(t *testing.T) {
+					var baseline []byte
+					for _, planned := range []bool{false, true} {
+						request := admissionRequest(t, llm.CacheBestEffort)
+						if !planned {
+							request.CachePlan = nil
+						}
+						before, err := llm.CloneInvokeRequest(request)
+						if err != nil {
+							t.Fatal(err)
+						}
+						var calls atomic.Int32
+						var payload []byte
+						var warnings []string
+						model := admissionModel(provider, func(r *http.Request) (*http.Response, error) {
+							calls.Add(1)
+							var err error
+							payload, err = io.ReadAll(r.Body)
+							if err != nil {
+								return nil, err
+							}
+							body := admissionSuccess[provider]
+							if stream {
+								body = admissionSSE(provider)
+							}
+							if status == 401 {
+								body = `{"error":{"message":"fixture rejected"}}`
+							}
+							return &http.Response{StatusCode: status, Header: make(http.Header), Body: io.NopCloser(strings.NewReader(body)), Request: r}, nil
+						}, func(format string, args ...any) { warnings = append(warnings, fmt.Sprintf(format, args...)) })
+						completion, err := callAdmissionModel(context.Background(), model, request, stream)
+						if calls.Load() != 1 || (err != nil) != (status == 401) {
+							t.Fatalf("calls=%d err=%v", calls.Load(), err)
+						}
+						if !reflect.DeepEqual(request, before) {
+							t.Fatal("admission mutated input")
+						}
+						if !planned {
+							baseline = payload
+						} else if !bytes.Equal(payload, baseline) {
+							t.Fatal("skip changed legacy wire")
+						}
+						if planned {
+							if !reflect.DeepEqual(warnings, []string{"cache_plan_skipped: directive 0: unsupported_target"}) {
+								t.Fatalf("warnings=%v", warnings)
+							}
+							if !stream && status == 200 && !reflect.DeepEqual(completion.Diagnostics, []llm.Diagnostic{{Kind: "cache_plan_skipped", Message: "directive 0: unsupported_target"}}) {
+								t.Fatal("missing typed completion diagnostic")
+							}
+						} else if len(warnings) != 0 {
+							t.Fatal("nil plan warned")
+						}
+					}
+				})
+			}
+			t.Run(fmt.Sprintf("%s/%v/warning-callback-mutation", provider, stream), func(t *testing.T) {
+				request := admissionRequest(t, llm.CacheBestEffort)
+				model := admissionModel(provider, func(r *http.Request) (*http.Response, error) {
+					body, _ := io.ReadAll(r.Body)
+					if bytes.Contains(body, []byte("private-mutated")) || !bytes.Contains(body, []byte("hello")) {
+						t.Error("caller mutation reached owned wire")
+					}
+					return &http.Response{StatusCode: 401, Header: make(http.Header), Body: io.NopCloser(strings.NewReader(`{"error":{"message":"fixture"}}`)), Request: r}, nil
+				}, func(string, ...any) { request.Messages[1].Content.Text = "private-mutated" })
+				_, _ = callAdmissionModel(context.Background(), model, request, stream)
+			})
+		}
+	}
+}
+
+func TestCacheAdmissionBindingPersistenceAndDiagnosticBound(t *testing.T) {
+	request := admissionRequest(t, llm.CacheBestEffort)
+	encoded, err := json.Marshal(request.CachePlan)
+	if err != nil || strings.Contains(string(encoded), "hello") {
+		t.Fatal("binding leaked via JSON")
+	}
+	var restored llm.CachePlan
+	if err := json.Unmarshal(encoded, &restored); err != nil {
+		t.Fatal(err)
+	}
+	request.CachePlan = &restored
+	_, _, err = llm.AdmitCachePlan(context.Background(), request, &openai.ChatClient{}, nil)
+	assertCacheViewError(t, err, "unbound_plan", -1)
+	request = llm.InvokeRequest{Messages: make([]llm.Message, 40)}
+	directives := make([]llm.CacheDirective, 40)
+	for i := range directives {
+		request.Messages[i] = llm.Message{Role: llm.RoleUser, Content: llm.TextContent("private-prompt")}
+		directives[i] = llm.CacheDirective{Target: llm.CacheTarget{Kind: llm.CacheAfterMessage, MessageIndex: i}, Policy: llm.CacheBestEffort}
+	}
+	view, err := llm.NewCacheTargetView(request)
+	if err != nil {
+		t.Fatal(err)
+	}
+	request.CachePlan, err = view.Bind(directives)
+	if err != nil {
+		t.Fatal(err)
+	}
+	directives[0].Target.MessageIndex = -1
+	_, diagnostics, err := llm.AdmitCachePlan(context.Background(), request, &openai.ChatClient{}, nil)
+	if err != nil || len(diagnostics) != 33 || diagnostics[32].Message != "8 additional directives skipped" {
+		t.Fatal("bounded diagnostics", err, diagnostics)
+	}
+	encoded, _ = json.Marshal(diagnostics)
+	if strings.Contains(string(encoded), "private-") {
+		t.Fatal("diagnostics leaked content")
+	}
+}
+
+type admissionCancelBody struct {
+	initial *strings.Reader
+	ctx     context.Context
+	closed  atomic.Bool
+}
+
+func (b *admissionCancelBody) Read(p []byte) (int, error) {
+	if b.initial.Len() > 0 {
+		return b.initial.Read(p)
+	}
+	<-b.ctx.Done()
+	return 0, b.ctx.Err()
+}
+
+func (b *admissionCancelBody) Close() error { b.closed.Store(true); return nil }
+
+func TestCacheAdmissionPartialStreamCancellation(t *testing.T) {
+	for _, provider := range []string{"anthropic", "chat", "responses"} {
+		t.Run(provider, func(t *testing.T) {
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			prefix := strings.SplitN(admissionSSE(provider), "\n\n", 2)[0] + "\n\n"
+			body := &admissionCancelBody{initial: strings.NewReader(prefix), ctx: ctx}
+			var calls atomic.Int32
+			model := admissionModel(provider, func(r *http.Request) (*http.Response, error) {
+				calls.Add(1)
+				return &http.Response{StatusCode: 200, Header: make(http.Header), Body: body, Request: r}, nil
+			}, func(string, ...any) {})
+			events, err := model.InvokeStream(ctx, admissionRequest(t, llm.CacheBestEffort))
+			if err != nil {
+				t.Fatal(err)
+			}
+			sawText := false
+			deadline := time.NewTimer(2 * time.Second)
+			defer deadline.Stop()
+			for {
+				select {
+				case event, ok := <-events:
+					if !ok {
+						if !sawText || !body.closed.Load() || calls.Load() != 1 {
+							t.Fatal("partial stream was not canceled/closed exactly once")
+						}
+						return
+					}
+					if e, ok := event.(llm.StreamTextDeltaEvent); ok && e.Delta == "ok" {
+						sawText = true
+						cancel()
+					}
+				case <-deadline.C:
+					t.Fatal("partial stream did not stop after cancellation")
+				}
+			}
+		})
+	}
+}
+
+func BenchmarkCacheAdmission(b *testing.B) {
+	request := llm.InvokeRequest{Messages: []llm.Message{{Role: llm.RoleUser, Content: llm.TextContent(strings.Repeat("x", 1024))}}}
+	view, err := llm.NewCacheTargetView(request)
+	if err != nil {
+		b.Fatal(err)
+	}
+	request.CachePlan, err = view.Bind([]llm.CacheDirective{{Target: llm.CacheTarget{Kind: llm.CacheAfterMessage}, Policy: llm.CacheBestEffort}})
+	if err != nil {
+		b.Fatal(err)
+	}
+	model := &openai.ChatClient{}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, _, err := llm.AdmitCachePlan(context.Background(), request, model, nil); err != nil {
+			b.Fatal(err)
+		}
+	}
+}

--- a/sdk/llm/cache_boundary_wire_test.go
+++ b/sdk/llm/cache_boundary_wire_test.go
@@ -78,10 +78,21 @@ func TestAnthropicLegacyCacheBoundaryWireGolden(t *testing.T) {
 			t.Run(fmt.Sprintf("%s/stream=%v", fixture.name, stream), func(t *testing.T) {
 				var baseline []byte
 				for _, plan := range []*llm.CachePlan{nil, {Directives: []llm.CacheDirective{}}, {
-					SchemaVersion: -1, RequestFingerprint: "private-plan-marker",
-					Directives: []llm.CacheDirective{{Target: llm.CacheTarget{Kind: llm.CacheAfterMessageBlock, MessageIndex: -1}, Policy: llm.CacheRequired}},
+					SchemaVersion: llm.CachePlanSchemaVersion,
+					Directives:    []llm.CacheDirective{{Target: llm.CacheTarget{Kind: llm.CacheAfterToolDefinition}, Policy: llm.CacheBestEffort}},
 				}} {
 					request := llm.InvokeRequest{Messages: llm.CloneMessages(fixture.messages), Tools: tools, CachePlan: plan}
+					if plan != nil && len(plan.Directives) != 0 {
+						view, err := llm.NewCacheTargetView(request)
+						if err != nil {
+							t.Fatal(err)
+						}
+						plan, err = view.Bind(plan.Directives)
+						if err != nil {
+							t.Fatal(err)
+						}
+						request.CachePlan = plan
+					}
 					before, err := llm.CloneInvokeRequest(request)
 					if err != nil {
 						t.Fatal(err)
@@ -125,7 +136,7 @@ func TestAnthropicLegacyCacheBoundaryWireGolden(t *testing.T) {
 						}
 					}
 					if baseline != nil && !bytes.Equal(baseline, payload) {
-						t.Fatal("inert plan changed wire payload")
+						t.Fatal("skipped best-effort plan changed wire payload")
 					}
 					baseline = payload
 				}

--- a/sdk/llm/cache_decision.go
+++ b/sdk/llm/cache_decision.go
@@ -25,7 +25,7 @@ type CachePlanDecision struct {
 // Decide validates against the retained view, queries the actual model's
 // optional capability interface once, and allocates logical breakpoints.
 // It never invokes the model, changes request/history, or guesses from names.
-// No production provider invokes this opt-in helper yet.
+// Built-in admission reuses this helper; it can also be called without sending.
 //
 // Invalid/stale plans fail for both policies. Required directives reserve
 // capacity first; remaining best-effort directives are kept in input order.

--- a/sdk/llm/cache_plan.go
+++ b/sdk/llm/cache_plan.go
@@ -50,14 +50,16 @@ type CacheDirective struct {
 
 // CachePlan is request-local optimization intent. It must not be written into
 // conversation history or treated as proof that a Provider cache was hit.
-// Provider adapters do not consume this type until explicit validation and
-// capability-gated mapping are added.
+// Bind a nonempty plan with CacheTargetView.Bind before passing it to a built-in
+// client. Clients enforce admission, but explicit wire mapping is not available.
 type CachePlan struct {
 	SchemaVersion int
 	// Reserved experimental field; unused by providers. CacheTargetView uses
 	// its retained request snapshot instead and requires this field empty.
 	RequestFingerprint string
 	Directives         []CacheDirective
+	// Immutable request binding, shared safely by CloneCachePlan. Never serialized.
+	view *CacheTargetView
 }
 
 // CloneCachePlan returns an owned copy while preserving nil versus non-nil

--- a/sdk/llm/cache_plan_wire_test.go
+++ b/sdk/llm/cache_plan_wire_test.go
@@ -26,8 +26,8 @@ func TestCachePlanAttachmentPreservesLegacyWireGolden(t *testing.T) {
 			t.Run(fmt.Sprintf("%s/stream=%v", provider, stream), func(t *testing.T) {
 				var baseline []byte
 				for _, plan := range []*llm.CachePlan{nil, {Directives: []llm.CacheDirective{}}, {
-					SchemaVersion: -1, RequestFingerprint: "private-plan-marker",
-					Directives: []llm.CacheDirective{{Target: llm.CacheTarget{Kind: llm.CacheAfterMessageBlock, MessageIndex: -1, ExpectedObjectFingerprint: "private-plan-marker"}, Policy: llm.CacheRequired, TTL: "unsupported"}},
+					SchemaVersion: llm.CachePlanSchemaVersion,
+					Directives:    []llm.CacheDirective{{Target: llm.CacheTarget{Kind: llm.CacheAfterToolDefinition}, Policy: llm.CacheBestEffort}},
 				}} {
 					calls := 0
 					var payload []byte
@@ -53,6 +53,17 @@ func TestCachePlanAttachmentPreservesLegacyWireGolden(t *testing.T) {
 						Messages:  []llm.Message{{Role: llm.RoleSystem, Content: llm.TextContent("system"), Cache: true}, {Role: llm.RoleUser, Content: llm.TextContent("hello"), Cache: true}},
 						Tools:     []llm.ToolDefinition{{Name: "work", Description: "fixture", Parameters: map[string]any{"type": "object"}}},
 						CachePlan: plan,
+					}
+					if plan != nil && len(plan.Directives) != 0 {
+						view, err := llm.NewCacheTargetView(request)
+						if err != nil {
+							t.Fatal(err)
+						}
+						plan, err = view.Bind(plan.Directives)
+						if err != nil {
+							t.Fatal(err)
+						}
+						request.CachePlan = plan
 					}
 					before, err := json.Marshal(request.Messages)
 					if err != nil {
@@ -90,7 +101,7 @@ func TestCachePlanAttachmentPreservesLegacyWireGolden(t *testing.T) {
 					if baseline == nil {
 						baseline = payload
 					} else if !bytes.Equal(payload, baseline) {
-						t.Fatal("inert plan changed legacy payload")
+						t.Fatal("skipped best-effort plan changed legacy payload")
 					}
 				}
 				// Fixed local wire golden: no remote endpoint is contacted.

--- a/sdk/llm/cache_target_view.go
+++ b/sdk/llm/cache_target_view.go
@@ -135,11 +135,11 @@ func (view *CacheTargetView) Targets() []CacheTargetDescriptor {
 }
 
 // Validate checks a plan against this retained view and the current request.
-// This is an opt-in pure check, not Provider admission: no client invokes it yet.
+// This is a pure check; built-in admission reuses it through AdmitCachePlan.
 // Nil plans require no check. Fingerprint fields from the experimental API are
 // unsupported here; the retained owned snapshot supplies the binding instead.
 // Both policies require valid structure; capability/TTL support and best-effort
-// downgrade remain the responsibility of a future Provider admission layer.
+// downgrade are handled by Decide and the Provider admission layer.
 func (view *CacheTargetView) Validate(request InvokeRequest, plan *CachePlan) error {
 	if plan == nil {
 		return nil

--- a/sdk/llm/model.go
+++ b/sdk/llm/model.go
@@ -130,9 +130,9 @@ type InvokeRequest struct {
 	// Responses options (OpenAI Responses API). Ignored by providers that don't use it.
 	Responses *ResponsesOptions
 
-	// CachePlan is experimental, in-memory request-local intent. It is cloned
-	// with the request but excluded from JSON and not consumed by providers yet;
-	// neither required nor best-effort policies are enforced at this stage.
-	// Do not rely on it for cache control until capability-gated mapping exists.
+	// CachePlan is in-memory request-local intent, cloned but excluded from JSON.
+	// Built-in clients require nonempty plans bound with CacheTargetView.Bind;
+	// they reject required unsupported/stale intent and diagnose best-effort skips.
+	// Explicit wire mapping is not implemented; nil/empty plans retain legacy behavior.
 	CachePlan *CachePlan `json:"-"`
 }

--- a/sdk/llm/openai/chat.go
+++ b/sdk/llm/openai/chat.go
@@ -94,6 +94,10 @@ func (c *ChatClient) PromptCacheCapabilities() llm.PromptCacheCapabilities {
 }
 
 func (c *ChatClient) Invoke(ctx context.Context, req llm.InvokeRequest) (*llm.Completion, error) {
+	req, cacheDiagnostics, err := llm.AdmitCachePlan(ctx, req, c, c.warnf)
+	if err != nil {
+		return nil, err
+	}
 	local := *c
 	local.Extra = cloneMap(c.Extra)
 	local.ExtraBody = cloneMap(c.ExtraBody)
@@ -104,7 +108,7 @@ func (c *ChatClient) Invoke(ctx context.Context, req llm.InvokeRequest) (*llm.Co
 	lastErr := error(nil)
 
 	retry := resolveRetryPolicy(local.MaxRetries, local.RetryBaseDelay, local.RetryMaxDelay)
-	diagnostics := []llm.Diagnostic{}
+	diagnostics := cacheDiagnostics
 
 	for attempt := 0; attempt < retry.maxRetries; attempt++ {
 		if err := ctx.Err(); err != nil {
@@ -212,6 +216,10 @@ func (c *ChatClient) Invoke(ctx context.Context, req llm.InvokeRequest) (*llm.Co
 // InvokeStream implements true SSE streaming for OpenAI chat/completions.
 // It emits text deltas and tool_call deltas.
 func (c *ChatClient) InvokeStream(ctx context.Context, req llm.InvokeRequest) (<-chan llm.StreamEvent, error) {
+	req, _, err := llm.AdmitCachePlan(ctx, req, c, c.warnf)
+	if err != nil {
+		return nil, err
+	}
 	// Keep provider production separate from caller delivery. If a caller stops
 	// consuming, cancellation switches the forwarding goroutine to drain-and-drop
 	// mode so the producer can finish and close the response body.

--- a/sdk/llm/openai/responses.go
+++ b/sdk/llm/openai/responses.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"log"
 	"net/http"
 	"strconv"
 	"strings"
@@ -49,6 +50,18 @@ type ResponsesClient struct {
 	// instead of the official array-of-content-parts form.
 	// Some OpenAI-compatible gateways (e.g. certain enterprise proxies) require this.
 	ForceStringInput bool
+
+	Warningf func(format string, args ...any)
+}
+
+func (c *ResponsesClient) SetWarningf(warnf func(string, ...any)) { c.Warningf = warnf }
+
+func (c *ResponsesClient) warnf(format string, args ...any) {
+	if c != nil && c.Warningf != nil {
+		c.Warningf(format, args...)
+		return
+	}
+	log.Printf(format, args...)
 }
 
 func (c *ResponsesClient) Provider() string { return openAIProviderLabel(c.ProviderLabel) }
@@ -62,6 +75,10 @@ func (c *ResponsesClient) PromptCacheCapabilities() llm.PromptCacheCapabilities 
 }
 
 func (c *ResponsesClient) Invoke(ctx context.Context, req llm.InvokeRequest) (*llm.Completion, error) {
+	req, cacheDiagnostics, err := llm.AdmitCachePlan(ctx, req, c, c.warnf)
+	if err != nil {
+		return nil, err
+	}
 	local := *c
 	local.Extra = cloneMap(c.Extra)
 	local.ExtraBody = cloneMap(c.ExtraBody)
@@ -72,7 +89,7 @@ func (c *ResponsesClient) Invoke(ctx context.Context, req llm.InvokeRequest) (*l
 	lastErr := error(nil)
 
 	retry := resolveRetryPolicy(local.MaxRetries, local.RetryBaseDelay, local.RetryMaxDelay)
-	diagnostics := []llm.Diagnostic{}
+	diagnostics := cacheDiagnostics
 
 	autoCompat := shouldAutoCompat(req)
 	compatStage := responsesCompatFull
@@ -386,6 +403,10 @@ func looksLikeResponsesInputUnsupported(msg string) bool {
 // InvokeStream implements true SSE streaming for OpenAI responses.
 // It emits text deltas and basic tool-call deltas (best-effort).
 func (c *ResponsesClient) InvokeStream(ctx context.Context, req llm.InvokeRequest) (<-chan llm.StreamEvent, error) {
+	req, _, err := llm.AdmitCachePlan(ctx, req, c, c.warnf)
+	if err != nil {
+		return nil, err
+	}
 	// Keep provider production separate from caller delivery. If a caller stops
 	// consuming, cancellation switches the forwarding goroutine to drain-and-drop
 	// mode so the producer can finish and close the response body.

--- a/sdk/llm/openai/responses.go
+++ b/sdk/llm/openai/responses.go
@@ -51,10 +51,10 @@ type ResponsesClient struct {
 	// Some OpenAI-compatible gateways (e.g. certain enterprise proxies) require this.
 	ForceStringInput bool
 
+	// Configure before concurrent use. Deliberately not a WarningSinkSetter:
+	// shared child Agents must not overwrite this client's sink in Agent.New.
 	Warningf func(format string, args ...any)
 }
-
-func (c *ResponsesClient) SetWarningf(warnf func(string, ...any)) { c.Warningf = warnf }
 
 func (c *ResponsesClient) warnf(format string, args ...any) {
 	if c != nil && c.Warningf != nil {


### PR DESCRIPTION
## Scope

Related to #89; this advances actual before-network admission, not another pure helper and not completion of explicit cache mapping.

CacheTargetView.Bind creates an owned nonempty plan with a private original-view binding. Bind copies the view value into unreachable private storage: the review-discovered whole-view overwrite/rebinding bypass is fixed and has external-package real-client regressions. CloneCachePlan shares only that immutable private binding; JSON cannot restore it.

All six built-in Invoke/InvokeStream entrypoints call shared AdmitCachePlan before goroutines/network. Nonempty requests use existing CloneInvokeRequest, validate the original binding, and reuse Decide. Required unsupported/stale/unbound intent fails before HTTP; best-effort unsupported intent is skipped while legacy flags/wire remain. No accepted unmapped directive is silently sent. Fixed diagnostics are capped at32 plus one summary; warning sinks receive them and buffered successes also carry Completion.Diagnostics.

Review caught another real regression in the first candidate: adding Responses.WarningSinkSetter caused concurrent shared child Agent.New to mutate one client's sink, including nil-plan flows. Final c4ed532 removes that setter entirely. Responses.Warningf is construction-time configuration (otherwise existing logger behavior), not automatically overwritten by child Agents. SDK concurrent child creation+real requests proves configured sink80/child sink0; Goode's original reproduction also passes after the fix. Buffered metadata and warning output are two observable channels, not two distinct decisions; per-child/request-local sink adoption remains future host work.

## Intentional compatibility changes

- Previously inert nonempty plans are now enforced. Construct them with view.Bind; handmade/restored unbound plans reject. Nil/empty plan legacy behavior remains, including wire bytes.
- CachePlan private binding and ResponsesClient.Warningf change public struct layouts; external unkeyed literals need migration. Existing keyed literals, Message/Completion layouts and session JSON remain compatible.
- No Prompt rewrite, explicit cache-control mapping, model snapshot, Scheduler/event sequence, persistent authority or hash gate is introduced.

## Validation

Focused100 passed. Real 3provider x buffered/streaming tests prove zero HTTP for required/unbound/stale/clone-stale/stale-best-effort/uncloneable/schema/cancel and whole-view overwrite. Tests also cover private sourceview clearing, best-effort 200/401 wire parity+diagnostics, callback-time caller mutation isolation, partial stream cancellation/body closure, JSON binding loss and diagnostic cap/privacy.

Legacy golden variants now cover nil/empty/bound best-effort parity; formerly ignored malformed/required cases move to explicit before-network rejection tests. Existing serializers are otherwise unchanged. Author final c4ed532 full/vet/LLM-provider-Agent race/focused100 passed. Original binding overwrite and new shared-sink race findings are fixed, not waived. Independent exact-head re-review required after both fixes.

Final test-only follow-up654b56f isolates Agent.New's temporary dump directory. Repeated race testing identified unrelated shared-temp index cleanup warnings contaminating the child sink count (configured80/child6 with only fixed dump-index warning formats, no data race). The fixture still asserts configured80/child0; it does not weaken the cache routing invariant. Isolated combined race100 passed; final full/vet/race and independent exact-head review refreshed before merge.

Non-goals: exact Anthropic mapping, actual cache hits, dynamic model/config snapshot, host plan generation and completed #89. Current builtin capabilities still advertise no explicit mapping.

Final-candidate admission benchmark (3-sample median):1266ns/op,880B/op,12allocs/op for one one-KiB message/one bound best-effort directive with prebuilt view, nil warning callback and no network. Includes owned clone, validation, decision and bounded diagnostic construction; excludes initial binding/Provider latency. Not a speedup/cache-hit claim.
