### PR TITLE
fix(agent): bind provider warnings per invocation without shared mutation

### DIFF
--- a/agent_docs/providers.md
+++ b/agent_docs/providers.md
@@ -23,10 +23,13 @@ stream normalization, and response metadata behavior.
   and [tool-definition API](https://platform.claude.com/docs/en/agents-and-tools/tool-use/tool-use-with-prompt-caching).
   Legacy `Message.Cache` behavior is unchanged; do not use the new field as a
   cache-control guarantee. No Agent Config or host plan generator is added.
-  `CachePlan` now includes a private binding. Responses diagnostics use its
-  construction-time `Warningf` (or the default logger), not automatic shared
-  `WarningSinkSetter` mutation during child Agent creation. Configure it before
-  concurrent use. External unkeyed literals need updating;
+  `CachePlan` includes a private binding. Agent/Compaction invocations carry
+  `llm.WithWarningSink` in context; built-in clients capture it in call-local
+  state. Agent.New never mutates a shared model's `WarningSinkSetter`. Direct
+  clients retain their construction-time Warningf/default logger; configure
+  fields/setters before concurrent use. Custom providers must read
+  `llm.WarningSink(ctx, fallback)` to honor invocation routing. External unkeyed
+  literals affected by the earlier CachePlan binding still need updating;
   JSON cannot restore a valid binding. Message/Completion layouts and session
   JSON remain unchanged. No content fingerprints or Git-hash gates are added.
 - Provider-neutral interfaces: `ChatModel`, `StreamingChatModel` (`sdk/llm/model.go:8`, `sdk/llm/model.go:17`)

--- a/sdk/agent/agent.go
+++ b/sdk/agent/agent.go
@@ -394,9 +394,6 @@ func New(cfg Config) (*Agent, error) {
 	if cfg.Deps == nil {
 		cfg.Deps = tools.NewContainer()
 	}
-	if setter, ok := cfg.LLM.(llm.WarningSinkSetter); ok {
-		setter.SetWarningf(cfg.Warningf)
-	}
 
 	ownedTools := make([]tools.Tool, len(cfg.Tools))
 	toolMap := map[string]tools.Tool{}
@@ -2165,6 +2162,7 @@ func (a *Agent) invokeModelCompletionWithSteering(ctx context.Context, model llm
 	if ctx == nil {
 		ctx = context.Background()
 	}
+	ctx = llm.WithWarningSink(ctx, a.warnf)
 	// Last line of defense for the tool_use/tool_result pairing invariant. Any
 	// loop-level defect that leaves a tool_use without its result (or an orphan
 	// result) would otherwise become an unrecoverable provider 400 that replays

--- a/sdk/agent/compaction/service.go
+++ b/sdk/agent/compaction/service.go
@@ -360,6 +360,7 @@ func (s *Service) compactSummary(ctx context.Context, model llm.ChatModel, messa
 		defer cancel()
 	}
 
+	invokeCtx = llm.WithWarningSink(invokeCtx, s.warningf)
 	comp, err := model.Invoke(invokeCtx, llm.InvokeRequest{Messages: prepared})
 	if err != nil {
 		return messages, Result{Compacted: false, Warnings: append(append([]string(nil), ledgerWarnings...), checkpointWarnings...)}, err

--- a/sdk/agent/compaction/warning_context_test.go
+++ b/sdk/agent/compaction/warning_context_test.go
@@ -1,0 +1,48 @@
+package compaction
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/timwhitez/agent-sdk-golang/sdk/llm"
+)
+
+type compactWarningModel struct{}
+
+func (compactWarningModel) Provider() string { return "fixture" }
+func (compactWarningModel) Model() string    { return "fixture" }
+func (compactWarningModel) Invoke(ctx context.Context, _ llm.InvokeRequest) (*llm.Completion, error) {
+	if sink := llm.WarningSink(ctx, nil); sink != nil {
+		sink("compaction fixture")
+	}
+	return nil, errors.New("fixture stop after warning")
+}
+
+func TestCompactionWarningContextUsesServiceScope(t *testing.T) {
+	var outer atomic.Int32
+	ctx := llm.WithWarningSink(context.Background(), func(string, ...any) { outer.Add(1) })
+	var counts [8]atomic.Int32
+	var workers sync.WaitGroup
+	for i := range counts {
+		workers.Add(1)
+		go func(index int) {
+			defer workers.Done()
+			service := NewService(&Config{Warningf: func(string, ...any) { counts[index].Add(1) }})
+			if _, _, err := service.compactSummary(ctx, compactWarningModel{}, []llm.Message{llm.NewUserMessage("fixture")}); err == nil {
+				t.Error("expected fixture stop")
+			}
+		}(i)
+	}
+	workers.Wait()
+	if outer.Load() != 0 {
+		t.Fatal("compaction reused caller's unrelated sink")
+	}
+	for i := range counts {
+		if counts[i].Load() != 1 {
+			t.Fatalf("service%d received %d diagnostics", i, counts[i].Load())
+		}
+	}
+}

--- a/sdk/agent/warning_context_test.go
+++ b/sdk/agent/warning_context_test.go
@@ -1,0 +1,111 @@
+package agent
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/timwhitez/agent-sdk-golang/sdk/llm"
+)
+
+type invocationWarningModel struct {
+	entered atomic.Int32
+	setters atomic.Int32
+	missing atomic.Int32
+	ready   chan struct{}
+}
+
+func (*invocationWarningModel) Provider() string                   { return "fixture" }
+func (*invocationWarningModel) Model() string                      { return "fixture" }
+func (m *invocationWarningModel) SetWarningf(func(string, ...any)) { m.setters.Add(1) }
+func (m *invocationWarningModel) warn(ctx context.Context, request llm.InvokeRequest) error {
+	if m.entered.Add(1) == 8 {
+		close(m.ready)
+	}
+	select {
+	case <-m.ready:
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+	sink := llm.WarningSink(ctx, nil)
+	if sink == nil {
+		m.missing.Add(1)
+	} else {
+		sink("%s", request.Messages[len(request.Messages)-1].Content.PlainText())
+	}
+	return nil
+}
+func (m *invocationWarningModel) Invoke(ctx context.Context, request llm.InvokeRequest) (*llm.Completion, error) {
+	if err := m.warn(ctx, request); err != nil {
+		return nil, err
+	}
+	return &llm.Completion{Content: llm.TextContent("ok"), StopReason: "stop"}, nil
+}
+
+type invocationWarningStreamModel struct{ *invocationWarningModel }
+
+func (m *invocationWarningStreamModel) InvokeStream(ctx context.Context, request llm.InvokeRequest) (<-chan llm.StreamEvent, error) {
+	out := make(chan llm.StreamEvent, 2)
+	go func() {
+		defer close(out)
+		if err := m.warn(ctx, request); err != nil {
+			out <- llm.StreamErrorEvent{Err: err}
+			return
+		}
+		out <- llm.StreamTextDeltaEvent{Delta: "ok"}
+		out <- llm.StreamDoneEvent{StopReason: "stop"}
+	}()
+	return out, nil
+}
+
+func TestSharedModelWarningsBelongToInvokingAgent(t *testing.T) {
+	temporary := t.TempDir()
+	t.Setenv("TMPDIR", temporary)
+	t.Setenv("TMP", temporary)
+	t.Setenv("TEMP", temporary)
+	for _, stream := range []bool{false, true} {
+		t.Run(fmt.Sprint(stream), func(t *testing.T) {
+			base := &invocationWarningModel{ready: make(chan struct{})}
+			var model llm.ChatModel = base
+			if stream {
+				model = &invocationWarningStreamModel{base}
+			}
+			var counts [8]atomic.Int32
+			var workers sync.WaitGroup
+			ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+			defer cancel()
+			for i := range counts {
+				workers.Add(1)
+				go func(index int) {
+					defer workers.Done()
+					label := fmt.Sprintf("agent-%d", index)
+					a, err := New(Config{LLM: model, MaxIterations: 1, Warningf: func(format string, args ...any) {
+						if got := fmt.Sprintf(format, args...); got != label {
+							t.Errorf("sink %s received %s", label, got)
+						}
+						counts[index].Add(1)
+					}})
+					if err != nil {
+						t.Error(err)
+						return
+					}
+					if _, err := a.Query(ctx, label); err != nil {
+						t.Error(err)
+					}
+				}(i)
+			}
+			workers.Wait()
+			if base.setters.Load() != 0 || base.missing.Load() != 0 {
+				t.Fatalf("shared setters=%d missing binding=%d", base.setters.Load(), base.missing.Load())
+			}
+			for i := range counts {
+				if counts[i].Load() != 1 {
+					t.Fatalf("agent%d warnings=%d", i, counts[i].Load())
+				}
+			}
+		})
+	}
+}

--- a/sdk/llm/anthropic/client.go
+++ b/sdk/llm/anthropic/client.go
@@ -83,6 +83,9 @@ func (c *Client) PromptCacheCapabilities() llm.PromptCacheCapabilities {
 func (c *Client) Model() string { return c.ModelName }
 
 func (c *Client) Invoke(ctx context.Context, req llm.InvokeRequest) (*llm.Completion, error) {
+	local := *c
+	local.Warningf = llm.WarningSink(ctx, c.Warningf)
+	c = &local
 	req, cacheDiagnostics, err := llm.AdmitCachePlan(ctx, req, c, c.warnf)
 	if err != nil {
 		return nil, err
@@ -662,6 +665,9 @@ type requestPayload struct {
 // InvokeStream implements true SSE streaming for Anthropic messages.
 // It emits text deltas, thinking deltas, and basic tool_use deltas (best-effort).
 func (c *Client) InvokeStream(ctx context.Context, req llm.InvokeRequest) (<-chan llm.StreamEvent, error) {
+	local := *c
+	local.Warningf = llm.WarningSink(ctx, c.Warningf)
+	c = &local
 	req, _, err := llm.AdmitCachePlan(ctx, req, c, c.warnf)
 	if err != nil {
 		return nil, err

--- a/sdk/llm/cache_admission_test.go
+++ b/sdk/llm/cache_admission_test.go
@@ -373,28 +373,32 @@ func TestResponsesCacheWarningSinkRemainsConstructionScoped(t *testing.T) {
 	t.Setenv("TMPDIR", temporary)
 	t.Setenv("TMP", temporary)
 	t.Setenv("TEMP", temporary)
-	var configured, child atomic.Int32
-	model := admissionModel("responses", func(r *http.Request) (*http.Response, error) {
-		return &http.Response{StatusCode: 401, Header: make(http.Header), Body: io.NopCloser(strings.NewReader(`{"error":{"message":"fixture"}}`)), Request: r}, nil
-	}, func(string, ...any) { configured.Add(1) })
-	request := admissionRequest(t, llm.CacheBestEffort)
-	var workers sync.WaitGroup
-	for i := 0; i < 8; i++ {
-		workers.Add(1)
-		go func() {
-			defer workers.Done()
-			for j := 0; j < 10; j++ {
-				if _, err := agent.New(agent.Config{LLM: model, Warningf: func(string, ...any) { child.Add(1) }}); err != nil {
-					t.Error(err)
-				}
-				if _, err := model.Invoke(context.Background(), request); err == nil {
-					t.Error("expected fixture rejection")
-				}
+	for _, provider := range []string{"anthropic", "chat", "responses"} {
+		t.Run(provider, func(t *testing.T) {
+			var configured, child atomic.Int32
+			model := admissionModel(provider, func(r *http.Request) (*http.Response, error) {
+				return &http.Response{StatusCode: 401, Header: make(http.Header), Body: io.NopCloser(strings.NewReader(`{"error":{"message":"fixture"}}`)), Request: r}, nil
+			}, func(string, ...any) { configured.Add(1) })
+			request := admissionRequest(t, llm.CacheBestEffort)
+			var workers sync.WaitGroup
+			for i := 0; i < 8; i++ {
+				workers.Add(1)
+				go func() {
+					defer workers.Done()
+					for j := 0; j < 10; j++ {
+						if _, err := agent.New(agent.Config{LLM: model, Warningf: func(string, ...any) { child.Add(1) }}); err != nil {
+							t.Error(err)
+						}
+						if _, err := model.Invoke(context.Background(), request); err == nil {
+							t.Error("expected fixture rejection")
+						}
+					}
+				}()
 			}
-		}()
-	}
-	workers.Wait()
-	if configured.Load() != 80 || child.Load() != 0 {
-		t.Fatalf("shared child construction sink: configured=%d child=%d", configured.Load(), child.Load())
+			workers.Wait()
+			if configured.Load() != 80 || child.Load() != 0 {
+				t.Fatalf("shared child construction sink: configured=%d child=%d", configured.Load(), child.Load())
+			}
+		})
 	}
 }

--- a/sdk/llm/openai/chat.go
+++ b/sdk/llm/openai/chat.go
@@ -94,13 +94,14 @@ func (c *ChatClient) PromptCacheCapabilities() llm.PromptCacheCapabilities {
 }
 
 func (c *ChatClient) Invoke(ctx context.Context, req llm.InvokeRequest) (*llm.Completion, error) {
-	req, cacheDiagnostics, err := llm.AdmitCachePlan(ctx, req, c, c.warnf)
+	local := *c
+	local.Warningf = llm.WarningSink(ctx, c.Warningf)
+	local.Extra = cloneMap(c.Extra)
+	local.ExtraBody = cloneMap(c.ExtraBody)
+	req, cacheDiagnostics, err := llm.AdmitCachePlan(ctx, req, &local, local.warnf)
 	if err != nil {
 		return nil, err
 	}
-	local := *c
-	local.Extra = cloneMap(c.Extra)
-	local.ExtraBody = cloneMap(c.ExtraBody)
 
 	client := local.httpClient()
 	baseURL := strings.TrimRight(local.baseURL(), "/")
@@ -216,7 +217,11 @@ func (c *ChatClient) Invoke(ctx context.Context, req llm.InvokeRequest) (*llm.Co
 // InvokeStream implements true SSE streaming for OpenAI chat/completions.
 // It emits text deltas and tool_call deltas.
 func (c *ChatClient) InvokeStream(ctx context.Context, req llm.InvokeRequest) (<-chan llm.StreamEvent, error) {
-	req, _, err := llm.AdmitCachePlan(ctx, req, c, c.warnf)
+	local := *c
+	local.Warningf = llm.WarningSink(ctx, c.Warningf)
+	local.Extra = cloneMap(c.Extra)
+	local.ExtraBody = cloneMap(c.ExtraBody)
+	req, _, err := llm.AdmitCachePlan(ctx, req, &local, local.warnf)
 	if err != nil {
 		return nil, err
 	}
@@ -226,9 +231,6 @@ func (c *ChatClient) InvokeStream(ctx context.Context, req llm.InvokeRequest) (<
 	out := make(chan llm.StreamEvent, 128)
 	forwarded := make(chan llm.StreamEvent, 128)
 	go forwardOpenAIStreamEvents(ctx, forwarded, out)
-	local := *c
-	local.Extra = cloneMap(c.Extra)
-	local.ExtraBody = cloneMap(c.ExtraBody)
 	go func() {
 		defer close(out)
 

--- a/sdk/llm/openai/responses.go
+++ b/sdk/llm/openai/responses.go
@@ -75,13 +75,14 @@ func (c *ResponsesClient) PromptCacheCapabilities() llm.PromptCacheCapabilities 
 }
 
 func (c *ResponsesClient) Invoke(ctx context.Context, req llm.InvokeRequest) (*llm.Completion, error) {
-	req, cacheDiagnostics, err := llm.AdmitCachePlan(ctx, req, c, c.warnf)
+	local := *c
+	local.Warningf = llm.WarningSink(ctx, c.Warningf)
+	local.Extra = cloneMap(c.Extra)
+	local.ExtraBody = cloneMap(c.ExtraBody)
+	req, cacheDiagnostics, err := llm.AdmitCachePlan(ctx, req, &local, local.warnf)
 	if err != nil {
 		return nil, err
 	}
-	local := *c
-	local.Extra = cloneMap(c.Extra)
-	local.ExtraBody = cloneMap(c.ExtraBody)
 
 	client := local.httpClient()
 	baseURL := strings.TrimRight(local.baseURL(), "/")
@@ -403,7 +404,11 @@ func looksLikeResponsesInputUnsupported(msg string) bool {
 // InvokeStream implements true SSE streaming for OpenAI responses.
 // It emits text deltas and basic tool-call deltas (best-effort).
 func (c *ResponsesClient) InvokeStream(ctx context.Context, req llm.InvokeRequest) (<-chan llm.StreamEvent, error) {
-	req, _, err := llm.AdmitCachePlan(ctx, req, c, c.warnf)
+	local := *c
+	local.Warningf = llm.WarningSink(ctx, c.Warningf)
+	local.Extra = cloneMap(c.Extra)
+	local.ExtraBody = cloneMap(c.ExtraBody)
+	req, _, err := llm.AdmitCachePlan(ctx, req, &local, local.warnf)
 	if err != nil {
 		return nil, err
 	}
@@ -413,9 +418,6 @@ func (c *ResponsesClient) InvokeStream(ctx context.Context, req llm.InvokeReques
 	out := make(chan llm.StreamEvent, 128)
 	forwarded := make(chan llm.StreamEvent, 128)
 	go forwardOpenAIStreamEvents(ctx, forwarded, out)
-	local := *c
-	local.Extra = cloneMap(c.Extra)
-	local.ExtraBody = cloneMap(c.ExtraBody)
 	go func() {
 		defer close(out)
 

--- a/sdk/llm/types.go
+++ b/sdk/llm/types.go
@@ -174,8 +174,10 @@ type Completion struct {
 	Raw         json.RawMessage `json:"-"`
 }
 
-// WarningSinkSetter lets runtime hosts route provider diagnostics without
-// allowing a client to write directly to a TUI or protocol stdout/stderr.
+// WarningSinkSetter is a configuration-time API. Call it before sharing a
+// client; it does not promise synchronization or per-Agent ownership. Agent.New
+// does not call it. Providers should read WarningSink(ctx, configuredFallback)
+// to support invocation-local routing without mutating shared model state.
 type WarningSinkSetter interface {
 	SetWarningf(func(format string, args ...any))
 }

--- a/sdk/llm/warning_context.go
+++ b/sdk/llm/warning_context.go
@@ -1,0 +1,28 @@
+package llm
+
+import "context"
+
+type warningSinkKey struct{}
+type warningSinkValue struct{ sink func(string, ...any) }
+
+// WithWarningSink binds diagnostics to one invocation without mutating a shared
+// model. Derived cancellation/deadline contexts preserve this binding. A nil
+// sink masks an inherited binding and restores the provider's fallback.
+func WithWarningSink(ctx context.Context, sink func(string, ...any)) context.Context {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	return context.WithValue(ctx, warningSinkKey{}, warningSinkValue{sink: sink})
+}
+
+// WarningSink returns the invocation binding, or fallback when no binding exists.
+// Providers should capture it in their call-local state before starting streams
+// or retries. The callback must support the concurrency of its owning caller.
+func WarningSink(ctx context.Context, fallback func(string, ...any)) func(string, ...any) {
+	if ctx != nil {
+		if value, ok := ctx.Value(warningSinkKey{}).(warningSinkValue); ok && value.sink != nil {
+			return value.sink
+		}
+	}
+	return fallback
+}

--- a/sdk/llm/warning_context_test.go
+++ b/sdk/llm/warning_context_test.go
@@ -1,0 +1,81 @@
+package llm_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/timwhitez/agent-sdk-golang/sdk/llm"
+)
+
+func TestWarningContextScopeAndCancellation(t *testing.T) {
+	var fallback, parent, child int
+	f := func(string, ...any) { fallback++ }
+	root, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	bound := llm.WithWarningSink(root, func(string, ...any) { parent++ })
+	nested := llm.WithWarningSink(bound, func(string, ...any) { child++ })
+	llm.WarningSink(context.Background(), f)("fixture")
+	llm.WarningSink(bound, f)("fixture")
+	llm.WarningSink(nested, f)("fixture")
+	if fallback != 1 || parent != 1 || child != 1 {
+		t.Fatal("warning scope leaked")
+	}
+	llm.WarningSink(llm.WithWarningSink(bound, nil), f)("fixture")
+	if fallback != 2 || parent != 1 {
+		t.Fatal("explicit nil did not restore fallback")
+	}
+	deadline, _ := root.Deadline()
+	got, _ := bound.Deadline()
+	if !got.Equal(deadline) || bound.Done() != root.Done() {
+		t.Fatal("binding changed deadline/cancellation")
+	}
+	cancel()
+	if !errors.Is(nested.Err(), context.Canceled) {
+		t.Fatal("nested cancellation lost")
+	}
+}
+
+func TestProviderWarningContextsDoNotMutateSharedClient(t *testing.T) {
+	for _, provider := range []string{"anthropic", "chat", "responses"} {
+		for _, stream := range []bool{false, true} {
+			t.Run(fmt.Sprintf("%s/%v", provider, stream), func(t *testing.T) {
+				var fallback atomic.Int32
+				model := admissionModel(provider, func(r *http.Request) (*http.Response, error) {
+					return &http.Response{StatusCode: 401, Header: make(http.Header), Body: io.NopCloser(strings.NewReader(`{"error":{"message":"fixture"}}`)), Request: r}, nil
+				}, func(string, ...any) { fallback.Add(1) })
+				request := admissionRequest(t, llm.CacheBestEffort)
+				var counts [8]atomic.Int32
+				var workers sync.WaitGroup
+				for i := range counts {
+					workers.Add(1)
+					go func(index int) {
+						defer workers.Done()
+						ctx := llm.WithWarningSink(context.Background(), func(string, ...any) { counts[index].Add(1) })
+						_, _ = callAdmissionModel(ctx, model, request, stream)
+					}(i)
+				}
+				workers.Wait()
+				for i := range counts {
+					if counts[i].Load() != 1 {
+						t.Fatalf("sink %d received %d warnings", i, counts[i].Load())
+					}
+				}
+				if fallback.Load() != 0 {
+					t.Fatal("invocation used configured global sink")
+				}
+				_, _ = callAdmissionModel(context.Background(), model, request, stream)
+				if fallback.Load() != 1 {
+					t.Fatal("invocation mutated direct-client fallback")
+				}
+			})
+		}
+	}
+}


### PR DESCRIPTION
## Scope / SDK issue133

Stop Agent.New from calling WarningSinkSetter on shared model handles. Bind the Agent warning sink through llm.WithWarningSink at the common model invocation path; bind the Service sink at compaction's only model call. All three builtin buffered/streaming clients capture the context sink in call-local state before admission/retry/goroutines. OpenAI reuses its existing local client copy; no global lock, shared registry, new event sequence or executor is added.

Direct clients without a binding retain configured/default logging. Nil binding masks an inherited sink and restores fallback. Manual setters remain configuration-time APIs, not concurrent runtime mutation APIs. Custom providers must read llm.WarningSink(ctx,fallback); SDK no longer implicitly configures their setter. Provider request/persistence formats are unchanged.

## Paired dependency

Goode Debug's own log-failure diagnostics previously relied on the automatic setter. Paired [Goode PR207](https://github.com/timwhitez/goode/pull/207) migrates logEntry/warnf (including streaming/error paths) and two old setter-dependent headless fixtures to the context binding. Both PRs must be independently reviewed and ready before merging SDK then Goode. Issue133 stays open until paired main validation; do not treat SDK alone as full delivery. No pin-only workflow; validate actual selected SDK sources.

## Validation

Author and independent exact6a538ff full/vet/LLM-provider-Agent-compaction race and focusedrace100 passed. Eight shared Agent invocations get exactly their own warning in buffered/streaming paths, no construction setter calls; all three concrete clients keep direct fallback while concurrent contexts isolate warnings; compaction uses its own Service scope; context cancellation/deadline/nil masking preserved. Shared-client construction plus real Invoke asserts configured80/child0 for all three clients. Independent six mutations caught restoredNewsetter, missingAgent/Servicecontext and eachprovider ignoringbinding; restoredclean. SDKreviewer APPROVE. Paired Goode finalreview still required before merge.

No logging-content expansion, model/tool/Prompt behavior change, cache mapping change or benchmark speedup claim. This fixes construction race and invocation ownership, not arbitrary concurrent mutation of public client config or uncooperative callback behavior.
