### PR TITLE
feat(anthropic): map canonical content-block cache targets to wire sources

### DIFF
--- a/agent_docs/providers.md
+++ b/agent_docs/providers.md
@@ -10,13 +10,17 @@ stream normalization, and response metadata behavior.
   entrypoints clone and validate that original binding before network I/O:
   stale/unbound/unsupported Required plans fail; accepted/skipped decisions produce
   bounded `Completion.Diagnostics` and warning metadata. Anthropic maps exact
-  Tool Definition and eligible Message boundaries with default/5m TTL and up to
+  Tool Definition and eligible Message/ContentBlock boundaries with default/5m TTL and up to
   four breakpoints. Eligibility comes from the same serialization traversal,
   before capacity allocation: hidden/empty/placeholder endpoints are not targets.
   A collapsed System string exposes only its last emitted source endpoint and
   is wrapped whole, never split to invent earlier boundaries. Structured System
-  and merged Tool Results retain per-source locations. Content-block targets and
-  1h TTL are not advertised yet. An accepted plan overrides
+  and merged Tool Results retain per-source locations. BlockOrdinal comes from
+  the shared `llm.CacheTargets` metadata projection, not a raw Blocks/wire index;
+  hidden/opaque/empty sources are not ordinal targets, and document placeholders
+  are unmappable. Tool Results expose only their outer result block. A collapsed
+  System string exposes only its final actual endpoint. 1h TTL remains unsupported.
+  An accepted plan overrides
   legacy cache markers without changing block shape/text/order. All-skipped,
   nil and empty plans preserve the legacy path. See the official
   [cache constraints](https://platform.claude.com/docs/en/build-with-claude/prompt-caching)

--- a/sdk/llm/anthropic/cache_plan.go
+++ b/sdk/llm/anthropic/cache_plan.go
@@ -9,6 +9,50 @@ import (
 type messageCacheLocation struct {
 	system, plain, eligible bool
 	message, block          int
+	blocks                  map[cacheSourceKey]messageCacheLocation
+}
+
+type cacheSourceKey struct {
+	source string
+	index  int
+}
+
+func newCacheLocations(request llm.InvokeRequest, targets []llm.CacheTarget) ([]messageCacheLocation, []llm.CacheTargetDescriptor) {
+	var locations []messageCacheLocation
+	needBlocks := false
+	for _, target := range targets {
+		if target.Kind != llm.CacheAfterMessage && target.Kind != llm.CacheAfterMessageBlock {
+			continue
+		}
+		if locations == nil {
+			locations = make([]messageCacheLocation, len(request.Messages))
+		}
+		if target.Kind == llm.CacheAfterMessageBlock && target.MessageIndex >= 0 && target.MessageIndex < len(locations) {
+			if locations[target.MessageIndex].blocks == nil {
+				locations[target.MessageIndex].blocks = make(map[cacheSourceKey]messageCacheLocation)
+			}
+			needBlocks = true
+		}
+	}
+	if needBlocks {
+		return locations, llm.CacheTargets(request)
+	}
+	return locations, nil
+}
+
+func cacheLocation(target llm.CacheTarget, locations []messageCacheLocation, descriptors []llm.CacheTargetDescriptor) messageCacheLocation {
+	if target.MessageIndex < 0 || target.MessageIndex >= len(locations) {
+		return messageCacheLocation{}
+	}
+	if target.Kind == llm.CacheAfterMessage {
+		return locations[target.MessageIndex]
+	}
+	for _, descriptor := range descriptors {
+		if descriptor.Target.Kind == llm.CacheAfterMessageBlock && descriptor.Target.MessageIndex == target.MessageIndex && descriptor.Target.BlockOrdinal == target.BlockOrdinal {
+			return locations[target.MessageIndex].blocks[cacheSourceKey{descriptor.Source, descriptor.SourceIndex}]
+		}
+	}
+	return messageCacheLocation{}
 }
 
 func cacheableContentBoundary(source llm.ContentBlock, wire contentBlockParam) bool {
@@ -27,13 +71,7 @@ func cacheableContentBoundary(source llm.ContentBlock, wire contentBlockParam) b
 // with warnings disabled. Tool-only plans do not need message serialization.
 func (c *Client) PromptCacheTargetEligibility(request llm.InvokeRequest, targets []llm.CacheTarget) []bool {
 	eligible := make([]bool, len(targets))
-	var locations []messageCacheLocation
-	for _, target := range targets {
-		if target.Kind == llm.CacheAfterMessage {
-			locations = make([]messageCacheLocation, len(request.Messages))
-			break
-		}
-	}
+	locations, descriptors := newCacheLocations(request, targets)
 	if locations != nil {
 		if _, _, err := serializeMessagesWithLocations(request.Messages, nil, locations); err != nil {
 			locations = nil
@@ -43,8 +81,8 @@ func (c *Client) PromptCacheTargetEligibility(request llm.InvokeRequest, targets
 		switch target.Kind {
 		case llm.CacheAfterToolDefinition:
 			eligible[i] = target.ToolIndex >= 0 && target.ToolIndex < len(request.Tools)
-		case llm.CacheAfterMessage:
-			eligible[i] = target.MessageIndex >= 0 && target.MessageIndex < len(locations) && locations[target.MessageIndex].eligible
+		case llm.CacheAfterMessage, llm.CacheAfterMessageBlock:
+			eligible[i] = cacheLocation(target, locations, descriptors).eligible
 		}
 	}
 	return eligible
@@ -53,7 +91,7 @@ func (c *Client) PromptCacheTargetEligibility(request llm.InvokeRequest, targets
 // applyCachePlan only touches newly serialized objects, after all destinations
 // pass validation. A collapsed system string can be wrapped whole, not split
 // to invent earlier source boundaries. Existing structured blocks keep shape.
-func applyCachePlan(plan *llm.CachePlan, system *any, messages []messageParam, tools []toolParam, locations []messageCacheLocation) error {
+func applyCachePlan(plan *llm.CachePlan, system *any, messages []messageParam, tools []toolParam, locations []messageCacheLocation, sources []llm.CacheTargetDescriptor) error {
 	if len(plan.Directives) > 4 {
 		return &llm.CachePlanValidationError{Reason: "breakpoint_limit", DirectiveIndex: -1}
 	}
@@ -68,9 +106,9 @@ func applyCachePlan(plan *llm.CachePlan, system *any, messages []messageParam, t
 			if target.ToolIndex >= 0 && target.ToolIndex < len(tools) {
 				destination = &tools[target.ToolIndex].CacheCtrl
 			}
-		case llm.CacheAfterMessage:
+		case llm.CacheAfterMessage, llm.CacheAfterMessageBlock:
 			if target.MessageIndex >= 0 && target.MessageIndex < len(locations) {
-				location := locations[target.MessageIndex]
+				location := cacheLocation(target, locations, sources)
 				if location.eligible {
 					if location.system {
 						if location.plain {

--- a/sdk/llm/anthropic/cache_plan_test.go
+++ b/sdk/llm/anthropic/cache_plan_test.go
@@ -13,7 +13,7 @@ func TestToolCacheMappingGuardDoesNotPartiallyRewrite(t *testing.T) {
 		tools := []toolParam{{Name: "fixture", CacheCtrl: &cacheControl{Type: "ephemeral"}}}
 		before, _ := json.Marshal(tools)
 		var system any
-		err := applyCachePlan(&llm.CachePlan{Directives: []llm.CacheDirective{{Target: target}}}, &system, nil, tools, nil)
+		err := applyCachePlan(&llm.CachePlan{Directives: []llm.CacheDirective{{Target: target}}}, &system, nil, tools, nil, nil)
 		after, _ := json.Marshal(tools)
 		if err == nil || string(before) != string(after) {
 			t.Fatal("invalid mapping changed payload", err)
@@ -25,14 +25,14 @@ func TestToolCacheMappingGuardDoesNotPartiallyRewrite(t *testing.T) {
 	} {
 		tools := []toolParam{{CacheCtrl: &cacheControl{Type: "ephemeral"}}}
 		var system any
-		if err := applyCachePlan(plan, &system, nil, tools, nil); err == nil || tools[0].CacheCtrl == nil {
+		if err := applyCachePlan(plan, &system, nil, tools, nil, nil); err == nil || tools[0].CacheCtrl == nil {
 			t.Fatal("limit/TTL guard failed")
 		}
 	}
 }
 
 func BenchmarkToolCacheRequestBuilder(b *testing.B) {
-	for _, mode := range []string{"legacy", "explicit", "message"} {
+	for _, mode := range []string{"legacy", "explicit", "message", "block"} {
 		b.Run(mode, func(b *testing.B) {
 			client := &Client{ModelName: "fixture", MaxTokens: 64, MaxCachedToolDefinitions: 1}
 			request := llm.InvokeRequest{Messages: []llm.Message{{Role: llm.RoleSystem, Content: llm.TextContent(strings.Repeat("x", 1024)), Cache: true}, {Role: llm.RoleUser, Content: llm.TextContent("hello"), Cache: true}}, Tools: []llm.ToolDefinition{{Name: "first"}, {Name: "second"}}}
@@ -44,6 +44,9 @@ func BenchmarkToolCacheRequestBuilder(b *testing.B) {
 				target := llm.CacheTarget{Kind: llm.CacheAfterToolDefinition}
 				if mode == "message" {
 					target = llm.CacheTarget{Kind: llm.CacheAfterMessage, MessageIndex: 1}
+				}
+				if mode == "block" {
+					target = llm.CacheTarget{Kind: llm.CacheAfterMessageBlock, MessageIndex: 1}
 				}
 				request.CachePlan, err = view.Bind([]llm.CacheDirective{{Target: target, Policy: llm.CacheRequired, TTL: llm.CacheTTL5Minutes}})
 				if err != nil {
@@ -68,7 +71,7 @@ func TestMessageMappingGuardDoesNotPartiallyWrapSystem(t *testing.T) {
 		{Target: llm.CacheTarget{Kind: llm.CacheAfterToolDefinition, ToolIndex: 99}},
 	}}
 	locations := []messageCacheLocation{{system: true, plain: true, eligible: true}}
-	if err := applyCachePlan(plan, &system, nil, nil, locations); err == nil {
+	if err := applyCachePlan(plan, &system, nil, nil, locations, nil); err == nil {
 		t.Fatal("invalid second destination accepted")
 	}
 	if system != "original\n\ntext" {

--- a/sdk/llm/anthropic/client.go
+++ b/sdk/llm/anthropic/client.go
@@ -75,9 +75,9 @@ func (c *Client) Provider() string { return "anthropic" }
 
 // PromptCacheCapabilities reports implemented explicit mappings, not a promise
 // of endpoint/model acceptance or a cache hit. Request-local eligibility further
-// restricts message boundaries. Content-block and 1h mapping remain unsupported.
+// restricts message/block boundaries. 1h mapping remains unsupported.
 func (c *Client) PromptCacheCapabilities() llm.PromptCacheCapabilities {
-	return llm.PromptCacheCapabilities{ExplicitMessageBoundary: true, ExplicitToolDefinition: true, SupportedTTLs: []llm.CacheTTL{llm.CacheTTL5Minutes}, MaxBreakpoints: 4, UsageTelemetry: true}
+	return llm.PromptCacheCapabilities{ExplicitMessageBoundary: true, ExplicitContentBlock: true, ExplicitToolDefinition: true, SupportedTTLs: []llm.CacheTTL{llm.CacheTTL5Minutes}, MaxBreakpoints: 4, UsageTelemetry: true}
 }
 
 func (c *Client) Model() string { return c.ModelName }
@@ -1168,15 +1168,13 @@ func (c *Client) buildRequestWithThinking(req llm.InvokeRequest, thinkingConfig 
 		maxTokens = 8192
 	}
 
-	var locations []messageCacheLocation
+	var targets []llm.CacheTarget
 	if req.CachePlan != nil {
 		for _, d := range req.CachePlan.Directives {
-			if d.Target.Kind == llm.CacheAfterMessage {
-				locations = make([]messageCacheLocation, len(req.Messages))
-				break
-			}
+			targets = append(targets, d.Target)
 		}
 	}
+	locations, descriptors := newCacheLocations(req, targets)
 	sys, msgs, err := serializeMessagesWithLocations(req.Messages, c.warnf, locations)
 	if err != nil {
 		return nil, err
@@ -1187,7 +1185,7 @@ func (c *Client) buildRequestWithThinking(req llm.InvokeRequest, thinkingConfig 
 		tools = serializeTools(req.Tools, c.MaxCachedToolDefinitions)
 	}
 	if req.CachePlan != nil && len(req.CachePlan.Directives) > 0 {
-		if err := applyCachePlan(req.CachePlan, &sys, msgs, tools, locations); err != nil {
+		if err := applyCachePlan(req.CachePlan, &sys, msgs, tools, locations, descriptors); err != nil {
 			return nil, err
 		}
 	}
@@ -1319,7 +1317,13 @@ func serializeMessagesWithLocations(in []llm.Message, warnf func(string, ...any)
 	var sysBlocks []contentBlockParam
 	record := func(index int, location messageCacheLocation) {
 		if locations != nil {
+			location.blocks = locations[index].blocks
 			locations[index] = location
+		}
+	}
+	recordBlock := func(index int, source string, sourceIndex int, location messageCacheLocation) {
+		if locations != nil && locations[index].blocks != nil {
+			locations[index].blocks[cacheSourceKey{source, sourceIndex}] = location
 		}
 	}
 
@@ -1336,14 +1340,16 @@ func serializeMessagesWithLocations(in []llm.Message, warnf func(string, ...any)
 				}
 				sysBlocks = append(sysBlocks, blk)
 				cacheable = true
+				recordBlock(i, "text", -1, messageCacheLocation{system: true, block: len(sysBlocks) - 1, eligible: true})
 			}
-			for _, b := range m.Content.Blocks {
+			for j, b := range m.Content.Blocks {
 				if llm.IsProviderStateBlock(b) {
 					continue
 				}
 				block := toAnthropicBlock(b, m.Cache)
 				sysBlocks = append(sysBlocks, block)
 				cacheable = cacheableContentBoundary(b, block) && block.Type == "text"
+				recordBlock(i, "content_block", j, messageCacheLocation{system: true, block: len(sysBlocks) - 1, eligible: cacheable})
 			}
 			if len(sysBlocks) > start {
 				record(i, messageCacheLocation{system: true, block: len(sysBlocks) - 1, eligible: cacheable})
@@ -1357,12 +1363,19 @@ func serializeMessagesWithLocations(in []llm.Message, warnf func(string, ...any)
 			for j < len(in) && in[j].Role == llm.RoleTool {
 				results = append(results, toAnthropicToolResultBlock(in[j], warnf))
 				record(j, messageCacheLocation{message: len(out), block: len(results) - 1, eligible: true})
+				recordBlock(j, "tool_result", -1, messageCacheLocation{message: len(out), block: len(results) - 1, eligible: true})
 				j++
 			}
 			i = j - 1
 			out = append(out, messageParam{Role: "user", Content: results})
 		default:
-			mp, cacheable, e := toAnthropicMessageForCache(m, warnf)
+			var blockRecorder func(string, int, int, bool)
+			if locations != nil && locations[i].blocks != nil {
+				blockRecorder = func(source string, sourceIndex, block int, eligible bool) {
+					recordBlock(i, source, sourceIndex, messageCacheLocation{message: len(out), block: block, eligible: eligible})
+				}
+			}
+			mp, cacheable, e := toAnthropicMessageForCache(m, warnf, blockRecorder)
 			if e != nil {
 				return nil, nil, e
 			}
@@ -1382,6 +1395,13 @@ func serializeMessagesWithLocations(in []llm.Message, warnf func(string, ...any)
 				if locations[i].system {
 					locations[i].eligible = locations[i].eligible && locations[i].block == len(sysBlocks)-1
 					locations[i].plain, locations[i].block = true, 0
+				}
+				for key, location := range locations[i].blocks {
+					if location.system {
+						location.eligible = location.eligible && location.block == len(sysBlocks)-1
+						location.plain, location.block = true, 0
+						locations[i].blocks[key] = location
+					}
 				}
 			}
 		} else {
@@ -1472,11 +1492,11 @@ func toAnthropicMessage(m llm.Message) (*messageParam, error) {
 }
 
 func toAnthropicMessageWithWarning(m llm.Message, warnf func(string, ...any)) (*messageParam, error) {
-	message, _, err := toAnthropicMessageForCache(m, warnf)
+	message, _, err := toAnthropicMessageForCache(m, warnf, nil)
 	return message, err
 }
 
-func toAnthropicMessageForCache(m llm.Message, warnf func(string, ...any)) (*messageParam, bool, error) {
+func toAnthropicMessageForCache(m llm.Message, warnf func(string, ...any), record func(string, int, int, bool)) (*messageParam, bool, error) {
 	if m.Role == llm.RoleTool {
 		// Anthropic expects tool results as role=user with tool_result blocks.
 		return &messageParam{Role: "user", Content: []contentBlockParam{toAnthropicToolResultBlock(m, warnf)}}, true, nil
@@ -1492,18 +1512,24 @@ func toAnthropicMessageForCache(m llm.Message, warnf func(string, ...any)) (*mes
 	if strings.TrimSpace(m.Content.Text) != "" {
 		blocks = append(blocks, contentBlockParam{Type: "text", Text: m.Content.Text})
 		cacheable = true
+		if record != nil {
+			record("text", -1, len(blocks)-1, true)
+		}
 	}
-	for _, b := range m.Content.Blocks {
+	for j, b := range m.Content.Blocks {
 		if llm.IsProviderStateBlock(b) {
 			continue
 		}
 		block := toAnthropicBlock(b, false)
 		blocks = append(blocks, block)
 		cacheable = cacheableContentBoundary(b, block) && (block.Type != "image" || m.Role == llm.RoleUser)
+		if record != nil {
+			record("content_block", j, len(blocks)-1, cacheable)
+		}
 	}
 
 	if m.Role == llm.RoleAssistant && len(m.ToolCalls) > 0 {
-		for _, tc := range m.ToolCalls {
+		for j, tc := range m.ToolCalls {
 			id := normalizeToolCallIDWithWarning(tc.ID, warnf)
 			if id == "" {
 				id = tc.ID
@@ -1524,6 +1550,9 @@ func toAnthropicMessageForCache(m llm.Message, warnf func(string, ...any)) (*mes
 				Input: input,
 			})
 			cacheable = true
+			if record != nil {
+				record("tool_call", j, len(blocks)-1, true)
+			}
 		}
 	}
 

--- a/sdk/llm/anthropic_block_cache_test.go
+++ b/sdk/llm/anthropic_block_cache_test.go
@@ -1,0 +1,292 @@
+package llm_test
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"reflect"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/timwhitez/agent-sdk-golang/sdk/llm"
+)
+
+func blockDirective(message, ordinal int, policy llm.CacheDirectivePolicy) llm.CacheDirective {
+	return llm.CacheDirective{Target: llm.CacheTarget{Kind: llm.CacheAfterMessageBlock, MessageIndex: message, BlockOrdinal: ordinal}, Policy: policy}
+}
+
+func blockCacheRequest(t *testing.T) llm.InvokeRequest {
+	t.Helper()
+	request := toolCacheRequest()
+	request.Messages[0].Content = llm.Content{Text: "system-top", Blocks: []llm.ContentBlock{{Type: "text"}, {Type: "text", Text: "section"}}}
+	request.Messages[1].Content = llm.Content{Text: "user-top", Blocks: []llm.ContentBlock{{Type: "unknown"}, {Type: "text"}, {Type: "text", Text: "part"}, {Type: "image_url", ImageURL: &llm.ImageURL{URL: "https://fixture.invalid/image.png"}}, {Type: "document", Source: &llm.DocSrc{Data: "private-document", MediaType: "application/pdf"}}}}
+	var err error
+	request.Messages[1].Content, err = llm.WithProviderState(request.Messages[1].Content, []llm.ProviderState{{Provider: "fixture", Kind: "opaque", Data: json.RawMessage(`{"secret":"private-opaque"}`)}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	blocks := request.Messages[1].Content.Blocks
+	request.Messages[1].Content.Blocks = append([]llm.ContentBlock{blocks[len(blocks)-1]}, blocks[:len(blocks)-1]...)
+	request.Messages[2].Content = llm.Content{Text: "assistant", Blocks: []llm.ContentBlock{{Type: "thinking", Thinking: "fixture-thinking", Signature: "fixture-signature"}}}
+	return request
+}
+
+func TestAnthropicBlockCacheOrdinalWireGolden(t *testing.T) {
+	for _, stream := range []bool{false, true} {
+		t.Run(fmt.Sprint(stream), func(t *testing.T) {
+			var baseline map[string]any
+			for _, planned := range []bool{false, true} {
+				request := blockCacheRequest(t)
+				if planned {
+					bindToolCache(t, &request, []llm.CacheDirective{blockDirective(0, 1, llm.CacheRequired), blockDirective(1, 2, llm.CacheRequired), blockDirective(2, 1, llm.CacheRequired), blockDirective(4, 0, llm.CacheRequired)})
+				}
+				before, err := llm.CloneInvokeRequest(request)
+				if err != nil {
+					t.Fatal(err)
+				}
+				var payload map[string]any
+				var calls atomic.Int32
+				model := admissionModel("anthropic", func(r *http.Request) (*http.Response, error) {
+					calls.Add(1)
+					data, _ := io.ReadAll(r.Body)
+					if strings.Contains(string(data), "private-opaque") {
+						t.Error("opaque state leaked")
+					}
+					if err := json.Unmarshal(data, &payload); err != nil {
+						return nil, err
+					}
+					return &http.Response{StatusCode: 401, Header: make(http.Header), Body: io.NopCloser(strings.NewReader(`{"error":{"message":"fixture"}}`)), Request: r}, nil
+				}, func(string, ...any) {})
+				_, _ = callAdmissionModel(context.Background(), model, request, stream)
+				if calls.Load() != 1 || !reflect.DeepEqual(request, before) {
+					t.Fatal("request not sent or source mutated")
+				}
+				if !planned {
+					baseline = payload
+					continue
+				}
+				clearWireCache(baseline)
+				cache := map[string]any{"type": "ephemeral"}
+				baseline["system"].([]any)[2].(map[string]any)["cache_control"] = cache
+				messages := baseline["messages"].([]any)
+				messages[0].(map[string]any)["content"].([]any)[4].(map[string]any)["cache_control"] = cache
+				messages[1].(map[string]any)["content"].([]any)[2].(map[string]any)["cache_control"] = cache
+				messages[2].(map[string]any)["content"].([]any)[1].(map[string]any)["cache_control"] = cache
+				if !reflect.DeepEqual(payload, baseline) {
+					t.Fatalf("logical ordinal/source/wire golden mismatch: %#v", payload)
+				}
+			}
+		})
+	}
+}
+
+func TestAnthropicBlockCacheEachToolUseAndResult(t *testing.T) {
+	for _, stream := range []bool{false, true} {
+		for _, reorder := range []bool{false, true} {
+			t.Run(fmt.Sprintf("%v/%v", stream, reorder), func(t *testing.T) {
+				request := blockCacheRequest(t)
+				if reorder {
+					request.Messages[3], request.Messages[4] = request.Messages[4], request.Messages[3]
+				}
+				bindToolCache(t, &request, []llm.CacheDirective{blockDirective(2, 1, llm.CacheRequired), blockDirective(2, 2, llm.CacheRequired), blockDirective(3, 0, llm.CacheRequired), blockDirective(4, 0, llm.CacheRequired)})
+				var calls atomic.Int32
+				model := admissionModel("anthropic", func(r *http.Request) (*http.Response, error) {
+					calls.Add(1)
+					data, _ := io.ReadAll(r.Body)
+					var payload map[string]any
+					if err := json.Unmarshal(data, &payload); err != nil {
+						return nil, err
+					}
+					messages := payload["messages"].([]any)
+					assistant := messages[1].(map[string]any)["content"].([]any)
+					for i, block := range assistant {
+						want := i == 2 || i == 3
+						if (block.(map[string]any)["cache_control"] != nil) != want {
+							t.Errorf("assistant block %d cache mismatch", i)
+						}
+					}
+					results := messages[2].(map[string]any)["content"].([]any)
+					for i, block := range results {
+						b := block.(map[string]any)
+						if b["cache_control"] == nil || b["tool_use_id"] != request.Messages[3+i].ToolCallID {
+							t.Errorf("result %d source/cache mismatch", i)
+						}
+					}
+					return &http.Response{StatusCode: 401, Header: make(http.Header), Body: io.NopCloser(strings.NewReader(`{"error":{"message":"fixture"}}`)), Request: r}, nil
+				}, func(string, ...any) {})
+				_, _ = callAdmissionModel(context.Background(), model, request, stream)
+				if calls.Load() != 1 {
+					t.Fatal("mapping not sent")
+				}
+			})
+		}
+	}
+}
+
+func TestAnthropicBlockCacheRejectsPlaceholderAndInvalidOrdinal(t *testing.T) {
+	for _, stream := range []bool{false, true} {
+		for _, failure := range []string{"document", "out-of-range", "duplicate-alias", "stale"} {
+			t.Run(fmt.Sprintf("%v/%s", stream, failure), func(t *testing.T) {
+				request := blockCacheRequest(t)
+				bindToolCache(t, &request, []llm.CacheDirective{blockDirective(1, 1, llm.CacheRequired)})
+				reason, index := "unmappable_target", 0
+				switch failure {
+				case "document":
+					request.CachePlan.Directives[0].Target.BlockOrdinal = 3
+				case "out-of-range":
+					request.CachePlan.Directives[0].Target.BlockOrdinal = 99
+					reason = "invalid_target"
+				case "duplicate-alias":
+					request.CachePlan.Directives = []llm.CacheDirective{blockDirective(4, 0, llm.CacheRequired), messageDirective(4, llm.CacheRequired)}
+					reason, index = "duplicate_boundary", 1
+				case "stale":
+					request.Messages[1].Content.Blocks[3].Text = "changed"
+					reason, index = "stale_request", -1
+				}
+				var calls atomic.Int32
+				model := admissionModel("anthropic", func(*http.Request) (*http.Response, error) { calls.Add(1); return nil, fmt.Errorf("must not send") }, func(string, ...any) { t.Error("invalid target warned as accepted") })
+				_, err := callAdmissionModel(context.Background(), model, request, stream)
+				assertCacheViewError(t, err, reason, index)
+				if calls.Load() != 0 {
+					t.Fatal("invalid block target reached HTTP")
+				}
+			})
+		}
+	}
+}
+
+func TestAnthropicBlockCacheCollapsedSystem(t *testing.T) {
+	for _, stream := range []bool{false, true} {
+		for _, ordinal := range []int{0, 1} {
+			t.Run(fmt.Sprintf("%v/%d", stream, ordinal), func(t *testing.T) {
+				request := llm.InvokeRequest{Messages: []llm.Message{{Role: llm.RoleSystem, Content: llm.Content{Blocks: []llm.ContentBlock{{Type: "text", Text: "one"}, {Type: "text", Text: "two"}}}}, {Role: llm.RoleUser, Content: llm.TextContent("hello")}}}
+				bindToolCache(t, &request, []llm.CacheDirective{blockDirective(0, ordinal, llm.CacheRequired)})
+				var calls atomic.Int32
+				model := admissionModel("anthropic", func(r *http.Request) (*http.Response, error) {
+					calls.Add(1)
+					data, _ := io.ReadAll(r.Body)
+					var payload map[string]any
+					if err := json.Unmarshal(data, &payload); err != nil {
+						return nil, err
+					}
+					want := []any{map[string]any{"type": "text", "text": "one\n\ntwo", "cache_control": map[string]any{"type": "ephemeral"}}}
+					if !reflect.DeepEqual(payload["system"], want) {
+						t.Error("collapsed string split or changed")
+					}
+					return &http.Response{StatusCode: 401, Header: make(http.Header), Body: io.NopCloser(strings.NewReader(`{"error":{"message":"fixture"}}`)), Request: r}, nil
+				}, func(string, ...any) {})
+				_, err := callAdmissionModel(context.Background(), model, request, stream)
+				if ordinal == 0 {
+					assertCacheViewError(t, err, "unmappable_target", 0)
+					if calls.Load() != 0 {
+						t.Fatal("earlier collapsed block sent")
+					}
+				} else if calls.Load() != 1 {
+					t.Fatal("final collapsed block not mapped", err)
+				}
+			})
+		}
+	}
+}
+
+func TestCacheTargetsProjectionIsOwnedAndIdentical(t *testing.T) {
+	request := blockCacheRequest(t)
+	view, err := llm.NewCacheTargetView(request)
+	if err != nil {
+		t.Fatal(err)
+	}
+	targets := llm.CacheTargets(request)
+	if !reflect.DeepEqual(targets, view.Targets()) {
+		t.Fatal("projection drifted from binding")
+	}
+	targets[0].Source = "mutated"
+	if reflect.DeepEqual(targets, llm.CacheTargets(request)) || view.Targets()[0].Source == "mutated" {
+		t.Fatal("projection aliasing")
+	}
+	encoded, _ := json.Marshal(llm.CacheTargets(request))
+	if strings.Contains(string(encoded), "private-") || strings.Contains(string(encoded), "fixture-thinking") {
+		t.Fatal("projection leaked content")
+	}
+}
+
+func TestAnthropicBlockCacheEachSourcePosition(t *testing.T) {
+	for _, position := range []struct {
+		message, ordinal int
+		key              string
+	}{
+		{0, 0, "s:0"}, {0, 1, "s:2"}, {1, 0, "m:0:0"}, {1, 1, "m:0:3"}, {1, 2, "m:0:4"},
+		{2, 0, "m:1:0"}, {2, 1, "m:1:2"}, {2, 2, "m:1:3"}, {3, 0, "m:2:0"}, {4, 0, "m:2:1"},
+	} {
+		for _, stream := range []bool{false, true} {
+			t.Run(fmt.Sprintf("%d/%d/%v", position.message, position.ordinal, stream), func(t *testing.T) {
+				request := blockCacheRequest(t)
+				bindToolCache(t, &request, []llm.CacheDirective{blockDirective(position.message, position.ordinal, llm.CacheRequired)})
+				var got []string
+				model := admissionModel("anthropic", func(r *http.Request) (*http.Response, error) {
+					data, _ := io.ReadAll(r.Body)
+					var payload map[string]any
+					if err := json.Unmarshal(data, &payload); err != nil {
+						return nil, err
+					}
+					for i, block := range payload["system"].([]any) {
+						if block.(map[string]any)["cache_control"] != nil {
+							got = append(got, fmt.Sprintf("s:%d", i))
+						}
+					}
+					for i, message := range payload["messages"].([]any) {
+						for j, block := range message.(map[string]any)["content"].([]any) {
+							if block.(map[string]any)["cache_control"] != nil {
+								got = append(got, fmt.Sprintf("m:%d:%d", i, j))
+							}
+						}
+					}
+					for i, tool := range payload["tools"].([]any) {
+						if tool.(map[string]any)["cache_control"] != nil {
+							got = append(got, fmt.Sprintf("t:%d", i))
+						}
+					}
+					return &http.Response{StatusCode: 401, Header: make(http.Header), Body: io.NopCloser(strings.NewReader(`{"error":{"message":"fixture"}}`)), Request: r}, nil
+				}, func(string, ...any) {})
+				_, _ = callAdmissionModel(context.Background(), model, request, stream)
+				if !reflect.DeepEqual(got, []string{position.key}) {
+					t.Fatalf("cache positions=%v want%s", got, position.key)
+				}
+			})
+		}
+	}
+}
+
+func TestAnthropicBlockCachePlaceholderDoesNotConsumeCapacity(t *testing.T) {
+	for _, stream := range []bool{false, true} {
+		t.Run(fmt.Sprint(stream), func(t *testing.T) {
+			request := llm.InvokeRequest{Messages: []llm.Message{{Role: llm.RoleUser, Content: llm.Content{Text: "top", Blocks: []llm.ContentBlock{{Type: "document", Source: &llm.DocSrc{Data: "private-document", MediaType: "application/pdf"}}, {Type: "text", Text: "a"}, {Type: "text", Text: "b"}, {Type: "text", Text: "c"}, {Type: "text", Text: "d"}}}}}}
+			directives := []llm.CacheDirective{blockDirective(0, 1, llm.CacheBestEffort)}
+			for ordinal := 2; ordinal <= 5; ordinal++ {
+				directives = append(directives, blockDirective(0, ordinal, llm.CacheBestEffort))
+			}
+			directives[4].Policy = llm.CacheRequired
+			bindToolCache(t, &request, directives)
+			var got []int
+			model := admissionModel("anthropic", func(r *http.Request) (*http.Response, error) {
+				data, _ := io.ReadAll(r.Body)
+				var payload map[string]any
+				if err := json.Unmarshal(data, &payload); err != nil {
+					return nil, err
+				}
+				for i, block := range payload["messages"].([]any)[0].(map[string]any)["content"].([]any) {
+					if block.(map[string]any)["cache_control"] != nil {
+						got = append(got, i)
+					}
+				}
+				return &http.Response{StatusCode: 401, Header: make(http.Header), Body: io.NopCloser(strings.NewReader(`{"error":{"message":"fixture"}}`)), Request: r}, nil
+			}, func(string, ...any) {})
+			_, _ = callAdmissionModel(context.Background(), model, request, stream)
+			if !reflect.DeepEqual(got, []int{2, 3, 4, 5}) {
+				t.Fatalf("placeholder consumed a slot: %v", got)
+			}
+		})
+	}
+}

--- a/sdk/llm/anthropic_tool_cache_wire_test.go
+++ b/sdk/llm/anthropic_tool_cache_wire_test.go
@@ -217,7 +217,7 @@ func TestCacheAdmissionMixedSummaryDoesNotMislabelAccepted(t *testing.T) {
 	var directives []llm.CacheDirective
 	for i := 0; i < 32; i++ {
 		request.Messages = append(request.Messages, llm.Message{Role: llm.RoleUser, Content: llm.TextContent("private-text")})
-		directives = append(directives, llm.CacheDirective{Target: llm.CacheTarget{Kind: llm.CacheAfterMessageBlock, MessageIndex: i}, Policy: llm.CacheBestEffort})
+		directives = append(directives, llm.CacheDirective{Target: llm.CacheTarget{Kind: llm.CacheAfterMessageBlock, MessageIndex: i}, Policy: llm.CacheBestEffort, TTL: llm.CacheTTL1Hour})
 	}
 	directives = append(directives, toolDirective(0, llm.CacheRequired, ""))
 	bindToolCache(t, &request, directives)

--- a/sdk/llm/cache_admission_test.go
+++ b/sdk/llm/cache_admission_test.go
@@ -47,7 +47,7 @@ func admissionRequest(t *testing.T, policy llm.CacheDirectivePolicy) llm.InvokeR
 	if err != nil {
 		t.Fatal(err)
 	}
-	request.CachePlan, err = view.Bind([]llm.CacheDirective{{Target: llm.CacheTarget{Kind: llm.CacheAfterMessageBlock, MessageIndex: 1}, Policy: policy}})
+	request.CachePlan, err = view.Bind([]llm.CacheDirective{{Target: llm.CacheTarget{Kind: llm.CacheAfterMessageBlock, MessageIndex: 1}, Policy: policy, TTL: llm.CacheTTL1Hour}})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -84,6 +84,9 @@ func TestCacheAdmissionRejectsBeforeNetwork(t *testing.T) {
 				t.Run(fmt.Sprintf("%s/%v/%s", provider, stream, failure), func(t *testing.T) {
 					request := admissionRequest(t, llm.CacheRequired)
 					reason := "unsupported_target"
+					if provider == "anthropic" {
+						reason = "unsupported_ttl"
+					}
 					index := 0
 					switch failure {
 					case "view-overwrite", "view-overwrite-best-effort", "view-clear":
@@ -220,10 +223,14 @@ func TestCacheAdmissionBestEffortWireDiagnosticsAndIsolation(t *testing.T) {
 							t.Fatal("skip changed legacy wire")
 						}
 						if planned {
-							if !reflect.DeepEqual(warnings, []string{"cache_plan_skipped: directive 0: unsupported_target"}) {
+							reason := "unsupported_target"
+							if provider == "anthropic" {
+								reason = "unsupported_ttl"
+							}
+							if !reflect.DeepEqual(warnings, []string{"cache_plan_skipped: directive 0: " + reason}) {
 								t.Fatalf("warnings=%v", warnings)
 							}
-							if !stream && status == 200 && !reflect.DeepEqual(completion.Diagnostics, []llm.Diagnostic{{Kind: "cache_plan_skipped", Message: "directive 0: unsupported_target"}}) {
+							if !stream && status == 200 && !reflect.DeepEqual(completion.Diagnostics, []llm.Diagnostic{{Kind: "cache_plan_skipped", Message: "directive 0: " + reason}}) {
 								t.Fatal("missing typed completion diagnostic")
 							}
 						} else if len(warnings) != 0 {

--- a/sdk/llm/cache_boundary_wire_test.go
+++ b/sdk/llm/cache_boundary_wire_test.go
@@ -79,7 +79,7 @@ func TestAnthropicLegacyCacheBoundaryWireGolden(t *testing.T) {
 				var baseline []byte
 				for _, plan := range []*llm.CachePlan{nil, {Directives: []llm.CacheDirective{}}, {
 					SchemaVersion: llm.CachePlanSchemaVersion,
-					Directives:    []llm.CacheDirective{{Target: llm.CacheTarget{Kind: llm.CacheAfterMessageBlock}, Policy: llm.CacheBestEffort}},
+					Directives:    []llm.CacheDirective{{Target: llm.CacheTarget{Kind: llm.CacheAfterMessageBlock}, Policy: llm.CacheBestEffort, TTL: llm.CacheTTL1Hour}},
 				}} {
 					request := llm.InvokeRequest{Messages: llm.CloneMessages(fixture.messages), Tools: tools, CachePlan: plan}
 					if plan != nil && len(plan.Directives) != 0 {

--- a/sdk/llm/cache_decision_test.go
+++ b/sdk/llm/cache_decision_test.go
@@ -171,6 +171,7 @@ func TestCacheDecisionBuiltinCapabilitiesAreConservative(t *testing.T) {
 		want := llm.PromptCacheCapabilities{UsageTelemetry: true}
 		if _, anthropicClient := model.(*anthropic.Client); anthropicClient {
 			want.ExplicitMessageBoundary = true
+			want.ExplicitContentBlock = true
 			want.ExplicitToolDefinition, want.MaxBreakpoints = true, 4
 			want.SupportedTTLs = []llm.CacheTTL{llm.CacheTTL5Minutes}
 		}
@@ -180,9 +181,14 @@ func TestCacheDecisionBuiltinCapabilitiesAreConservative(t *testing.T) {
 		request, view, plan := cacheDecisionFixture(t)
 		for i := range plan.Directives {
 			plan.Directives[i].Target.Kind = llm.CacheAfterMessageBlock
+			plan.Directives[i].TTL = llm.CacheTTL1Hour
 		}
 		_, err := view.Decide(request, plan, model)
-		assertCacheViewError(t, err, "unsupported_target", 2)
+		reason := "unsupported_target"
+		if _, ok := model.(*anthropic.Client); ok {
+			reason = "unsupported_ttl"
+		}
+		assertCacheViewError(t, err, reason, 2)
 		plan.Directives[2].Policy = llm.CacheBestEffort
 		result, err := view.Decide(request, plan, model)
 		if err != nil || len(result.Plan.Directives) != 0 || len(result.Directives) != 3 {

--- a/sdk/llm/cache_plan_wire_test.go
+++ b/sdk/llm/cache_plan_wire_test.go
@@ -27,7 +27,7 @@ func TestCachePlanAttachmentPreservesLegacyWireGolden(t *testing.T) {
 				var baseline []byte
 				for _, plan := range []*llm.CachePlan{nil, {Directives: []llm.CacheDirective{}}, {
 					SchemaVersion: llm.CachePlanSchemaVersion,
-					Directives:    []llm.CacheDirective{{Target: llm.CacheTarget{Kind: llm.CacheAfterMessageBlock}, Policy: llm.CacheBestEffort}},
+					Directives:    []llm.CacheDirective{{Target: llm.CacheTarget{Kind: llm.CacheAfterMessageBlock}, Policy: llm.CacheBestEffort, TTL: llm.CacheTTL1Hour}},
 				}} {
 					calls := 0
 					var payload []byte

--- a/sdk/llm/cache_target_view.go
+++ b/sdk/llm/cache_target_view.go
@@ -53,15 +53,22 @@ func NewCacheTargetView(request InvokeRequest) (*CacheTargetView, error) {
 	if err != nil {
 		return nil, cachePlanError("uncloneable_request", -1)
 	}
-	view := &CacheTargetView{request: &owned}
-	for i, message := range owned.Messages {
+	return &CacheTargetView{request: &owned, targets: CacheTargets(owned)}, nil
+}
+
+// CacheTargets returns owned, content-free logical target metadata for a request.
+// It is the same projection used by CacheTargetView, not a new binding or proof
+// that a stale plan is valid. Callers must own inputs while this reads them.
+func CacheTargets(request InvokeRequest) []CacheTargetDescriptor {
+	var targets []CacheTargetDescriptor
+	for i, message := range request.Messages {
 		if message.Role != RoleSystem && message.Role != RoleUser && message.Role != RoleAssistant && message.Role != RoleTool {
 			continue
 		}
 		ordinal := 0
-		start := len(view.targets)
+		start := len(targets)
 		appendBlock := func(source string, index int) {
-			view.targets = append(view.targets, CacheTargetDescriptor{
+			targets = append(targets, CacheTargetDescriptor{
 				Target: CacheTarget{Kind: CacheAfterMessageBlock, MessageIndex: i, BlockOrdinal: ordinal},
 				Source: source, SourceIndex: index,
 			})
@@ -105,21 +112,21 @@ func NewCacheTargetView(request InvokeRequest) (*CacheTargetView, error) {
 				}
 			}
 		}
-		if len(view.targets) > start {
-			last := view.targets[len(view.targets)-1]
+		if len(targets) > start {
+			last := targets[len(targets)-1]
 			// This is a logical message boundary. Provider mapping must still
 			// reject unsupported/hidden trailing wire blocks instead of guessing.
 			last.Target = CacheTarget{Kind: CacheAfterMessage, MessageIndex: i}
-			view.targets = append(view.targets, last)
+			targets = append(targets, last)
 		}
 	}
-	for i := range owned.Tools {
-		view.targets = append(view.targets, CacheTargetDescriptor{
+	for i := range request.Tools {
+		targets = append(targets, CacheTargetDescriptor{
 			Target: CacheTarget{Kind: CacheAfterToolDefinition, ToolIndex: i},
 			Source: "tool_definition", SourceIndex: i,
 		})
 	}
-	return view, nil
+	return targets
 }
 
 // Targets returns an owned list. BlockOrdinal indexes visible logical blocks:


### PR DESCRIPTION
## Scope

Related to #89; implements eligible ContentBlock cache targets through the existing admission and Anthropic serializer. No second normalization algorithm, serializer, execution/event sequence or hash gate.

- Extract existing normalized descriptor projection as llm.CacheTargets; NewCacheTargetView still owns a cloned original request and uses that same projection. Metadata projection is not a new binding or stale-plan authorization.
- Record raw source kind/index to actual wire location only for messages whose block locations are needed. Resolve canonical BlockOrdinal through that source metadata, never as a raw Content.Blocks or wire index.
- Supports eligible text, user image, assistant tool-use and outer Tool Result boundaries. Hidden/opaque/empty sources are not ordinal targets; document placeholders remain unmappable. Collapsed System keeps its whole string and only the last actual endpoint; no invented earlier split. Message/final-block alias validation remains.
- Default/5m TTL/four breakpoints;1h still unsupported. Accepted plans override legacy cache markers, nil/empty/all-skipped preserve legacy. Existing generic unsupported tests now use1h TTL because block targets are implemented; golden bytes remain unchanged.

Official cache rules: [supported blocks and exclusions](https://platform.claude.com/docs/en/build-with-claude/prompt-caching). This is client mapping, not proof of remote acceptance, full document/image validity, or cache hit. Nested Tool Result subcontent is not a separate normalized target.

## Validation

Focused100 passed. Actual buffered/streamed coupled golden plus20 individual source positions cover first/middle/last, hidden/opaque/empty/placeholder offsets, both tool calls and both merged results before/after reorder, capacity exclusion, stale/invalid/alias zero I/O, collapsed System and metadata isolation. Earlier canonical view golden still verifies the extracted projection.

Author and independent exactc84e27b full/vet/LLM-provider-Agent race/focused100 passed; author also Compaction race, reviewer build. Six mutations caught rawwireindex-as-ordinal, missingTextsource, allToolCall/allToolResult block0, droppedDocumentordinal and retainedlegacymarkers; restoredclean. Independent Goode full/vet/5pkgrace/strictactualSDKbuild and prior133warning/debug/wrapperprobes race10 passed.

Builder-only three-sample medians: legacy1012ns/984B/14alloc, tool1220ns/1088B/17alloc, message1329ns/1152B/18alloc, block2363ns/2944B/24alloc. Two tools, one one-KiB system block and one user block; excludes admission/eligibility/JSON/network. No speedup, live cache-hit or model-quality claim.
