### PR TITLE
feat(anthropic): map explicit tool-definition cache breakpoints

### DIFF
--- a/agent_docs/providers.md
+++ b/agent_docs/providers.md
@@ -8,9 +8,14 @@ stream normalization, and response metadata behavior.
   `CloneInvokeRequest` and the private execution frame, and excluded from JSON.
   Bind nonempty plans with `CacheTargetView.Bind`. Built-in buffered/streaming
   entrypoints clone and validate that original binding before network I/O:
-  stale/unbound/unsupported Required plans fail; Best-effort skips produce bounded
-  `Completion.Diagnostics` and warning-sink metadata. Explicit wire mapping is
-  still unavailable; nil/empty plans preserve the legacy path.
+  stale/unbound/unsupported Required plans fail; accepted/skipped decisions produce
+  bounded `Completion.Diagnostics` and warning metadata. Anthropic maps exact
+  Tool Definition indexes with default/5m TTL and up to four breakpoints; other
+  explicit targets and 1h TTL are not advertised yet. An accepted plan overrides
+  legacy cache markers without changing block shape/text/order. All-skipped,
+  nil and empty plans preserve the legacy path. See the official
+  [cache constraints](https://platform.claude.com/docs/en/build-with-claude/prompt-caching)
+  and [tool-definition API](https://platform.claude.com/docs/en/agents-and-tools/tool-use/tool-use-with-prompt-caching).
   Legacy `Message.Cache` behavior is unchanged; do not use the new field as a
   cache-control guarantee. No Agent Config or host plan generator is added.
   `CachePlan` now includes a private binding. Responses diagnostics use its

--- a/sdk/llm/anthropic/cache_plan.go
+++ b/sdk/llm/anthropic/cache_plan.go
@@ -1,0 +1,37 @@
+package anthropic
+
+import "github.com/timwhitez/agent-sdk-golang/sdk/llm"
+
+// applyToolCachePlan only touches newly serialized payload objects. Preserve
+// block shape/order/text while removing legacy breakpoints; do not rewrite
+// request/history Cache flags or reserialize system blocks as a plain string.
+func applyToolCachePlan(plan *llm.CachePlan, system any, messages []messageParam, tools []toolParam) error {
+	if len(plan.Directives) > 4 {
+		return &llm.CachePlanValidationError{Reason: "breakpoint_limit", DirectiveIndex: -1}
+	}
+	for i, directive := range plan.Directives {
+		if directive.Target.Kind != llm.CacheAfterToolDefinition || directive.Target.ToolIndex < 0 || directive.Target.ToolIndex >= len(tools) {
+			return &llm.CachePlanValidationError{Reason: "unmappable_target", DirectiveIndex: i}
+		}
+		if directive.TTL != llm.CacheTTLProviderDefault && directive.TTL != llm.CacheTTL5Minutes {
+			return &llm.CachePlanValidationError{Reason: "unsupported_ttl", DirectiveIndex: i}
+		}
+	}
+	if blocks, ok := system.([]contentBlockParam); ok {
+		for i := range blocks {
+			blocks[i].CacheCtrl = nil
+		}
+	}
+	for i := range messages {
+		for j := range messages[i].Content {
+			messages[i].Content[j].CacheCtrl = nil
+		}
+	}
+	for i := range tools {
+		tools[i].CacheCtrl = nil
+	}
+	for _, directive := range plan.Directives {
+		tools[directive.Target.ToolIndex].CacheCtrl = &cacheControl{Type: "ephemeral", TTL: directive.TTL}
+	}
+	return nil
+}

--- a/sdk/llm/anthropic/cache_plan_test.go
+++ b/sdk/llm/anthropic/cache_plan_test.go
@@ -1,0 +1,56 @@
+package anthropic
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/timwhitez/agent-sdk-golang/sdk/llm"
+)
+
+func TestToolCacheMappingGuardDoesNotPartiallyRewrite(t *testing.T) {
+	for _, target := range []llm.CacheTarget{{Kind: llm.CacheAfterMessage}, {Kind: llm.CacheAfterToolDefinition, ToolIndex: -1}, {Kind: llm.CacheAfterToolDefinition, ToolIndex: 1}} {
+		tools := []toolParam{{Name: "fixture", CacheCtrl: &cacheControl{Type: "ephemeral"}}}
+		before, _ := json.Marshal(tools)
+		err := applyToolCachePlan(&llm.CachePlan{Directives: []llm.CacheDirective{{Target: target}}}, nil, nil, tools)
+		after, _ := json.Marshal(tools)
+		if err == nil || string(before) != string(after) {
+			t.Fatal("invalid mapping changed payload", err)
+		}
+	}
+	for _, plan := range []*llm.CachePlan{
+		{Directives: make([]llm.CacheDirective, 5)},
+		{Directives: []llm.CacheDirective{{Target: llm.CacheTarget{Kind: llm.CacheAfterToolDefinition}, TTL: llm.CacheTTL1Hour}}},
+	} {
+		tools := []toolParam{{CacheCtrl: &cacheControl{Type: "ephemeral"}}}
+		if err := applyToolCachePlan(plan, nil, nil, tools); err == nil || tools[0].CacheCtrl == nil {
+			t.Fatal("limit/TTL guard failed")
+		}
+	}
+}
+
+func BenchmarkToolCacheRequestBuilder(b *testing.B) {
+	for _, mode := range []string{"legacy", "explicit"} {
+		b.Run(mode, func(b *testing.B) {
+			client := &Client{ModelName: "fixture", MaxTokens: 64, MaxCachedToolDefinitions: 1}
+			request := llm.InvokeRequest{Messages: []llm.Message{{Role: llm.RoleSystem, Content: llm.TextContent(strings.Repeat("x", 1024)), Cache: true}, {Role: llm.RoleUser, Content: llm.TextContent("hello"), Cache: true}}, Tools: []llm.ToolDefinition{{Name: "first"}, {Name: "second"}}}
+			if mode == "explicit" {
+				view, err := llm.NewCacheTargetView(request)
+				if err != nil {
+					b.Fatal(err)
+				}
+				request.CachePlan, err = view.Bind([]llm.CacheDirective{{Target: llm.CacheTarget{Kind: llm.CacheAfterToolDefinition}, Policy: llm.CacheRequired, TTL: llm.CacheTTL5Minutes}})
+				if err != nil {
+					b.Fatal(err)
+				}
+			}
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				if _, err := client.buildRequest(request, nil); err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}

--- a/sdk/llm/anthropic/client.go
+++ b/sdk/llm/anthropic/client.go
@@ -73,10 +73,11 @@ func (c *Client) warnf(format string, args ...any) {
 
 func (c *Client) Provider() string { return "anthropic" }
 
-// PromptCacheCapabilities reports explicit CachePlan mapping, not legacy
-// Message.Cache/MaxCachedToolDefinitions. Those legacy controls remain separate.
+// PromptCacheCapabilities reports implemented explicit mappings, not a promise
+// of endpoint/model acceptance or a cache hit. Message/block and 1h TTL mapping
+// are deliberately not advertised by this first tool-definition slice.
 func (c *Client) PromptCacheCapabilities() llm.PromptCacheCapabilities {
-	return llm.PromptCacheCapabilities{UsageTelemetry: true}
+	return llm.PromptCacheCapabilities{ExplicitToolDefinition: true, SupportedTTLs: []llm.CacheTTL{llm.CacheTTL5Minutes}, MaxBreakpoints: 4, UsageTelemetry: true}
 }
 
 func (c *Client) Model() string { return c.ModelName }
@@ -544,7 +545,8 @@ func isClientTimeoutErr(err error) bool {
 // ---- request/response mapping ----
 
 type cacheControl struct {
-	Type string `json:"type"`
+	Type string       `json:"type"`
+	TTL  llm.CacheTTL `json:"ttl,omitempty"`
 }
 
 type toolParam struct {
@@ -1168,6 +1170,11 @@ func (c *Client) buildRequestWithThinking(req llm.InvokeRequest, thinkingConfig 
 	tools := []toolParam(nil)
 	if len(req.Tools) > 0 {
 		tools = serializeTools(req.Tools, c.MaxCachedToolDefinitions)
+	}
+	if req.CachePlan != nil && len(req.CachePlan.Directives) > 0 {
+		if err := applyToolCachePlan(req.CachePlan, sys, msgs, tools); err != nil {
+			return nil, err
+		}
 	}
 
 	// Effective extended thinking for this call. A per-call DisableThinking wins

--- a/sdk/llm/anthropic_tool_cache_wire_test.go
+++ b/sdk/llm/anthropic_tool_cache_wire_test.go
@@ -1,0 +1,278 @@
+package llm_test
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"reflect"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/timwhitez/agent-sdk-golang/sdk/llm"
+	"github.com/timwhitez/agent-sdk-golang/sdk/llm/anthropic"
+)
+
+func toolCacheRequest() llm.InvokeRequest {
+	request := llm.InvokeRequest{Messages: []llm.Message{
+		{Role: llm.RoleSystem, Cache: true, Content: llm.Content{Text: "system", Blocks: []llm.ContentBlock{{Type: "text", Text: "section"}}}},
+		{Role: llm.RoleUser, Cache: true, Content: llm.TextContent("hello")},
+		{Role: llm.RoleAssistant, Cache: true, ToolCalls: []llm.ToolCall{{ID: "a", Function: llm.FunctionCall{Name: "tool_0", Arguments: `{}`}}, {ID: "b", Function: llm.FunctionCall{Name: "tool_1", Arguments: `{}`}}}},
+		{Role: llm.RoleTool, ToolCallID: "a", Cache: true, Content: llm.TextContent("result_a")},
+		{Role: llm.RoleTool, ToolCallID: "b", Cache: true, Content: llm.TextContent("result_b")},
+	}}
+	for i := 0; i < 6; i++ {
+		request.Tools = append(request.Tools, llm.ToolDefinition{Name: fmt.Sprintf("tool_%d", i), Parameters: map[string]any{"type": "object", "title": "removed-title", "properties": map[string]any{"cache_control": map[string]any{"type": "string"}}}})
+	}
+	return request
+}
+
+func bindToolCache(t *testing.T, request *llm.InvokeRequest, directives []llm.CacheDirective) {
+	t.Helper()
+	view, err := llm.NewCacheTargetView(*request)
+	if err != nil {
+		t.Fatal(err)
+	}
+	request.CachePlan, err = view.Bind(directives)
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func toolDirective(index int, policy llm.CacheDirectivePolicy, ttl llm.CacheTTL) llm.CacheDirective {
+	return llm.CacheDirective{Target: llm.CacheTarget{Kind: llm.CacheAfterToolDefinition, ToolIndex: index}, Policy: policy, TTL: ttl}
+}
+
+// Only remove wire cache fields. A schema property named cache_control is data,
+// not a breakpoint, and must remain untouched.
+func clearWireCache(payload map[string]any) {
+	if blocks, ok := payload["system"].([]any); ok {
+		for _, b := range blocks {
+			delete(b.(map[string]any), "cache_control")
+		}
+	}
+	for _, m := range payload["messages"].([]any) {
+		for _, b := range m.(map[string]any)["content"].([]any) {
+			delete(b.(map[string]any), "cache_control")
+		}
+	}
+	for _, tool := range payload["tools"].([]any) {
+		delete(tool.(map[string]any), "cache_control")
+	}
+}
+
+func TestAnthropicExactToolCacheWireAndLegacyPrecedence(t *testing.T) {
+	for _, stream := range []bool{false, true} {
+		for _, status := range []int{200, 401} {
+			t.Run(fmt.Sprintf("%v/%d", stream, status), func(t *testing.T) {
+				var baseline map[string]any
+				for _, planned := range []bool{false, true} {
+					request := toolCacheRequest()
+					if planned {
+						bindToolCache(t, &request, []llm.CacheDirective{toolDirective(3, llm.CacheRequired, llm.CacheTTL5Minutes), toolDirective(0, llm.CacheBestEffort, llm.CacheTTLProviderDefault)})
+					}
+					before, err := llm.CloneInvokeRequest(request)
+					if err != nil {
+						t.Fatal(err)
+					}
+					var payload map[string]any
+					var warnings []string
+					var calls atomic.Int32
+					model := admissionModel("anthropic", func(r *http.Request) (*http.Response, error) {
+						calls.Add(1)
+						data, err := io.ReadAll(r.Body)
+						if err != nil {
+							return nil, err
+						}
+						if err := json.Unmarshal(data, &payload); err != nil {
+							return nil, err
+						}
+						body := admissionSuccess["anthropic"]
+						if stream {
+							body = admissionSSE("anthropic")
+						}
+						if status == 401 {
+							body = `{"error":{"message":"fixture rejected"}}`
+						}
+						return &http.Response{StatusCode: status, Header: make(http.Header), Body: io.NopCloser(strings.NewReader(body)), Request: r}, nil
+					}, func(f string, a ...any) { warnings = append(warnings, fmt.Sprintf(f, a...)) })
+					model.(*anthropic.Client).MaxCachedToolDefinitions = 2
+					completion, err := callAdmissionModel(context.Background(), model, request, stream)
+					if calls.Load() != 1 || (err != nil) != (status == 401) {
+						t.Fatalf("calls=%d err=%v", calls.Load(), err)
+					}
+					if !reflect.DeepEqual(before, request) {
+						t.Fatal("mapping mutated request/history/plan")
+					}
+					if !planned {
+						baseline = payload
+						continue
+					}
+					clearWireCache(baseline)
+					tools := baseline["tools"].([]any)
+					tools[0].(map[string]any)["cache_control"] = map[string]any{"type": "ephemeral"}
+					tools[3].(map[string]any)["cache_control"] = map[string]any{"type": "ephemeral", "ttl": "5m"}
+					if !reflect.DeepEqual(payload, baseline) {
+						t.Fatalf("exact breakpoint/legacy precedence mismatch: %#v", payload)
+					}
+					want := []string{"cache_plan_accepted: directive 0: explicit plan takes precedence over legacy cache hints", "cache_plan_accepted: directive 1: explicit plan takes precedence over legacy cache hints"}
+					if !reflect.DeepEqual(warnings, want) {
+						t.Fatalf("diagnostic golden=%v", warnings)
+					}
+					if !stream && status == 200 && (len(completion.Diagnostics) != 2 || completion.Diagnostics[0].Kind != "cache_plan_accepted") {
+						t.Fatal("missing typed accepted diagnostics")
+					}
+				}
+			})
+		}
+	}
+}
+
+func TestAnthropicToolCacheFailuresBeforeNetwork(t *testing.T) {
+	for _, stream := range []bool{false, true} {
+		for _, failure := range []string{"ttl", "overflow", "stale", "out-of-range", "duplicate"} {
+			t.Run(fmt.Sprintf("%v/%s", stream, failure), func(t *testing.T) {
+				request := toolCacheRequest()
+				directives := []llm.CacheDirective{toolDirective(0, llm.CacheRequired, "")}
+				reason, index := "unsupported_ttl", 0
+				if failure == "ttl" {
+					directives[0].TTL = llm.CacheTTL1Hour
+				}
+				if failure == "overflow" {
+					for i := 1; i < 5; i++ {
+						directives = append(directives, toolDirective(i, llm.CacheRequired, ""))
+					}
+					reason, index = "breakpoint_limit", 4
+				}
+				bindToolCache(t, &request, directives)
+				switch failure {
+				case "stale":
+					request.Tools[0], request.Tools[1] = request.Tools[1], request.Tools[0]
+					reason, index = "stale_request", -1
+				case "out-of-range":
+					request.CachePlan.Directives[0].Target.ToolIndex = 100
+					reason = "invalid_target"
+				case "duplicate":
+					request.CachePlan.Directives = append(request.CachePlan.Directives, request.CachePlan.Directives[0])
+					reason, index = "duplicate_boundary", 1
+				}
+				var calls atomic.Int32
+				model := admissionModel("anthropic", func(*http.Request) (*http.Response, error) { calls.Add(1); return nil, fmt.Errorf("must not send") }, func(string, ...any) { t.Error("rejected plan emitted accepted/skip warning") })
+				_, err := callAdmissionModel(context.Background(), model, request, stream)
+				assertCacheViewError(t, err, reason, index)
+				if calls.Load() != 0 {
+					t.Fatal("invalid plan reached network")
+				}
+			})
+		}
+	}
+}
+
+func TestAnthropicToolCacheRequiredCapacityAndCallerIsolation(t *testing.T) {
+	for _, stream := range []bool{false, true} {
+		t.Run(fmt.Sprint(stream), func(t *testing.T) {
+			request := toolCacheRequest()
+			var directives []llm.CacheDirective
+			for i := 0; i < 4; i++ {
+				directives = append(directives, toolDirective(i, llm.CacheBestEffort, ""))
+			}
+			directives = append(directives, toolDirective(5, llm.CacheRequired, ""), toolDirective(4, llm.CacheRequired, ""))
+			bindToolCache(t, &request, directives)
+			var got []int
+			mutated := false
+			model := admissionModel("anthropic", func(r *http.Request) (*http.Response, error) {
+				var payload map[string]any
+				data, _ := io.ReadAll(r.Body)
+				if err := json.Unmarshal(data, &payload); err != nil {
+					return nil, err
+				}
+				for i, v := range payload["tools"].([]any) {
+					tool := v.(map[string]any)
+					if tool["name"] != fmt.Sprintf("tool_%d", i) {
+						t.Error("caller reorder changed owned wire")
+					}
+					if tool["cache_control"] != nil {
+						got = append(got, i)
+					}
+				}
+				return &http.Response{StatusCode: 401, Header: make(http.Header), Body: io.NopCloser(strings.NewReader(`{"error":{"message":"fixture"}}`)), Request: r}, nil
+			}, func(string, ...any) {
+				if !mutated {
+					mutated = true
+					request.Tools[0], request.Tools[5] = request.Tools[5], request.Tools[0]
+				}
+			})
+			_, _ = callAdmissionModel(context.Background(), model, request, stream)
+			if !reflect.DeepEqual(got, []int{0, 1, 4, 5}) {
+				t.Fatalf("required capacity/selection=%v", got)
+			}
+		})
+	}
+}
+
+func TestCacheAdmissionMixedSummaryDoesNotMislabelAccepted(t *testing.T) {
+	request := llm.InvokeRequest{Tools: []llm.ToolDefinition{{Name: "private-tool"}}}
+	var directives []llm.CacheDirective
+	for i := 0; i < 32; i++ {
+		request.Messages = append(request.Messages, llm.Message{Role: llm.RoleUser, Content: llm.TextContent("private-text")})
+		directives = append(directives, llm.CacheDirective{Target: llm.CacheTarget{Kind: llm.CacheAfterMessage, MessageIndex: i}, Policy: llm.CacheBestEffort})
+	}
+	directives = append(directives, toolDirective(0, llm.CacheRequired, ""))
+	bindToolCache(t, &request, directives)
+	owned, diagnostics, err := llm.AdmitCachePlan(context.Background(), request, &anthropic.Client{}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(owned.CachePlan.Directives) != 1 || len(diagnostics) != 33 || diagnostics[32].Kind != "cache_plan_summary" || diagnostics[32].Message != "1 additional directives: 1 accepted, 0 skipped" {
+		t.Fatal("mixed decision summary", diagnostics)
+	}
+	encoded, _ := json.Marshal(diagnostics)
+	if strings.Contains(string(encoded), "private-") {
+		t.Fatal("summary leaked source content")
+	}
+}
+
+func TestAnthropicExplicitToolCacheSurvivesBetaRetry(t *testing.T) {
+	for _, stream := range []bool{false, true} {
+		t.Run(fmt.Sprint(stream), func(t *testing.T) {
+			request := toolCacheRequest()
+			bindToolCache(t, &request, []llm.CacheDirective{toolDirective(2, llm.CacheRequired, llm.CacheTTL5Minutes)})
+			before, err := llm.CloneInvokeRequest(request)
+			if err != nil {
+				t.Fatal(err)
+			}
+			var payloads []string
+			var accepted atomic.Int32
+			model := admissionModel("anthropic", func(r *http.Request) (*http.Response, error) {
+				data, err := io.ReadAll(r.Body)
+				if err != nil {
+					return nil, err
+				}
+				payloads = append(payloads, string(data))
+				status, body := 200, admissionSuccess["anthropic"]
+				if stream {
+					body = admissionSSE("anthropic")
+				}
+				if len(payloads) == 1 {
+					status, body = 400, `{"error":{"message":"unsupported beta header"}}`
+				}
+				return &http.Response{StatusCode: status, Header: make(http.Header), Body: io.NopCloser(strings.NewReader(body)), Request: r}, nil
+			}, func(format string, args ...any) {
+				if strings.HasPrefix(fmt.Sprintf(format, args...), "cache_plan_accepted:") {
+					accepted.Add(1)
+				}
+			})
+			client := model.(*anthropic.Client)
+			client.Beta = []string{"unsupported-beta"}
+			_, err = callAdmissionModel(context.Background(), model, request, stream)
+			if err != nil || len(payloads) != 2 || payloads[0] != payloads[1] || accepted.Load() != 1 {
+				t.Fatalf("retry count=%d accepted=%d err=%v", len(payloads), accepted.Load(), err)
+			}
+			if !reflect.DeepEqual(request, before) || !reflect.DeepEqual(client.Beta, []string{"unsupported-beta"}) {
+				t.Fatal("compat retry mutated source")
+			}
+		})
+	}
+}

--- a/sdk/llm/cache_admission.go
+++ b/sdk/llm/cache_admission.go
@@ -29,10 +29,10 @@ func (view *CacheTargetView) Bind(directives []CacheDirective) (*CachePlan, erro
 // The returned request is isolated from caller mutation before asynchronous
 // streaming or retry. Callers must exclusively own input graphs during this call.
 //
-// Current clients have no explicit mapper: required intent fails, best-effort
-// intent is skipped with bounded diagnostics while legacy cache flags remain.
-// An accepted directive fails as unmapped rather than silently reaching a client
-// whose serializer cannot implement it. Future mappers must extend this boundary.
+// Accepted directives remain on the owned request for the concrete client's
+// serializer. Capability reports must describe actual implemented mappings.
+// Unsupported best-effort intent is skipped; when none is accepted the legacy
+// path remains. An accepted explicit plan takes precedence over legacy hints.
 // Warning callbacks see fixed metadata only; buffered clients also return these
 // diagnostics in Completion.Diagnostics. No new event or invocation path is used.
 func AdmitCachePlan(ctx context.Context, request InvokeRequest, model ChatModel, warnf func(string, ...any)) (InvokeRequest, []Diagnostic, error) {
@@ -56,9 +56,6 @@ func AdmitCachePlan(ctx context.Context, request InvokeRequest, model ChatModel,
 	if err != nil {
 		return InvokeRequest{}, nil, err
 	}
-	if len(decision.Plan.Directives) != 0 {
-		return InvokeRequest{}, nil, cachePlanError("unmapped_plan", -1)
-	}
 	const diagnosticLimit = 32
 	count := len(decision.Directives)
 	if count > diagnosticLimit {
@@ -66,12 +63,29 @@ func AdmitCachePlan(ctx context.Context, request InvokeRequest, model ChatModel,
 	}
 	diagnostics := make([]Diagnostic, 0, count+1)
 	for _, d := range decision.Directives[:count] {
-		diagnostics = append(diagnostics, Diagnostic{Kind: "cache_plan_skipped", Message: fmt.Sprintf("directive %d: %s", d.DirectiveIndex, d.Reason)})
+		kind, reason := "cache_plan_skipped", d.Reason
+		if d.Accepted {
+			kind, reason = "cache_plan_accepted", "explicit plan takes precedence over legacy cache hints"
+		}
+		diagnostics = append(diagnostics, Diagnostic{Kind: kind, Message: fmt.Sprintf("directive %d: %s", d.DirectiveIndex, reason)})
 	}
 	if count < len(decision.Directives) {
-		diagnostics = append(diagnostics, Diagnostic{Kind: "cache_plan_skipped_summary", Message: fmt.Sprintf("%d additional directives skipped", len(decision.Directives)-count)})
+		accepted := 0
+		for _, d := range decision.Directives[count:] {
+			if d.Accepted {
+				accepted++
+			}
+		}
+		if accepted == 0 {
+			diagnostics = append(diagnostics, Diagnostic{Kind: "cache_plan_skipped_summary", Message: fmt.Sprintf("%d additional directives skipped", len(decision.Directives)-count)})
+		} else {
+			diagnostics = append(diagnostics, Diagnostic{Kind: "cache_plan_summary", Message: fmt.Sprintf("%d additional directives: %d accepted, %d skipped", len(decision.Directives)-count, accepted, len(decision.Directives)-count-accepted)})
+		}
 	}
 	owned.CachePlan = nil
+	if len(decision.Plan.Directives) > 0 {
+		owned.CachePlan = decision.Plan
+	}
 	if warnf != nil {
 		for _, d := range diagnostics {
 			warnf("%s: %s", d.Kind, d.Message)

--- a/sdk/llm/cache_admission_test.go
+++ b/sdk/llm/cache_admission_test.go
@@ -313,7 +313,12 @@ func TestCacheAdmissionPartialStreamCancellation(t *testing.T) {
 				calls.Add(1)
 				return &http.Response{StatusCode: 200, Header: make(http.Header), Body: body, Request: r}, nil
 			}, func(string, ...any) {})
-			events, err := model.InvokeStream(ctx, admissionRequest(t, llm.CacheBestEffort))
+			request := admissionRequest(t, llm.CacheBestEffort)
+			if provider == "anthropic" {
+				request = toolCacheRequest()
+				bindToolCache(t, &request, []llm.CacheDirective{toolDirective(2, llm.CacheRequired, llm.CacheTTLProviderDefault)})
+			}
+			events, err := model.InvokeStream(ctx, request)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/sdk/llm/cache_boundary_wire_test.go
+++ b/sdk/llm/cache_boundary_wire_test.go
@@ -79,7 +79,7 @@ func TestAnthropicLegacyCacheBoundaryWireGolden(t *testing.T) {
 				var baseline []byte
 				for _, plan := range []*llm.CachePlan{nil, {Directives: []llm.CacheDirective{}}, {
 					SchemaVersion: llm.CachePlanSchemaVersion,
-					Directives:    []llm.CacheDirective{{Target: llm.CacheTarget{Kind: llm.CacheAfterToolDefinition}, Policy: llm.CacheBestEffort}},
+					Directives:    []llm.CacheDirective{{Target: llm.CacheTarget{Kind: llm.CacheAfterMessage}, Policy: llm.CacheBestEffort}},
 				}} {
 					request := llm.InvokeRequest{Messages: llm.CloneMessages(fixture.messages), Tools: tools, CachePlan: plan}
 					if plan != nil && len(plan.Directives) != 0 {

--- a/sdk/llm/cache_decision_test.go
+++ b/sdk/llm/cache_decision_test.go
@@ -168,7 +168,12 @@ func TestCacheDecisionFailuresAndNoCapabilityGuessing(t *testing.T) {
 func TestCacheDecisionBuiltinCapabilitiesAreConservative(t *testing.T) {
 	for _, model := range []llm.ChatModel{&anthropic.Client{}, &openai.ChatClient{}, &openai.ResponsesClient{}} {
 		provider, ok := model.(llm.PromptCacheCapabilityProvider)
-		if !ok || !reflect.DeepEqual(provider.PromptCacheCapabilities(), llm.PromptCacheCapabilities{UsageTelemetry: true}) {
+		want := llm.PromptCacheCapabilities{UsageTelemetry: true}
+		if _, anthropicClient := model.(*anthropic.Client); anthropicClient {
+			want.ExplicitToolDefinition, want.MaxBreakpoints = true, 4
+			want.SupportedTTLs = []llm.CacheTTL{llm.CacheTTL5Minutes}
+		}
+		if !ok || !reflect.DeepEqual(provider.PromptCacheCapabilities(), want) {
 			t.Fatal("builtin claims unimplemented explicit control")
 		}
 		request, view, plan := cacheDecisionFixture(t)

--- a/sdk/llm/cache_plan.go
+++ b/sdk/llm/cache_plan.go
@@ -51,7 +51,7 @@ type CacheDirective struct {
 // CachePlan is request-local optimization intent. It must not be written into
 // conversation history or treated as proof that a Provider cache was hit.
 // Bind a nonempty plan with CacheTargetView.Bind before passing it to a built-in
-// client. Clients enforce admission, but explicit wire mapping is not available.
+// client. Clients enforce admission and report only implemented wire mappings.
 type CachePlan struct {
 	SchemaVersion int
 	// Reserved experimental field; unused by providers. CacheTargetView uses

--- a/sdk/llm/cache_plan_wire_test.go
+++ b/sdk/llm/cache_plan_wire_test.go
@@ -27,7 +27,7 @@ func TestCachePlanAttachmentPreservesLegacyWireGolden(t *testing.T) {
 				var baseline []byte
 				for _, plan := range []*llm.CachePlan{nil, {Directives: []llm.CacheDirective{}}, {
 					SchemaVersion: llm.CachePlanSchemaVersion,
-					Directives:    []llm.CacheDirective{{Target: llm.CacheTarget{Kind: llm.CacheAfterToolDefinition}, Policy: llm.CacheBestEffort}},
+					Directives:    []llm.CacheDirective{{Target: llm.CacheTarget{Kind: llm.CacheAfterMessage}, Policy: llm.CacheBestEffort}},
 				}} {
 					calls := 0
 					var payload []byte

--- a/sdk/llm/model.go
+++ b/sdk/llm/model.go
@@ -133,6 +133,6 @@ type InvokeRequest struct {
 	// CachePlan is in-memory request-local intent, cloned but excluded from JSON.
 	// Built-in clients require nonempty plans bound with CacheTargetView.Bind;
 	// they reject required unsupported/stale intent and diagnose best-effort skips.
-	// Explicit wire mapping is not implemented; nil/empty plans retain legacy behavior.
+	// Concrete client capabilities define mapped targets; nil/empty retain legacy behavior.
 	CachePlan *CachePlan `json:"-"`
 }


### PR DESCRIPTION
## Scope

Related to #89 (multi-phase, remains open). First actual explicit mapper: Anthropic Tool Definition indexes with default/5m TTL and at most four breakpoints. Message/block targets and 1h TTL remain unsupported and are not advertised. OpenAI clients remain explicit-cache unsupported.

Official contracts checked: [prompt caching](https://platform.claude.com/docs/en/build-with-claude/prompt-caching), [tool cache boundaries](https://platform.claude.com/docs/en/agents-and-tools/tool-use/tool-use-with-prompt-caching), [API TTL enum](https://platform.claude.com/docs/en/api/messages/create). They allow four explicit breakpoints, default/5m TTL; mixed1h/5m adds ordering constraints intentionally outside this slice. Client mapping support is not proof of gateway acceptance or cache hit.

## Behavior

- Reuse existing binding/admission/Decide and Anthropic request builder. Accepted plan is retained on the owned request for its concrete serializer; no new mapper interface or execution/event chain.
- For accepted explicit plans, only fresh wire cache fields change: all legacy system/message/tool-root cache markers are removed, exact requested ToolIndex markers added. Block shape, text, order, tool schemas (including a property named cache_control), source history and Cache flags remain unchanged.
- Nil/empty/all-skipped plans retain legacy behavior. Accepted/skipped diagnostics remain bounded; truncated mixed decisions no longer falsely label accepted items skipped. Required capacity is reserved first.
- Shared Admit now trusts concrete capability declarations to describe an implemented mapper; it does not automatically map arbitrary third-party model handles. No hash gate is added.

## Verification

Focused100 passed. Actual buffered/stream HTTP tests cover exact selection rather than last-N, precedence, default/5m TTL, 200/401, required overflow/1h/stale/index/duplicates zero I/O, caller reorder isolation, beta downgrade retry with identical payload and one admission decision, accepted partial streaming cancellation and bounded summary/privacy.

Existing legacy golden tests are unchanged in expected bytes; their best-effort directive now targets still-unsupported message boundaries, while precise tool mapping has dedicated tests. Mapper guard tests prove invalid input does not partially rewrite payload. Final full/vet/LLM-provider-Agent race and builder benchmark running; independent exact-head review required before merge.

Final c7815b1 author and independent full/vet/LLM-provider-Agent race/focused100 passed; independent build also passed. Mutations caught wrong ToolIndex, missing5m TTL, leftover legacy System cache marker and duplicate retry admission, then restored clean. Independent Goode full/vet/5pkg race/strictactualSDKbuild and wrapper/Responses regression probes passed.

Builder-only three-sample medians: legacy1147ns/984B/14alloc, explicit1225ns/1016B/15alloc. Two tools, one one-KiB system block, one user block; excludes admission/JSON/network. Not end-to-end latency, a speedup or cache-hit measurement.

Non-goals: live cache-hit/cost claims, 1h/mixed TTL, message/block mapping, model snapshot, host generator and complete #89 closure.
