### PR TITLE
feat(anthropic): map eligible message cache boundaries from serialization

### DIFF
--- a/agent_docs/providers.md
+++ b/agent_docs/providers.md
@@ -10,8 +10,13 @@ stream normalization, and response metadata behavior.
   entrypoints clone and validate that original binding before network I/O:
   stale/unbound/unsupported Required plans fail; accepted/skipped decisions produce
   bounded `Completion.Diagnostics` and warning metadata. Anthropic maps exact
-  Tool Definition indexes with default/5m TTL and up to four breakpoints; other
-  explicit targets and 1h TTL are not advertised yet. An accepted plan overrides
+  Tool Definition and eligible Message boundaries with default/5m TTL and up to
+  four breakpoints. Eligibility comes from the same serialization traversal,
+  before capacity allocation: hidden/empty/placeholder endpoints are not targets.
+  A collapsed System string exposes only its last emitted source endpoint and
+  is wrapped whole, never split to invent earlier boundaries. Structured System
+  and merged Tool Results retain per-source locations. Content-block targets and
+  1h TTL are not advertised yet. An accepted plan overrides
   legacy cache markers without changing block shape/text/order. All-skipped,
   nil and empty plans preserve the legacy path. See the official
   [cache constraints](https://platform.claude.com/docs/en/build-with-claude/prompt-caching)

--- a/sdk/llm/anthropic/cache_plan.go
+++ b/sdk/llm/anthropic/cache_plan.go
@@ -1,26 +1,104 @@
 package anthropic
 
-import "github.com/timwhitez/agent-sdk-golang/sdk/llm"
+import (
+	"strings"
 
-// applyToolCachePlan only touches newly serialized payload objects. Preserve
-// block shape/order/text while removing legacy breakpoints; do not rewrite
-// request/history Cache flags or reserialize system blocks as a plain string.
-func applyToolCachePlan(plan *llm.CachePlan, system any, messages []messageParam, tools []toolParam) error {
+	"github.com/timwhitez/agent-sdk-golang/sdk/llm"
+)
+
+type messageCacheLocation struct {
+	system, plain, eligible bool
+	message, block          int
+}
+
+func cacheableContentBoundary(source llm.ContentBlock, wire contentBlockParam) bool {
+	switch source.Type {
+	case "text":
+		return wire.Type == "text" && strings.TrimSpace(wire.Text) != ""
+	case "image_url":
+		return wire.Type == "image" && wire.Source != nil
+	default:
+		// Never treat a placeholder for unsupported content as its source.
+		return false
+	}
+}
+
+// PromptCacheTargetEligibility uses the same traversal as the actual builder,
+// with warnings disabled. Tool-only plans do not need message serialization.
+func (c *Client) PromptCacheTargetEligibility(request llm.InvokeRequest, targets []llm.CacheTarget) []bool {
+	eligible := make([]bool, len(targets))
+	var locations []messageCacheLocation
+	for _, target := range targets {
+		if target.Kind == llm.CacheAfterMessage {
+			locations = make([]messageCacheLocation, len(request.Messages))
+			break
+		}
+	}
+	if locations != nil {
+		if _, _, err := serializeMessagesWithLocations(request.Messages, nil, locations); err != nil {
+			locations = nil
+		}
+	}
+	for i, target := range targets {
+		switch target.Kind {
+		case llm.CacheAfterToolDefinition:
+			eligible[i] = target.ToolIndex >= 0 && target.ToolIndex < len(request.Tools)
+		case llm.CacheAfterMessage:
+			eligible[i] = target.MessageIndex >= 0 && target.MessageIndex < len(locations) && locations[target.MessageIndex].eligible
+		}
+	}
+	return eligible
+}
+
+// applyCachePlan only touches newly serialized objects, after all destinations
+// pass validation. A collapsed system string can be wrapped whole, not split
+// to invent earlier source boundaries. Existing structured blocks keep shape.
+func applyCachePlan(plan *llm.CachePlan, system *any, messages []messageParam, tools []toolParam, locations []messageCacheLocation) error {
 	if len(plan.Directives) > 4 {
 		return &llm.CachePlanValidationError{Reason: "breakpoint_limit", DirectiveIndex: -1}
 	}
+	sysBlocks, _ := (*system).([]contentBlockParam)
+	var wrapped []contentBlockParam
+	destinations := make([]**cacheControl, 0, len(plan.Directives))
 	for i, directive := range plan.Directives {
-		if directive.Target.Kind != llm.CacheAfterToolDefinition || directive.Target.ToolIndex < 0 || directive.Target.ToolIndex >= len(tools) {
+		var destination **cacheControl
+		target := directive.Target
+		switch target.Kind {
+		case llm.CacheAfterToolDefinition:
+			if target.ToolIndex >= 0 && target.ToolIndex < len(tools) {
+				destination = &tools[target.ToolIndex].CacheCtrl
+			}
+		case llm.CacheAfterMessage:
+			if target.MessageIndex >= 0 && target.MessageIndex < len(locations) {
+				location := locations[target.MessageIndex]
+				if location.eligible {
+					if location.system {
+						if location.plain {
+							if text, ok := (*system).(string); ok {
+								if wrapped == nil {
+									wrapped = []contentBlockParam{{Type: "text", Text: text}}
+								}
+								destination = &wrapped[0].CacheCtrl
+							}
+						} else if location.block >= 0 && location.block < len(sysBlocks) {
+							destination = &sysBlocks[location.block].CacheCtrl
+						}
+					} else if location.message >= 0 && location.message < len(messages) && location.block >= 0 && location.block < len(messages[location.message].Content) {
+						destination = &messages[location.message].Content[location.block].CacheCtrl
+					}
+				}
+			}
+		}
+		if destination == nil {
 			return &llm.CachePlanValidationError{Reason: "unmappable_target", DirectiveIndex: i}
 		}
 		if directive.TTL != llm.CacheTTLProviderDefault && directive.TTL != llm.CacheTTL5Minutes {
 			return &llm.CachePlanValidationError{Reason: "unsupported_ttl", DirectiveIndex: i}
 		}
+		destinations = append(destinations, destination)
 	}
-	if blocks, ok := system.([]contentBlockParam); ok {
-		for i := range blocks {
-			blocks[i].CacheCtrl = nil
-		}
+	for i := range sysBlocks {
+		sysBlocks[i].CacheCtrl = nil
 	}
 	for i := range messages {
 		for j := range messages[i].Content {
@@ -30,8 +108,11 @@ func applyToolCachePlan(plan *llm.CachePlan, system any, messages []messageParam
 	for i := range tools {
 		tools[i].CacheCtrl = nil
 	}
-	for _, directive := range plan.Directives {
-		tools[directive.Target.ToolIndex].CacheCtrl = &cacheControl{Type: "ephemeral", TTL: directive.TTL}
+	for i, directive := range plan.Directives {
+		*destinations[i] = &cacheControl{Type: "ephemeral", TTL: directive.TTL}
+	}
+	if wrapped != nil {
+		*system = wrapped
 	}
 	return nil
 }

--- a/sdk/llm/anthropic/cache_plan_test.go
+++ b/sdk/llm/anthropic/cache_plan_test.go
@@ -12,7 +12,8 @@ func TestToolCacheMappingGuardDoesNotPartiallyRewrite(t *testing.T) {
 	for _, target := range []llm.CacheTarget{{Kind: llm.CacheAfterMessage}, {Kind: llm.CacheAfterToolDefinition, ToolIndex: -1}, {Kind: llm.CacheAfterToolDefinition, ToolIndex: 1}} {
 		tools := []toolParam{{Name: "fixture", CacheCtrl: &cacheControl{Type: "ephemeral"}}}
 		before, _ := json.Marshal(tools)
-		err := applyToolCachePlan(&llm.CachePlan{Directives: []llm.CacheDirective{{Target: target}}}, nil, nil, tools)
+		var system any
+		err := applyCachePlan(&llm.CachePlan{Directives: []llm.CacheDirective{{Target: target}}}, &system, nil, tools, nil)
 		after, _ := json.Marshal(tools)
 		if err == nil || string(before) != string(after) {
 			t.Fatal("invalid mapping changed payload", err)
@@ -23,23 +24,28 @@ func TestToolCacheMappingGuardDoesNotPartiallyRewrite(t *testing.T) {
 		{Directives: []llm.CacheDirective{{Target: llm.CacheTarget{Kind: llm.CacheAfterToolDefinition}, TTL: llm.CacheTTL1Hour}}},
 	} {
 		tools := []toolParam{{CacheCtrl: &cacheControl{Type: "ephemeral"}}}
-		if err := applyToolCachePlan(plan, nil, nil, tools); err == nil || tools[0].CacheCtrl == nil {
+		var system any
+		if err := applyCachePlan(plan, &system, nil, tools, nil); err == nil || tools[0].CacheCtrl == nil {
 			t.Fatal("limit/TTL guard failed")
 		}
 	}
 }
 
 func BenchmarkToolCacheRequestBuilder(b *testing.B) {
-	for _, mode := range []string{"legacy", "explicit"} {
+	for _, mode := range []string{"legacy", "explicit", "message"} {
 		b.Run(mode, func(b *testing.B) {
 			client := &Client{ModelName: "fixture", MaxTokens: 64, MaxCachedToolDefinitions: 1}
 			request := llm.InvokeRequest{Messages: []llm.Message{{Role: llm.RoleSystem, Content: llm.TextContent(strings.Repeat("x", 1024)), Cache: true}, {Role: llm.RoleUser, Content: llm.TextContent("hello"), Cache: true}}, Tools: []llm.ToolDefinition{{Name: "first"}, {Name: "second"}}}
-			if mode == "explicit" {
+			if mode != "legacy" {
 				view, err := llm.NewCacheTargetView(request)
 				if err != nil {
 					b.Fatal(err)
 				}
-				request.CachePlan, err = view.Bind([]llm.CacheDirective{{Target: llm.CacheTarget{Kind: llm.CacheAfterToolDefinition}, Policy: llm.CacheRequired, TTL: llm.CacheTTL5Minutes}})
+				target := llm.CacheTarget{Kind: llm.CacheAfterToolDefinition}
+				if mode == "message" {
+					target = llm.CacheTarget{Kind: llm.CacheAfterMessage, MessageIndex: 1}
+				}
+				request.CachePlan, err = view.Bind([]llm.CacheDirective{{Target: target, Policy: llm.CacheRequired, TTL: llm.CacheTTL5Minutes}})
 				if err != nil {
 					b.Fatal(err)
 				}
@@ -52,5 +58,20 @@ func BenchmarkToolCacheRequestBuilder(b *testing.B) {
 				}
 			}
 		})
+	}
+}
+
+func TestMessageMappingGuardDoesNotPartiallyWrapSystem(t *testing.T) {
+	var system any = "original\n\ntext"
+	plan := &llm.CachePlan{Directives: []llm.CacheDirective{
+		{Target: llm.CacheTarget{Kind: llm.CacheAfterMessage}},
+		{Target: llm.CacheTarget{Kind: llm.CacheAfterToolDefinition, ToolIndex: 99}},
+	}}
+	locations := []messageCacheLocation{{system: true, plain: true, eligible: true}}
+	if err := applyCachePlan(plan, &system, nil, nil, locations); err == nil {
+		t.Fatal("invalid second destination accepted")
+	}
+	if system != "original\n\ntext" {
+		t.Fatal("failed mapping partially rewrote system")
 	}
 }

--- a/sdk/llm/anthropic/client.go
+++ b/sdk/llm/anthropic/client.go
@@ -74,10 +74,10 @@ func (c *Client) warnf(format string, args ...any) {
 func (c *Client) Provider() string { return "anthropic" }
 
 // PromptCacheCapabilities reports implemented explicit mappings, not a promise
-// of endpoint/model acceptance or a cache hit. Message/block and 1h TTL mapping
-// are deliberately not advertised by this first tool-definition slice.
+// of endpoint/model acceptance or a cache hit. Request-local eligibility further
+// restricts message boundaries. Content-block and 1h mapping remain unsupported.
 func (c *Client) PromptCacheCapabilities() llm.PromptCacheCapabilities {
-	return llm.PromptCacheCapabilities{ExplicitToolDefinition: true, SupportedTTLs: []llm.CacheTTL{llm.CacheTTL5Minutes}, MaxBreakpoints: 4, UsageTelemetry: true}
+	return llm.PromptCacheCapabilities{ExplicitMessageBoundary: true, ExplicitToolDefinition: true, SupportedTTLs: []llm.CacheTTL{llm.CacheTTL5Minutes}, MaxBreakpoints: 4, UsageTelemetry: true}
 }
 
 func (c *Client) Model() string { return c.ModelName }
@@ -1162,7 +1162,16 @@ func (c *Client) buildRequestWithThinking(req llm.InvokeRequest, thinkingConfig 
 		maxTokens = 8192
 	}
 
-	sys, msgs, err := serializeMessagesWithWarning(req.Messages, c.warnf)
+	var locations []messageCacheLocation
+	if req.CachePlan != nil {
+		for _, d := range req.CachePlan.Directives {
+			if d.Target.Kind == llm.CacheAfterMessage {
+				locations = make([]messageCacheLocation, len(req.Messages))
+				break
+			}
+		}
+	}
+	sys, msgs, err := serializeMessagesWithLocations(req.Messages, c.warnf, locations)
 	if err != nil {
 		return nil, err
 	}
@@ -1172,7 +1181,7 @@ func (c *Client) buildRequestWithThinking(req llm.InvokeRequest, thinkingConfig 
 		tools = serializeTools(req.Tools, c.MaxCachedToolDefinitions)
 	}
 	if req.CachePlan != nil && len(req.CachePlan.Directives) > 0 {
-		if err := applyToolCachePlan(req.CachePlan, sys, msgs, tools); err != nil {
+		if err := applyCachePlan(req.CachePlan, &sys, msgs, tools, locations); err != nil {
 			return nil, err
 		}
 	}
@@ -1293,28 +1302,45 @@ func serializeMessages(in []llm.Message) (system any, out []messageParam, err er
 }
 
 func serializeMessagesWithWarning(in []llm.Message, warnf func(string, ...any)) (system any, out []messageParam, err error) {
+	return serializeMessagesWithLocations(in, warnf, nil)
+}
+
+func serializeMessagesWithLocations(in []llm.Message, warnf func(string, ...any), locations []messageCacheLocation) (system any, out []messageParam, err error) {
 	if err := validateAnthropicToolHistory(in); err != nil {
 		return nil, nil, err
 	}
 
 	var sysBlocks []contentBlockParam
+	record := func(index int, location messageCacheLocation) {
+		if locations != nil {
+			locations[index] = location
+		}
+	}
 
 	for i := 0; i < len(in); i++ {
 		m := in[i]
 		switch m.Role {
 		case llm.RoleSystem:
+			start := len(sysBlocks)
+			cacheable := false
 			if strings.TrimSpace(m.Content.Text) != "" {
 				blk := contentBlockParam{Type: "text", Text: m.Content.Text}
 				if m.Cache {
 					blk.CacheCtrl = &cacheControl{Type: "ephemeral"}
 				}
 				sysBlocks = append(sysBlocks, blk)
+				cacheable = true
 			}
 			for _, b := range m.Content.Blocks {
 				if llm.IsProviderStateBlock(b) {
 					continue
 				}
-				sysBlocks = append(sysBlocks, toAnthropicBlock(b, m.Cache))
+				block := toAnthropicBlock(b, m.Cache)
+				sysBlocks = append(sysBlocks, block)
+				cacheable = cacheableContentBoundary(b, block) && block.Type == "text"
+			}
+			if len(sysBlocks) > start {
+				record(i, messageCacheLocation{system: true, block: len(sysBlocks) - 1, eligible: cacheable})
 			}
 		case llm.RoleTool:
 			// Anthropic requires every tool_result for one assistant turn to be
@@ -1324,16 +1350,18 @@ func serializeMessagesWithWarning(in []llm.Message, warnf func(string, ...any)) 
 			j := i
 			for j < len(in) && in[j].Role == llm.RoleTool {
 				results = append(results, toAnthropicToolResultBlock(in[j], warnf))
+				record(j, messageCacheLocation{message: len(out), block: len(results) - 1, eligible: true})
 				j++
 			}
 			i = j - 1
 			out = append(out, messageParam{Role: "user", Content: results})
 		default:
-			mp, e := toAnthropicMessageWithWarning(m, warnf)
+			mp, cacheable, e := toAnthropicMessageForCache(m, warnf)
 			if e != nil {
 				return nil, nil, e
 			}
 			if mp != nil {
+				record(i, messageCacheLocation{message: len(out), block: len(mp.Content) - 1, eligible: cacheable})
 				out = append(out, *mp)
 			}
 		}
@@ -1342,6 +1370,14 @@ func serializeMessagesWithWarning(in []llm.Message, warnf func(string, ...any)) 
 	if len(sysBlocks) > 0 {
 		if text, ok := joinPlainSystemText(sysBlocks); ok {
 			system = text
+			// A collapsed string has one provable endpoint. Do not split or
+			// reconstruct earlier message boundaries just to insert cache markers.
+			for i := range locations {
+				if locations[i].system {
+					locations[i].eligible = locations[i].eligible && locations[i].block == len(sysBlocks)-1
+					locations[i].plain, locations[i].block = true, 0
+				}
+			}
 		} else {
 			// Use structured system blocks when we need cache_control or non-text blocks.
 			system = sysBlocks
@@ -1430,25 +1466,34 @@ func toAnthropicMessage(m llm.Message) (*messageParam, error) {
 }
 
 func toAnthropicMessageWithWarning(m llm.Message, warnf func(string, ...any)) (*messageParam, error) {
+	message, _, err := toAnthropicMessageForCache(m, warnf)
+	return message, err
+}
+
+func toAnthropicMessageForCache(m llm.Message, warnf func(string, ...any)) (*messageParam, bool, error) {
 	if m.Role == llm.RoleTool {
 		// Anthropic expects tool results as role=user with tool_result blocks.
-		return &messageParam{Role: "user", Content: []contentBlockParam{toAnthropicToolResultBlock(m, warnf)}}, nil
+		return &messageParam{Role: "user", Content: []contentBlockParam{toAnthropicToolResultBlock(m, warnf)}}, true, nil
 	}
 
 	role := string(m.Role)
 	if role != "user" && role != "assistant" {
-		return nil, nil
+		return nil, false, nil
 	}
 
 	blocks := []contentBlockParam{}
+	cacheable := false
 	if strings.TrimSpace(m.Content.Text) != "" {
 		blocks = append(blocks, contentBlockParam{Type: "text", Text: m.Content.Text})
+		cacheable = true
 	}
 	for _, b := range m.Content.Blocks {
 		if llm.IsProviderStateBlock(b) {
 			continue
 		}
-		blocks = append(blocks, toAnthropicBlock(b, false))
+		block := toAnthropicBlock(b, false)
+		blocks = append(blocks, block)
+		cacheable = cacheableContentBoundary(b, block) && (block.Type != "image" || m.Role == llm.RoleUser)
 	}
 
 	if m.Role == llm.RoleAssistant && len(m.ToolCalls) > 0 {
@@ -1472,12 +1517,13 @@ func toAnthropicMessageWithWarning(m llm.Message, warnf func(string, ...any)) (*
 				Name:  tc.Function.Name,
 				Input: input,
 			})
+			cacheable = true
 		}
 	}
 
 	if len(blocks) == 0 {
 		// Anthropic rejects empty messages; omit them.
-		return nil, nil
+		return nil, false, nil
 	}
 	if m.Cache {
 		// cache_control is a block-level breakpoint: mark only the final block
@@ -1485,7 +1531,7 @@ func toAnthropicMessageWithWarning(m llm.Message, warnf func(string, ...any)) (*
 		// turns whose last block is a tool_use still advance the prefix.
 		blocks[len(blocks)-1].CacheCtrl = &cacheControl{Type: "ephemeral"}
 	}
-	return &messageParam{Role: role, Content: blocks}, nil
+	return &messageParam{Role: role, Content: blocks}, cacheable, nil
 }
 
 // toAnthropicToolResultBlock maps a tool message onto a single tool_result

--- a/sdk/llm/anthropic_message_cache_test.go
+++ b/sdk/llm/anthropic_message_cache_test.go
@@ -235,3 +235,54 @@ func TestAnthropicMessageCacheImageRoleEligibility(t *testing.T) {
 		}
 	}
 }
+
+func TestAnthropicMessageCacheEachMergedResult(t *testing.T) {
+	for _, stream := range []bool{false, true} {
+		for _, reorder := range []bool{false, true} {
+			for _, selected := range [][]int{{3}, {4}, {3, 4}} {
+				t.Run(fmt.Sprintf("%v/reorder=%v/selected=%v", stream, reorder, selected), func(t *testing.T) {
+					request := toolCacheRequest()
+					if reorder {
+						request.Messages[3], request.Messages[4] = request.Messages[4], request.Messages[3]
+					}
+					var directives []llm.CacheDirective
+					for _, index := range selected {
+						directives = append(directives, messageDirective(index, llm.CacheRequired))
+					}
+					bindToolCache(t, &request, directives)
+					var calls atomic.Int32
+					model := admissionModel("anthropic", func(r *http.Request) (*http.Response, error) {
+						calls.Add(1)
+						data, _ := io.ReadAll(r.Body)
+						var payload map[string]any
+						if err := json.Unmarshal(data, &payload); err != nil {
+							return nil, err
+						}
+						results := payload["messages"].([]any)[2].(map[string]any)["content"].([]any)
+						if len(results) != 2 {
+							t.Error("tool result group changed")
+							return nil, fmt.Errorf("fixture group mismatch")
+						}
+						for offset, raw := range results {
+							block := raw.(map[string]any)
+							wantCache := false
+							for _, index := range selected {
+								if index == 3+offset {
+									wantCache = true
+								}
+							}
+							if block["tool_use_id"] != request.Messages[3+offset].ToolCallID || (block["cache_control"] != nil) != wantCache {
+								t.Errorf("source %d cache/id mismatch: %#v", 3+offset, block)
+							}
+						}
+						return &http.Response{StatusCode: 401, Header: make(http.Header), Body: io.NopCloser(strings.NewReader(`{"error":{"message":"fixture"}}`)), Request: r}, nil
+					}, func(string, ...any) {})
+					_, _ = callAdmissionModel(context.Background(), model, request, stream)
+					if calls.Load() != 1 {
+						t.Fatal("mapped request not sent")
+					}
+				})
+			}
+		}
+	}
+}

--- a/sdk/llm/anthropic_message_cache_test.go
+++ b/sdk/llm/anthropic_message_cache_test.go
@@ -1,0 +1,237 @@
+package llm_test
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"reflect"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/timwhitez/agent-sdk-golang/sdk/llm"
+)
+
+func messageDirective(index int, policy llm.CacheDirectivePolicy) llm.CacheDirective {
+	return llm.CacheDirective{Target: llm.CacheTarget{Kind: llm.CacheAfterMessage, MessageIndex: index}, Policy: policy}
+}
+
+func TestAnthropicMessageCacheJointWireGolden(t *testing.T) {
+	for _, stream := range []bool{false, true} {
+		t.Run(fmt.Sprint(stream), func(t *testing.T) {
+			var baseline map[string]any
+			for _, planned := range []bool{false, true} {
+				request := toolCacheRequest()
+				if planned {
+					bindToolCache(t, &request, []llm.CacheDirective{messageDirective(0, llm.CacheRequired), messageDirective(2, llm.CacheRequired), messageDirective(3, llm.CacheRequired), toolDirective(1, llm.CacheRequired, llm.CacheTTL5Minutes)})
+				}
+				before, err := llm.CloneInvokeRequest(request)
+				if err != nil {
+					t.Fatal(err)
+				}
+				var payload map[string]any
+				var calls atomic.Int32
+				model := admissionModel("anthropic", func(r *http.Request) (*http.Response, error) {
+					calls.Add(1)
+					data, err := io.ReadAll(r.Body)
+					if err != nil {
+						return nil, err
+					}
+					if err := json.Unmarshal(data, &payload); err != nil {
+						return nil, err
+					}
+					body := admissionSuccess["anthropic"]
+					if stream {
+						body = admissionSSE("anthropic")
+					}
+					return &http.Response{StatusCode: 200, Header: make(http.Header), Body: io.NopCloser(strings.NewReader(body)), Request: r}, nil
+				}, func(string, ...any) {})
+				if _, err := callAdmissionModel(context.Background(), model, request, stream); err != nil || calls.Load() != 1 {
+					t.Fatal(err, calls.Load())
+				}
+				if !reflect.DeepEqual(request, before) {
+					t.Fatal("message mapping mutated source")
+				}
+				if !planned {
+					baseline = payload
+					continue
+				}
+				clearWireCache(baseline)
+				cache := map[string]any{"type": "ephemeral"}
+				baseline["system"].([]any)[1].(map[string]any)["cache_control"] = cache
+				messages := baseline["messages"].([]any)
+				messages[1].(map[string]any)["content"].([]any)[1].(map[string]any)["cache_control"] = cache
+				messages[2].(map[string]any)["content"].([]any)[0].(map[string]any)["cache_control"] = cache
+				baseline["tools"].([]any)[1].(map[string]any)["cache_control"] = map[string]any{"type": "ephemeral", "ttl": "5m"}
+				if !reflect.DeepEqual(payload, baseline) {
+					t.Fatalf("source-to-wire joint golden mismatch: %#v", payload)
+				}
+			}
+		})
+	}
+}
+
+func TestAnthropicMessageCacheRejectsUnmappableBeforeCapacity(t *testing.T) {
+	for _, block := range []llm.ContentBlock{{Type: "thinking", Thinking: "private-thinking"}, {Type: "redacted_thinking", Data: "private-redacted"}, {Type: "unknown", Text: "private-unknown"}, {Type: "text"}, {Type: "document", Source: &llm.DocSrc{Data: "private-data", MediaType: "application/pdf"}}, {Type: "image_url"}} {
+		for _, stream := range []bool{false, true} {
+			t.Run(fmt.Sprintf("%s/%v", block.Type, stream), func(t *testing.T) {
+				request := llm.InvokeRequest{Messages: []llm.Message{{Role: llm.RoleUser, Content: llm.Content{Text: "visible", Blocks: []llm.ContentBlock{block}}}}}
+				bindToolCache(t, &request, []llm.CacheDirective{messageDirective(0, llm.CacheRequired)})
+				var calls atomic.Int32
+				model := admissionModel("anthropic", func(*http.Request) (*http.Response, error) { calls.Add(1); return nil, fmt.Errorf("must not send") }, func(string, ...any) { t.Error("rejected mapping warned as accepted") })
+				_, err := callAdmissionModel(context.Background(), model, request, stream)
+				assertCacheViewError(t, err, "unmappable_target", 0)
+				if calls.Load() != 0 {
+					t.Fatal("unmappable boundary reached HTTP")
+				}
+			})
+		}
+	}
+	for _, stream := range []bool{false, true} {
+		t.Run(fmt.Sprintf("capacity/%v", stream), func(t *testing.T) {
+			request := llm.InvokeRequest{Messages: []llm.Message{{Role: llm.RoleUser, Content: llm.Content{Text: "visible", Blocks: []llm.ContentBlock{{Type: "unknown"}}}}}}
+			directives := []llm.CacheDirective{messageDirective(0, llm.CacheBestEffort)}
+			for i := 1; i < 5; i++ {
+				request.Messages = append(request.Messages, llm.Message{Role: llm.RoleUser, Content: llm.TextContent(fmt.Sprint(i))})
+				directives = append(directives, messageDirective(i, llm.CacheBestEffort))
+			}
+			directives[4].Policy = llm.CacheRequired
+			bindToolCache(t, &request, directives)
+			var got []int
+			model := admissionModel("anthropic", func(r *http.Request) (*http.Response, error) {
+				var payload map[string]any
+				data, _ := io.ReadAll(r.Body)
+				if err := json.Unmarshal(data, &payload); err != nil {
+					return nil, err
+				}
+				for i, m := range payload["messages"].([]any) {
+					blocks := m.(map[string]any)["content"].([]any)
+					if blocks[len(blocks)-1].(map[string]any)["cache_control"] != nil {
+						got = append(got, i)
+					}
+				}
+				return &http.Response{StatusCode: 401, Header: make(http.Header), Body: io.NopCloser(strings.NewReader(`{"error":{"message":"fixture"}}`)), Request: r}, nil
+			}, func(string, ...any) {})
+			_, _ = callAdmissionModel(context.Background(), model, request, stream)
+			if !reflect.DeepEqual(got, []int{1, 2, 3, 4}) {
+				t.Fatalf("unmappable target consumed capacity: %v", got)
+			}
+		})
+	}
+}
+
+func TestAnthropicMessageCacheCollapsedSystemBoundary(t *testing.T) {
+	for _, stream := range []bool{false, true} {
+		for _, early := range []bool{false, true} {
+			t.Run(fmt.Sprintf("%v/early=%v", stream, early), func(t *testing.T) {
+				request := llm.InvokeRequest{Messages: []llm.Message{{Role: llm.RoleSystem, Content: llm.TextContent("first")}, {Role: llm.RoleSystem, Content: llm.Content{Text: "second", Blocks: []llm.ContentBlock{{Type: "text", Text: "third"}}}}, {Role: llm.RoleUser, Content: llm.TextContent("hello")}}}
+				index := 1
+				if early {
+					index = 0
+				}
+				bindToolCache(t, &request, []llm.CacheDirective{messageDirective(index, llm.CacheRequired)})
+				var calls atomic.Int32
+				model := admissionModel("anthropic", func(r *http.Request) (*http.Response, error) {
+					calls.Add(1)
+					var payload map[string]any
+					data, _ := io.ReadAll(r.Body)
+					if err := json.Unmarshal(data, &payload); err != nil {
+						return nil, err
+					}
+					want := []any{map[string]any{"type": "text", "text": "first\n\nsecond\n\nthird", "cache_control": map[string]any{"type": "ephemeral"}}}
+					if !reflect.DeepEqual(payload["system"], want) {
+						t.Error("collapsed system string was split or rewritten")
+					}
+					return &http.Response{StatusCode: 401, Header: make(http.Header), Body: io.NopCloser(strings.NewReader(`{"error":{"message":"fixture"}}`)), Request: r}, nil
+				}, func(string, ...any) {})
+				_, err := callAdmissionModel(context.Background(), model, request, stream)
+				if early {
+					assertCacheViewError(t, err, "unmappable_target", 0)
+					if calls.Load() != 0 {
+						t.Fatal("invented earlier collapsed boundary")
+					}
+				} else if calls.Load() != 1 {
+					t.Fatal("whole collapsed boundary not sent", err)
+				}
+			})
+		}
+	}
+}
+
+func TestAnthropicMessageCacheOpaqueAndReorderedResults(t *testing.T) {
+	for _, stream := range []bool{false, true} {
+		t.Run(fmt.Sprint(stream), func(t *testing.T) {
+			request := toolCacheRequest()
+			request.Messages[3], request.Messages[4] = request.Messages[4], request.Messages[3]
+			var err error
+			request.Messages[1].Content, err = llm.WithProviderState(request.Messages[1].Content, []llm.ProviderState{{Provider: "fixture", Kind: "opaque", Data: json.RawMessage(`{"secret":"private-opaque"}`)}})
+			if err != nil {
+				t.Fatal(err)
+			}
+			bindToolCache(t, &request, []llm.CacheDirective{messageDirective(1, llm.CacheRequired), messageDirective(3, llm.CacheRequired)})
+			var calls atomic.Int32
+			model := admissionModel("anthropic", func(r *http.Request) (*http.Response, error) {
+				calls.Add(1)
+				data, _ := io.ReadAll(r.Body)
+				if strings.Contains(string(data), "private-opaque") {
+					t.Error("opaque data entered wire")
+				}
+				var payload map[string]any
+				if err := json.Unmarshal(data, &payload); err != nil {
+					return nil, err
+				}
+				messages := payload["messages"].([]any)
+				if messages[0].(map[string]any)["content"].([]any)[0].(map[string]any)["cache_control"] == nil {
+					t.Error("opaque block shifted visible boundary")
+				}
+				results := messages[2].(map[string]any)["content"].([]any)
+				if results[0].(map[string]any)["tool_use_id"] != "b" || results[0].(map[string]any)["cache_control"] == nil || results[1].(map[string]any)["cache_control"] != nil {
+					t.Error("result reordering changed source association")
+				}
+				return &http.Response{StatusCode: 401, Header: make(http.Header), Body: io.NopCloser(strings.NewReader(`{"error":{"message":"fixture"}}`)), Request: r}, nil
+			}, func(string, ...any) {})
+			_, _ = callAdmissionModel(context.Background(), model, request, stream)
+			if calls.Load() != 1 {
+				t.Fatal("mapped request not sent")
+			}
+		})
+	}
+}
+
+func TestAnthropicMessageCacheImageRoleEligibility(t *testing.T) {
+	for _, role := range []llm.Role{llm.RoleSystem, llm.RoleUser, llm.RoleAssistant} {
+		for _, stream := range []bool{false, true} {
+			t.Run(fmt.Sprintf("%s/%v", role, stream), func(t *testing.T) {
+				request := llm.InvokeRequest{Messages: []llm.Message{{Role: role, Content: llm.Content{Text: "visible", Blocks: []llm.ContentBlock{{Type: "image_url", ImageURL: &llm.ImageURL{URL: "https://fixture.invalid/image.png"}}}}}}}
+				bindToolCache(t, &request, []llm.CacheDirective{messageDirective(0, llm.CacheRequired)})
+				var calls atomic.Int32
+				model := admissionModel("anthropic", func(r *http.Request) (*http.Response, error) {
+					calls.Add(1)
+					var payload map[string]any
+					data, _ := io.ReadAll(r.Body)
+					if err := json.Unmarshal(data, &payload); err != nil {
+						return nil, err
+					}
+					blocks := payload["messages"].([]any)[0].(map[string]any)["content"].([]any)
+					if blocks[1].(map[string]any)["type"] != "image" || blocks[1].(map[string]any)["cache_control"] == nil || blocks[0].(map[string]any)["cache_control"] != nil {
+						t.Error("image endpoint mapping")
+					}
+					return &http.Response{StatusCode: 401, Header: make(http.Header), Body: io.NopCloser(strings.NewReader(`{"error":{"message":"fixture"}}`)), Request: r}, nil
+				}, func(string, ...any) {})
+				_, err := callAdmissionModel(context.Background(), model, request, stream)
+				if role == llm.RoleUser {
+					if calls.Load() != 1 {
+						t.Fatal("user image boundary not mapped", err)
+					}
+				} else {
+					assertCacheViewError(t, err, "unmappable_target", 0)
+					if calls.Load() != 0 {
+						t.Fatal("unsupported role image reached HTTP")
+					}
+				}
+			})
+		}
+	}
+}

--- a/sdk/llm/anthropic_tool_cache_wire_test.go
+++ b/sdk/llm/anthropic_tool_cache_wire_test.go
@@ -217,7 +217,7 @@ func TestCacheAdmissionMixedSummaryDoesNotMislabelAccepted(t *testing.T) {
 	var directives []llm.CacheDirective
 	for i := 0; i < 32; i++ {
 		request.Messages = append(request.Messages, llm.Message{Role: llm.RoleUser, Content: llm.TextContent("private-text")})
-		directives = append(directives, llm.CacheDirective{Target: llm.CacheTarget{Kind: llm.CacheAfterMessage, MessageIndex: i}, Policy: llm.CacheBestEffort})
+		directives = append(directives, llm.CacheDirective{Target: llm.CacheTarget{Kind: llm.CacheAfterMessageBlock, MessageIndex: i}, Policy: llm.CacheBestEffort})
 	}
 	directives = append(directives, toolDirective(0, llm.CacheRequired, ""))
 	bindToolCache(t, &request, directives)

--- a/sdk/llm/cache_admission_test.go
+++ b/sdk/llm/cache_admission_test.go
@@ -47,7 +47,7 @@ func admissionRequest(t *testing.T, policy llm.CacheDirectivePolicy) llm.InvokeR
 	if err != nil {
 		t.Fatal(err)
 	}
-	request.CachePlan, err = view.Bind([]llm.CacheDirective{{Target: llm.CacheTarget{Kind: llm.CacheAfterMessage, MessageIndex: 1}, Policy: policy}})
+	request.CachePlan, err = view.Bind([]llm.CacheDirective{{Target: llm.CacheTarget{Kind: llm.CacheAfterMessageBlock, MessageIndex: 1}, Policy: policy}})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/sdk/llm/cache_boundary_wire_test.go
+++ b/sdk/llm/cache_boundary_wire_test.go
@@ -79,7 +79,7 @@ func TestAnthropicLegacyCacheBoundaryWireGolden(t *testing.T) {
 				var baseline []byte
 				for _, plan := range []*llm.CachePlan{nil, {Directives: []llm.CacheDirective{}}, {
 					SchemaVersion: llm.CachePlanSchemaVersion,
-					Directives:    []llm.CacheDirective{{Target: llm.CacheTarget{Kind: llm.CacheAfterMessage}, Policy: llm.CacheBestEffort}},
+					Directives:    []llm.CacheDirective{{Target: llm.CacheTarget{Kind: llm.CacheAfterMessageBlock}, Policy: llm.CacheBestEffort}},
 				}} {
 					request := llm.InvokeRequest{Messages: llm.CloneMessages(fixture.messages), Tools: tools, CachePlan: plan}
 					if plan != nil && len(plan.Directives) != 0 {

--- a/sdk/llm/cache_decision.go
+++ b/sdk/llm/cache_decision.go
@@ -4,8 +4,9 @@ import "reflect"
 
 // CacheDirectiveDecision is bounded, content-free metadata for one original
 // directive. Accepted means eligible under reported capabilities, not mapped,
-// sent, or cached. Reason is accepted, unsupported_target, unsupported_ttl, or
-// breakpoint_limit. No content, names, IDs, hashes or Provider strings are kept.
+// sent, or cached. Reason is accepted, unsupported_target, unsupported_ttl,
+// unmappable_target, or breakpoint_limit. No content, names, IDs, hashes or
+// Provider strings are kept.
 type CacheDirectiveDecision struct {
 	DirectiveIndex int
 	Accepted       bool
@@ -45,6 +46,7 @@ func (view *CacheTargetView) Decide(request InvokeRequest, plan *CachePlan, mode
 	if len(plan.Directives) == 0 {
 		return result, nil
 	}
+	snapshot := view.request
 	value := reflect.ValueOf(model)
 	if !value.IsValid() || (value.Kind() == reflect.Pointer && value.IsNil()) {
 		return nil, cachePlanError("missing_model", -1)
@@ -60,6 +62,23 @@ func (view *CacheTargetView) Decide(request InvokeRequest, plan *CachePlan, mode
 		if ttl != CacheTTLProviderDefault && ttl != CacheTTL5Minutes && ttl != CacheTTL1Hour {
 			return nil, cachePlanError("invalid_capabilities", -1)
 		}
+	}
+	var eligible []bool
+	if mapper, ok := model.(PromptCacheTargetEligibilityProvider); ok {
+		// Do not expose the retained snapshot or caller graph to a provider hook.
+		mappingRequest, err := CloneInvokeRequest(*snapshot)
+		if err != nil {
+			return nil, cachePlanError("uncloneable_request", -1)
+		}
+		targets := make([]CacheTarget, len(plan.Directives))
+		for i, directive := range plan.Directives {
+			targets[i] = directive.Target
+		}
+		mapping := mapper.PromptCacheTargetEligibility(mappingRequest, targets)
+		if len(mapping) != len(plan.Directives) {
+			return nil, cachePlanError("invalid_capabilities", -1)
+		}
+		eligible = append([]bool(nil), mapping...)
 	}
 	result.Directives = make([]CacheDirectiveDecision, len(plan.Directives))
 	required := 0
@@ -87,6 +106,9 @@ func (view *CacheTargetView) Decide(request InvokeRequest, plan *CachePlan, mode
 			if !ttlSupported {
 				reason = "unsupported_ttl"
 			}
+		}
+		if reason == "accepted" && eligible != nil && !eligible[i] {
+			reason = "unmappable_target"
 		}
 		if directive.Policy == CacheRequired {
 			if reason != "accepted" {

--- a/sdk/llm/cache_decision_test.go
+++ b/sdk/llm/cache_decision_test.go
@@ -170,6 +170,7 @@ func TestCacheDecisionBuiltinCapabilitiesAreConservative(t *testing.T) {
 		provider, ok := model.(llm.PromptCacheCapabilityProvider)
 		want := llm.PromptCacheCapabilities{UsageTelemetry: true}
 		if _, anthropicClient := model.(*anthropic.Client); anthropicClient {
+			want.ExplicitMessageBoundary = true
 			want.ExplicitToolDefinition, want.MaxBreakpoints = true, 4
 			want.SupportedTTLs = []llm.CacheTTL{llm.CacheTTL5Minutes}
 		}
@@ -177,6 +178,9 @@ func TestCacheDecisionBuiltinCapabilitiesAreConservative(t *testing.T) {
 			t.Fatal("builtin claims unimplemented explicit control")
 		}
 		request, view, plan := cacheDecisionFixture(t)
+		for i := range plan.Directives {
+			plan.Directives[i].Target.Kind = llm.CacheAfterMessageBlock
+		}
 		_, err := view.Decide(request, plan, model)
 		assertCacheViewError(t, err, "unsupported_target", 2)
 		plan.Directives[2].Policy = llm.CacheBestEffort
@@ -222,5 +226,76 @@ func BenchmarkCacheDecision(b *testing.B) {
 		if _, err := view.Decide(request, plan, model); err != nil {
 			b.Fatal(err)
 		}
+	}
+}
+
+type cacheEligibilityModel struct {
+	cacheDecisionModel
+	hook func(llm.InvokeRequest, []llm.CacheTarget) []bool
+}
+
+func (m *cacheEligibilityModel) PromptCacheTargetEligibility(request llm.InvokeRequest, targets []llm.CacheTarget) []bool {
+	return m.hook(request, targets)
+}
+
+func TestCacheEligibilitySnapshotOwnershipAndPreallocation(t *testing.T) {
+	request, view, plan := cacheDecisionFixture(t)
+	before, err := llm.CloneInvokeRequest(request)
+	if err != nil {
+		t.Fatal(err)
+	}
+	mask := []bool{false, true, true}
+	model := &cacheEligibilityModel{cacheDecisionModel: cacheDecisionModel{caps: llm.PromptCacheCapabilities{ExplicitMessageBoundary: true, MaxBreakpoints: 2}}}
+	model.hook = func(copy llm.InvokeRequest, targets []llm.CacheTarget) []bool {
+		if !reflect.DeepEqual(copy, before) {
+			t.Error("eligibility did not receive validated original snapshot")
+		}
+		copy.Messages[0].Content.Text = "private-mutated"
+		copy.Tools[0].Name = "private-mutated"
+		targets[1].MessageIndex = 99
+		return mask
+	}
+	result, err := view.Decide(request, plan, model)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Directives[0].Reason != "unmappable_target" || len(result.Plan.Directives) != 2 || result.Plan.Directives[0].Target.MessageIndex != 1 || result.Plan.Directives[1].Target.MessageIndex != 2 {
+		t.Fatal("eligibility was applied after capacity or exposed target aliases")
+	}
+	mask[1] = false
+	if !result.Directives[1].Accepted || !reflect.DeepEqual(request, before) {
+		t.Fatal("eligibility exposed caller or result aliases")
+	}
+	if err := view.Validate(request, plan); err != nil {
+		t.Fatal("provider mutated retained snapshot", err)
+	}
+	changed, _ := llm.CloneInvokeRequest(request)
+	changed.Messages[0].Content.Text = "new-view"
+	fresh, err := llm.NewCacheTargetView(changed)
+	if err != nil {
+		t.Fatal(err)
+	}
+	model.onRead = func() { *view = *fresh }
+	mask[1] = true
+	if _, err := view.Decide(request, plan, model); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestCacheEligibilityMalformedAndStale(t *testing.T) {
+	request, view, plan := cacheDecisionFixture(t)
+	model := &cacheEligibilityModel{cacheDecisionModel: cacheDecisionModel{caps: llm.PromptCacheCapabilities{ExplicitMessageBoundary: true, MaxBreakpoints: 4}}}
+	var calls int
+	model.hook = func(llm.InvokeRequest, []llm.CacheTarget) []bool { calls++; return []bool{true} }
+	result, err := view.Decide(request, plan, model)
+	assertCacheViewError(t, err, "invalid_capabilities", -1)
+	if result != nil || calls != 1 {
+		t.Fatal("malformed hook produced partial result")
+	}
+	request.Messages[0].Content.Text = "changed"
+	_, err = view.Decide(request, plan, model)
+	assertCacheViewError(t, err, "stale_request", -1)
+	if calls != 1 {
+		t.Fatal("stale request reached mapper")
 	}
 }

--- a/sdk/llm/cache_plan.go
+++ b/sdk/llm/cache_plan.go
@@ -106,3 +106,12 @@ func (capabilities PromptCacheCapabilities) Clone() PromptCacheCapabilities {
 type PromptCacheCapabilityProvider interface {
 	PromptCacheCapabilities() PromptCacheCapabilities
 }
+
+// PromptCacheTargetEligibilityProvider optionally refines global capabilities
+// using the concrete serializer. Results correspond to targets in input order;
+// false means the exact boundary cannot be mapped. Decide supplies owned copies
+// and checks eligibility before reserving capacity. No network or diagnostics
+// should be emitted by this request-local preflight.
+type PromptCacheTargetEligibilityProvider interface {
+	PromptCacheTargetEligibility(InvokeRequest, []CacheTarget) []bool
+}

--- a/sdk/llm/cache_plan_wire_test.go
+++ b/sdk/llm/cache_plan_wire_test.go
@@ -27,7 +27,7 @@ func TestCachePlanAttachmentPreservesLegacyWireGolden(t *testing.T) {
 				var baseline []byte
 				for _, plan := range []*llm.CachePlan{nil, {Directives: []llm.CacheDirective{}}, {
 					SchemaVersion: llm.CachePlanSchemaVersion,
-					Directives:    []llm.CacheDirective{{Target: llm.CacheTarget{Kind: llm.CacheAfterMessage}, Policy: llm.CacheBestEffort}},
+					Directives:    []llm.CacheDirective{{Target: llm.CacheTarget{Kind: llm.CacheAfterMessageBlock}, Policy: llm.CacheBestEffort}},
 				}} {
 					calls := 0
 					var payload []byte


### PR DESCRIPTION
## Scope

Related to #89 (multi-phase, remains open). Actual Anthropic Message boundary mapping reuses the existing serializer traversal and before-network admission. No second serializer, execution/event sequence, Prompt builder or hash gate.

The optional batch PromptCacheTargetEligibilityProvider supplies request-local mapping eligibility before capacity allocation. Decide passes owned copies from the validated retained snapshot, validates result length, and never exposes the private binding. Required unmappable targets reject; best-effort unmappable targets do not consume slots.

## Exact boundary contract

- Structured System blocks keep per-source endpoints; assistant final tool-use and each merged Tool Result retain their actual source→wire locations, independent of tool IDs/order guesses.
- A collapsed System string exposes only its last emitted source endpoint. It is wrapped whole with identical text, not split to invent earlier boundaries.
- Hidden/unknown/placeholder/empty trailing blocks are not cache targets. Opaque blocks omitted from wire do not shift endpoints. Supported user images can be endpoints; System/assistant images are not advertised as mappable.
- Destinations all validate before legacy cache controls are cleared or new markers assigned. Exact Tool Definition mapping remains. Content-block targets and1h TTL remain unsupported.
- Eligibility locates boundaries, not complete request/image validity or remote endpoint acceptance/cache hits. Official references: [cache limitations](https://platform.claude.com/docs/en/build-with-claude/prompt-caching), [System TextBlock API](https://platform.claude.com/docs/en/api/messages/create).

## Validation

Focused100 passed. Actual buffered/streamed joint wire golden, each merged result first/second/both before/after reorder, collapsed System success/early rejection, hidden/empty/placeholders zeroI/O, pre-capacity exclusion, opaque omission, image role constraints, hook cloning/invalid length/stale validation, and no partial System wrap are covered. Existing all-skip goldens now use still-unsupported ContentBlock targets; expected legacy bytes remain unchanged.

Review caught a test gap: a mutation setting every merged-result block index to0 survived old first-only tests. Final ca1d701 adds second-only/both/reordered cases; independent mutation re-check required before merge. Production code is unchanged from initial a7759ac.

Author full/vet/LLM-provider-Agent race and independent exact review in progress. Goode preliminary full/vet/5pkg race/actual candidate build and interface/Responses probes passed against runtime-equivalent a775; final candidate binding to be verified explicitly.

Builder-only benchmark medians (3 samples): legacy830.9ns/984B/14alloc, tool917.7ns/1024B/16alloc, message1435ns/1072B/17alloc. Two tools, one one-KiB system block and one user block; excludes preflight eligibility/admission, JSON and network. No end-to-end improvement or cache-hit claim.
