### PR TITLE
feat(anthropic): support mixed cache TTLs in wire order

### DIFF
--- a/agent_docs/providers.md
+++ b/agent_docs/providers.md
@@ -10,7 +10,7 @@ stream normalization, and response metadata behavior.
   entrypoints clone and validate that original binding before network I/O:
   stale/unbound/unsupported Required plans fail; accepted/skipped decisions produce
   bounded `Completion.Diagnostics` and warning metadata. Anthropic maps exact
-  Tool Definition and eligible Message/ContentBlock boundaries with default/5m TTL and up to
+  Tool Definition and eligible Message/ContentBlock boundaries with default/5m/1h TTL and up to
   four breakpoints. Eligibility comes from the same serialization traversal,
   before capacity allocation: hidden/empty/placeholder endpoints are not targets.
   A collapsed System string exposes only its last emitted source endpoint and
@@ -19,7 +19,10 @@ stream normalization, and response metadata behavior.
   the shared `llm.CacheTargets` metadata projection, not a raw Blocks/wire index;
   hidden/opaque/empty sources are not ordinal targets, and document placeholders
   are unmappable. Tool Results expose only their outer result block. A collapsed
-  System string exposes only its final actual endpoint. 1h TTL remains unsupported.
+  System string exposes only its final actual endpoint. Mixed TTLs follow actual
+  tools/system/messages wire order: long TTLs must precede short/default TTLs.
+  Required conflicts reject before network; best-effort entries are selected in
+  original priority order only when compatible, without rewriting TTL or Prompt.
   An accepted plan overrides
   legacy cache markers without changing block shape/text/order. All-skipped,
   nil and empty plans preserve the legacy path. See the official

--- a/sdk/llm/anthropic/cache_plan.go
+++ b/sdk/llm/anthropic/cache_plan.go
@@ -88,12 +88,81 @@ func (c *Client) PromptCacheTargetEligibility(request llm.InvokeRequest, targets
 	return eligible
 }
 
+// PromptCacheTTLOrder uses tools -> system -> messages, including merged-result
+// and collapsed-system locations. Input directive order is not wire order.
+func (c *Client) PromptCacheTTLOrder(request llm.InvokeRequest, targets []llm.CacheTarget) []int {
+	locations, descriptors := newCacheLocations(request, targets)
+	var system any
+	var messages []messageParam
+	if locations != nil {
+		var err error
+		system, messages, err = serializeMessagesWithLocations(request.Messages, nil, locations)
+		if err != nil {
+			locations = nil
+		}
+	}
+	return cacheWireOrder(targets, len(request.Tools), system, messages, locations, descriptors)
+}
+
+func cacheWireOrder(targets []llm.CacheTarget, toolCount int, system any, messages []messageParam, locations []messageCacheLocation, descriptors []llm.CacheTargetDescriptor) []int {
+	systemCount := 0
+	switch blocks := system.(type) {
+	case string:
+		systemCount = 1
+	case []contentBlockParam:
+		systemCount = len(blocks)
+	}
+	offsets := make([]int, len(messages))
+	next := toolCount + systemCount
+	for i, message := range messages {
+		offsets[i] = next
+		next += len(message.Content)
+	}
+	order := make([]int, len(targets))
+	for i, target := range targets {
+		order[i] = -1
+		if target.Kind == llm.CacheAfterToolDefinition {
+			if target.ToolIndex >= 0 && target.ToolIndex < toolCount {
+				order[i] = target.ToolIndex
+			}
+			continue
+		}
+		location := cacheLocation(target, locations, descriptors)
+		if !location.eligible {
+			continue
+		}
+		if location.system {
+			order[i] = toolCount + location.block
+		} else if location.message >= 0 && location.message < len(offsets) {
+			order[i] = offsets[location.message] + location.block
+		}
+	}
+	return order
+}
+
 // applyCachePlan only touches newly serialized objects, after all destinations
 // pass validation. A collapsed system string can be wrapped whole, not split
 // to invent earlier source boundaries. Existing structured blocks keep shape.
 func applyCachePlan(plan *llm.CachePlan, system *any, messages []messageParam, tools []toolParam, locations []messageCacheLocation, sources []llm.CacheTargetDescriptor) error {
 	if len(plan.Directives) > 4 {
 		return &llm.CachePlanValidationError{Reason: "breakpoint_limit", DirectiveIndex: -1}
+	}
+	targets := make([]llm.CacheTarget, len(plan.Directives))
+	for i, d := range plan.Directives {
+		targets[i] = d.Target
+	}
+	order := cacheWireOrder(targets, len(tools), *system, messages, locations, sources)
+	for i, d := range plan.Directives {
+		for j := 0; j < i; j++ {
+			previous := plan.Directives[j]
+			if order[i] >= 0 && order[i] == order[j] {
+				return &llm.CachePlanValidationError{Reason: "duplicate_boundary", DirectiveIndex: i}
+			}
+			long, previousLong := d.TTL == llm.CacheTTL1Hour, previous.TTL == llm.CacheTTL1Hour
+			if order[i] >= 0 && order[j] >= 0 && long != previousLong && ((long && order[i] > order[j]) || (!long && order[i] < order[j])) {
+				return &llm.CachePlanValidationError{Reason: "ttl_order_conflict", DirectiveIndex: i}
+			}
+		}
 	}
 	sysBlocks, _ := (*system).([]contentBlockParam)
 	var wrapped []contentBlockParam
@@ -130,7 +199,7 @@ func applyCachePlan(plan *llm.CachePlan, system *any, messages []messageParam, t
 		if destination == nil {
 			return &llm.CachePlanValidationError{Reason: "unmappable_target", DirectiveIndex: i}
 		}
-		if directive.TTL != llm.CacheTTLProviderDefault && directive.TTL != llm.CacheTTL5Minutes {
+		if directive.TTL != llm.CacheTTLProviderDefault && directive.TTL != llm.CacheTTL5Minutes && directive.TTL != llm.CacheTTL1Hour {
 			return &llm.CachePlanValidationError{Reason: "unsupported_ttl", DirectiveIndex: i}
 		}
 		destinations = append(destinations, destination)

--- a/sdk/llm/anthropic/cache_plan_test.go
+++ b/sdk/llm/anthropic/cache_plan_test.go
@@ -21,7 +21,7 @@ func TestToolCacheMappingGuardDoesNotPartiallyRewrite(t *testing.T) {
 	}
 	for _, plan := range []*llm.CachePlan{
 		{Directives: make([]llm.CacheDirective, 5)},
-		{Directives: []llm.CacheDirective{{Target: llm.CacheTarget{Kind: llm.CacheAfterToolDefinition}, TTL: llm.CacheTTL1Hour}}},
+		{Directives: []llm.CacheDirective{{Target: llm.CacheTarget{Kind: llm.CacheAfterToolDefinition}, TTL: "invalid"}}},
 	} {
 		tools := []toolParam{{CacheCtrl: &cacheControl{Type: "ephemeral"}}}
 		var system any
@@ -76,5 +76,22 @@ func TestMessageMappingGuardDoesNotPartiallyWrapSystem(t *testing.T) {
 	}
 	if system != "original\n\ntext" {
 		t.Fatal("failed mapping partially rewrote system")
+	}
+}
+
+func TestMixedTTLBuilderGuardBeforeMutation(t *testing.T) {
+	var system any = "unchanged"
+	tools := []toolParam{{CacheCtrl: &cacheControl{Type: "ephemeral"}}, {CacheCtrl: &cacheControl{Type: "ephemeral"}}}
+	before, _ := json.Marshal(tools)
+	plan := &llm.CachePlan{Directives: []llm.CacheDirective{
+		{Target: llm.CacheTarget{Kind: llm.CacheAfterToolDefinition, ToolIndex: 1}, TTL: llm.CacheTTL1Hour},
+		{Target: llm.CacheTarget{Kind: llm.CacheAfterToolDefinition, ToolIndex: 0}},
+	}}
+	if err := applyCachePlan(plan, &system, nil, tools, nil, nil); err == nil {
+		t.Fatal("illegal wire order accepted")
+	}
+	after, _ := json.Marshal(tools)
+	if string(before) != string(after) || system != "unchanged" {
+		t.Fatal("TTL guard partially rewrote payload")
 	}
 }

--- a/sdk/llm/anthropic/client.go
+++ b/sdk/llm/anthropic/client.go
@@ -75,9 +75,9 @@ func (c *Client) Provider() string { return "anthropic" }
 
 // PromptCacheCapabilities reports implemented explicit mappings, not a promise
 // of endpoint/model acceptance or a cache hit. Request-local eligibility further
-// restricts message/block boundaries. 1h mapping remains unsupported.
+// restricts message/block boundaries; mixed TTLs follow actual wire order.
 func (c *Client) PromptCacheCapabilities() llm.PromptCacheCapabilities {
-	return llm.PromptCacheCapabilities{ExplicitMessageBoundary: true, ExplicitContentBlock: true, ExplicitToolDefinition: true, SupportedTTLs: []llm.CacheTTL{llm.CacheTTL5Minutes}, MaxBreakpoints: 4, UsageTelemetry: true}
+	return llm.PromptCacheCapabilities{ExplicitMessageBoundary: true, ExplicitContentBlock: true, ExplicitToolDefinition: true, SupportedTTLs: []llm.CacheTTL{llm.CacheTTL5Minutes, llm.CacheTTL1Hour}, MaxBreakpoints: 4, UsageTelemetry: true}
 }
 
 func (c *Client) Model() string { return c.ModelName }

--- a/sdk/llm/anthropic_tool_cache_wire_test.go
+++ b/sdk/llm/anthropic_tool_cache_wire_test.go
@@ -138,7 +138,8 @@ func TestAnthropicToolCacheFailuresBeforeNetwork(t *testing.T) {
 				directives := []llm.CacheDirective{toolDirective(0, llm.CacheRequired, "")}
 				reason, index := "unsupported_ttl", 0
 				if failure == "ttl" {
-					directives[0].TTL = llm.CacheTTL1Hour
+					directives = append(directives, toolDirective(1, llm.CacheRequired, llm.CacheTTL1Hour))
+					reason, index = "ttl_order_conflict", 1
 				}
 				if failure == "overflow" {
 					for i := 1; i < 5; i++ {

--- a/sdk/llm/anthropic_tool_cache_wire_test.go
+++ b/sdk/llm/anthropic_tool_cache_wire_test.go
@@ -236,10 +236,19 @@ func TestCacheAdmissionMixedSummaryDoesNotMislabelAccepted(t *testing.T) {
 }
 
 func TestAnthropicExplicitToolCacheSurvivesBetaRetry(t *testing.T) {
-	for _, stream := range []bool{false, true} {
-		t.Run(fmt.Sprint(stream), func(t *testing.T) {
+	for _, test := range []struct {
+		stream bool
+		ttl    llm.CacheTTL
+		mixed  bool
+	}{{false, llm.CacheTTL5Minutes, false}, {true, llm.CacheTTL5Minutes, false}, {false, llm.CacheTTL1Hour, false}, {true, llm.CacheTTL1Hour, false}, {false, llm.CacheTTL1Hour, true}, {true, llm.CacheTTL1Hour, true}} {
+		stream := test.stream
+		t.Run(fmt.Sprintf("%v/%s/mixed=%v", stream, test.ttl, test.mixed), func(t *testing.T) {
 			request := toolCacheRequest()
-			bindToolCache(t, &request, []llm.CacheDirective{toolDirective(2, llm.CacheRequired, llm.CacheTTL5Minutes)})
+			directives := []llm.CacheDirective{toolDirective(2, llm.CacheRequired, test.ttl)}
+			if test.mixed {
+				directives = append(directives, toolDirective(4, llm.CacheRequired, llm.CacheTTL5Minutes))
+			}
+			bindToolCache(t, &request, directives)
 			before, err := llm.CloneInvokeRequest(request)
 			if err != nil {
 				t.Fatal(err)
@@ -268,8 +277,11 @@ func TestAnthropicExplicitToolCacheSurvivesBetaRetry(t *testing.T) {
 			client := model.(*anthropic.Client)
 			client.Beta = []string{"unsupported-beta"}
 			_, err = callAdmissionModel(context.Background(), model, request, stream)
-			if err != nil || len(payloads) != 2 || payloads[0] != payloads[1] || accepted.Load() != 1 {
+			if err != nil || len(payloads) != 2 || payloads[0] != payloads[1] || accepted.Load() != int32(len(directives)) {
 				t.Fatalf("retry count=%d accepted=%d err=%v", len(payloads), accepted.Load(), err)
+			}
+			if test.ttl == llm.CacheTTL1Hour && !strings.Contains(payloads[0], `"ttl":"1h"`) {
+				t.Fatal("long TTL fixture did not reach wire")
 			}
 			if !reflect.DeepEqual(request, before) || !reflect.DeepEqual(client.Beta, []string{"unsupported-beta"}) {
 				t.Fatal("compat retry mutated source")

--- a/sdk/llm/cache_admission_test.go
+++ b/sdk/llm/cache_admission_test.go
@@ -43,11 +43,12 @@ func admissionModel(provider string, transport cacheWireTransport, warning func(
 func admissionRequest(t *testing.T, policy llm.CacheDirectivePolicy) llm.InvokeRequest {
 	t.Helper()
 	request := llm.InvokeRequest{Messages: []llm.Message{{Role: llm.RoleSystem, Content: llm.TextContent("system"), Cache: true}, {Role: llm.RoleUser, Content: llm.TextContent("hello")}}}
+	request.Messages[1].Content.Blocks = []llm.ContentBlock{{Type: "document", Source: &llm.DocSrc{Data: "fixture-document", MediaType: "application/pdf"}}}
 	view, err := llm.NewCacheTargetView(request)
 	if err != nil {
 		t.Fatal(err)
 	}
-	request.CachePlan, err = view.Bind([]llm.CacheDirective{{Target: llm.CacheTarget{Kind: llm.CacheAfterMessageBlock, MessageIndex: 1}, Policy: policy, TTL: llm.CacheTTL1Hour}})
+	request.CachePlan, err = view.Bind([]llm.CacheDirective{{Target: llm.CacheTarget{Kind: llm.CacheAfterMessageBlock, MessageIndex: 1, BlockOrdinal: 1}, Policy: policy}})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -85,7 +86,7 @@ func TestCacheAdmissionRejectsBeforeNetwork(t *testing.T) {
 					request := admissionRequest(t, llm.CacheRequired)
 					reason := "unsupported_target"
 					if provider == "anthropic" {
-						reason = "unsupported_ttl"
+						reason = "unmappable_target"
 					}
 					index := 0
 					switch failure {
@@ -225,7 +226,7 @@ func TestCacheAdmissionBestEffortWireDiagnosticsAndIsolation(t *testing.T) {
 						if planned {
 							reason := "unsupported_target"
 							if provider == "anthropic" {
-								reason = "unsupported_ttl"
+								reason = "unmappable_target"
 							}
 							if !reflect.DeepEqual(warnings, []string{"cache_plan_skipped: directive 0: " + reason}) {
 								t.Fatalf("warnings=%v", warnings)

--- a/sdk/llm/cache_boundary_wire_test.go
+++ b/sdk/llm/cache_boundary_wire_test.go
@@ -77,22 +77,8 @@ func TestAnthropicLegacyCacheBoundaryWireGolden(t *testing.T) {
 		for _, stream := range []bool{false, true} {
 			t.Run(fmt.Sprintf("%s/stream=%v", fixture.name, stream), func(t *testing.T) {
 				var baseline []byte
-				for _, plan := range []*llm.CachePlan{nil, {Directives: []llm.CacheDirective{}}, {
-					SchemaVersion: llm.CachePlanSchemaVersion,
-					Directives:    []llm.CacheDirective{{Target: llm.CacheTarget{Kind: llm.CacheAfterMessageBlock}, Policy: llm.CacheBestEffort, TTL: llm.CacheTTL1Hour}},
-				}} {
+				for _, plan := range []*llm.CachePlan{nil, {Directives: []llm.CacheDirective{}}} {
 					request := llm.InvokeRequest{Messages: llm.CloneMessages(fixture.messages), Tools: tools, CachePlan: plan}
-					if plan != nil && len(plan.Directives) != 0 {
-						view, err := llm.NewCacheTargetView(request)
-						if err != nil {
-							t.Fatal(err)
-						}
-						plan, err = view.Bind(plan.Directives)
-						if err != nil {
-							t.Fatal(err)
-						}
-						request.CachePlan = plan
-					}
 					before, err := llm.CloneInvokeRequest(request)
 					if err != nil {
 						t.Fatal(err)

--- a/sdk/llm/cache_decision.go
+++ b/sdk/llm/cache_decision.go
@@ -5,7 +5,8 @@ import "reflect"
 // CacheDirectiveDecision is bounded, content-free metadata for one original
 // directive. Accepted means eligible under reported capabilities, not mapped,
 // sent, or cached. Reason is accepted, unsupported_target, unsupported_ttl,
-// unmappable_target, or breakpoint_limit. No content, names, IDs, hashes or
+// unmappable_target, breakpoint_limit, ttl_order_conflict, or duplicate_boundary.
+// No content, names, IDs, hashes or
 // Provider strings are kept.
 type CacheDirectiveDecision struct {
 	DirectiveIndex int
@@ -29,7 +30,8 @@ type CachePlanDecision struct {
 // Built-in admission reuses this helper; it can also be called without sending.
 //
 // Invalid/stale plans fail for both policies. Required directives reserve
-// capacity first; remaining best-effort directives are kept in input order.
+// capacity first; remaining best-effort directives are kept in input order when
+// compatible with required/previously selected wire TTL boundaries.
 // Unsupported required directives or required overflow reject the entire plan
 // with a fixed CachePlanValidationError, never a partially accepted result.
 func (view *CacheTargetView) Decide(request InvokeRequest, plan *CachePlan, model ChatModel) (*CachePlanDecision, error) {
@@ -80,6 +82,28 @@ func (view *CacheTargetView) Decide(request InvokeRequest, plan *CachePlan, mode
 		}
 		eligible = append([]bool(nil), mapping...)
 	}
+	var order []int
+	for _, directive := range plan.Directives {
+		if directive.TTL != CacheTTL1Hour {
+			continue
+		}
+		if provider, ok := model.(PromptCacheTTLOrderProvider); ok {
+			copy, err := CloneInvokeRequest(*snapshot)
+			if err != nil {
+				return nil, cachePlanError("uncloneable_request", -1)
+			}
+			targets := make([]CacheTarget, len(plan.Directives))
+			for i, d := range plan.Directives {
+				targets[i] = d.Target
+			}
+			positions := provider.PromptCacheTTLOrder(copy, targets)
+			if len(positions) != len(targets) {
+				return nil, cachePlanError("invalid_capabilities", -1)
+			}
+			order = append([]int(nil), positions...)
+		}
+		break
+	}
 	result.Directives = make([]CacheDirectiveDecision, len(plan.Directives))
 	required := 0
 	for i, directive := range plan.Directives {
@@ -110,6 +134,9 @@ func (view *CacheTargetView) Decide(request InvokeRequest, plan *CachePlan, mode
 		if reason == "accepted" && eligible != nil && !eligible[i] {
 			reason = "unmappable_target"
 		}
+		if reason == "accepted" && order != nil && order[i] < 0 {
+			reason = "unmappable_target"
+		}
 		if directive.Policy == CacheRequired {
 			if reason != "accepted" {
 				return nil, cachePlanError(reason, i)
@@ -122,23 +149,59 @@ func (view *CacheTargetView) Decide(request InvokeRequest, plan *CachePlan, mode
 		result.Directives[i] = CacheDirectiveDecision{DirectiveIndex: i, Reason: reason}
 	}
 	remaining := caps.MaxBreakpoints - required
-	// Filter the owned slice, preserving nil/empty ownership and original order.
-	directives := result.Plan.Directives
-	result.Plan.Directives = result.Plan.Directives[:0]
-	for i, directive := range directives {
+	selected := make([]int, 0, required)
+	conflict := func(index int) string {
+		if order == nil {
+			return ""
+		}
+		for _, previous := range selected {
+			if order[index] == order[previous] {
+				return "duplicate_boundary"
+			}
+			long, previousLong := plan.Directives[index].TTL == CacheTTL1Hour, plan.Directives[previous].TTL == CacheTTL1Hour
+			if long != previousLong && ((long && order[index] > order[previous]) || (!long && order[index] < order[previous])) {
+				return "ttl_order_conflict"
+			}
+		}
+		return ""
+	}
+	for i, d := range plan.Directives {
+		if d.Policy != CacheRequired {
+			continue
+		}
+		if reason := conflict(i); reason != "" {
+			return nil, cachePlanError(reason, i)
+		}
+		selected = append(selected, i)
+	}
+	// Decide optional entries before compacting the slice: conflict lookup must
+	// keep the original directive indexes and TTLs throughout selection.
+	for i, d := range plan.Directives {
 		decision := &result.Directives[i]
 		if decision.Reason != "accepted" {
 			continue
 		}
-		if directive.Policy == CacheBestEffort {
+		if d.Policy == CacheBestEffort {
+			if reason := conflict(i); reason != "" {
+				decision.Reason = reason
+				continue
+			}
 			if remaining == 0 {
 				decision.Reason = "breakpoint_limit"
 				continue
 			}
 			remaining--
+			selected = append(selected, i)
 		}
 		decision.Accepted = true
-		result.Plan.Directives = append(result.Plan.Directives, directive)
+	}
+	// Filter the owned slice, preserving nil/empty ownership and original order.
+	directives := result.Plan.Directives
+	result.Plan.Directives = result.Plan.Directives[:0]
+	for i, directive := range directives {
+		if result.Directives[i].Accepted {
+			result.Plan.Directives = append(result.Plan.Directives, directive)
+		}
 	}
 	return result, nil
 }

--- a/sdk/llm/cache_decision_test.go
+++ b/sdk/llm/cache_decision_test.go
@@ -173,20 +173,25 @@ func TestCacheDecisionBuiltinCapabilitiesAreConservative(t *testing.T) {
 			want.ExplicitMessageBoundary = true
 			want.ExplicitContentBlock = true
 			want.ExplicitToolDefinition, want.MaxBreakpoints = true, 4
-			want.SupportedTTLs = []llm.CacheTTL{llm.CacheTTL5Minutes}
+			want.SupportedTTLs = []llm.CacheTTL{llm.CacheTTL5Minutes, llm.CacheTTL1Hour}
 		}
 		if !ok || !reflect.DeepEqual(provider.PromptCacheCapabilities(), want) {
 			t.Fatal("builtin claims unimplemented explicit control")
 		}
 		request, view, plan := cacheDecisionFixture(t)
 		for i := range plan.Directives {
+			request.Messages[i].Content.Blocks = []llm.ContentBlock{{Type: "document", Source: &llm.DocSrc{Data: "fixture", MediaType: "application/pdf"}}}
 			plan.Directives[i].Target.Kind = llm.CacheAfterMessageBlock
-			plan.Directives[i].TTL = llm.CacheTTL1Hour
+			plan.Directives[i].Target.BlockOrdinal = 1
 		}
-		_, err := view.Decide(request, plan, model)
+		view, err := llm.NewCacheTargetView(request)
+		if err != nil {
+			t.Fatal(err)
+		}
+		_, err = view.Decide(request, plan, model)
 		reason := "unsupported_target"
 		if _, ok := model.(*anthropic.Client); ok {
-			reason = "unsupported_ttl"
+			reason = "unmappable_target"
 		}
 		assertCacheViewError(t, err, reason, 2)
 		plan.Directives[2].Policy = llm.CacheBestEffort

--- a/sdk/llm/cache_plan.go
+++ b/sdk/llm/cache_plan.go
@@ -115,3 +115,10 @@ type PromptCacheCapabilityProvider interface {
 type PromptCacheTargetEligibilityProvider interface {
 	PromptCacheTargetEligibility(InvokeRequest, []CacheTarget) []bool
 }
+
+// PromptCacheTTLOrderProvider reports actual wire positions for clients that
+// require longer TTLs before shorter ones. Negative positions are unmappable;
+// equal positions identify the same breakpoint. Results follow target input order.
+type PromptCacheTTLOrderProvider interface {
+	PromptCacheTTLOrder(InvokeRequest, []CacheTarget) []int
+}

--- a/sdk/llm/cache_plan_wire_test.go
+++ b/sdk/llm/cache_plan_wire_test.go
@@ -25,10 +25,7 @@ func TestCachePlanAttachmentPreservesLegacyWireGolden(t *testing.T) {
 		for _, stream := range []bool{false, true} {
 			t.Run(fmt.Sprintf("%s/stream=%v", provider, stream), func(t *testing.T) {
 				var baseline []byte
-				for _, plan := range []*llm.CachePlan{nil, {Directives: []llm.CacheDirective{}}, {
-					SchemaVersion: llm.CachePlanSchemaVersion,
-					Directives:    []llm.CacheDirective{{Target: llm.CacheTarget{Kind: llm.CacheAfterMessageBlock}, Policy: llm.CacheBestEffort, TTL: llm.CacheTTL1Hour}},
-				}} {
+				for _, plan := range []*llm.CachePlan{nil, {Directives: []llm.CacheDirective{}}} {
 					calls := 0
 					var payload []byte
 					httpClient := &http.Client{Transport: cacheWireTransport(func(r *http.Request) (*http.Response, error) {
@@ -53,17 +50,6 @@ func TestCachePlanAttachmentPreservesLegacyWireGolden(t *testing.T) {
 						Messages:  []llm.Message{{Role: llm.RoleSystem, Content: llm.TextContent("system"), Cache: true}, {Role: llm.RoleUser, Content: llm.TextContent("hello"), Cache: true}},
 						Tools:     []llm.ToolDefinition{{Name: "work", Description: "fixture", Parameters: map[string]any{"type": "object"}}},
 						CachePlan: plan,
-					}
-					if plan != nil && len(plan.Directives) != 0 {
-						view, err := llm.NewCacheTargetView(request)
-						if err != nil {
-							t.Fatal(err)
-						}
-						plan, err = view.Bind(plan.Directives)
-						if err != nil {
-							t.Fatal(err)
-						}
-						request.CachePlan = plan
 					}
 					before, err := json.Marshal(request.Messages)
 					if err != nil {

--- a/sdk/llm/cache_ttl_test.go
+++ b/sdk/llm/cache_ttl_test.go
@@ -1,0 +1,213 @@
+package llm_test
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"reflect"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/timwhitez/agent-sdk-golang/sdk/llm"
+)
+
+func ttlDirective(d llm.CacheDirective, ttl llm.CacheTTL) llm.CacheDirective { d.TTL = ttl; return d }
+
+func TestAnthropicMixedTTLWireGolden(t *testing.T) {
+	for _, stream := range []bool{false, true} {
+		t.Run(fmt.Sprint(stream), func(t *testing.T) {
+			request := toolCacheRequest()
+			// Deliberately not wire order: results, system, tools, assistant.
+			bindToolCache(t, &request, []llm.CacheDirective{ttlDirective(messageDirective(4, llm.CacheRequired), llm.CacheTTL5Minutes), ttlDirective(messageDirective(0, llm.CacheRequired), llm.CacheTTL1Hour), toolDirective(1, llm.CacheRequired, llm.CacheTTL1Hour), messageDirective(2, llm.CacheRequired)})
+			before, err := llm.CloneInvokeRequest(request)
+			if err != nil {
+				t.Fatal(err)
+			}
+			var got map[string]any
+			var warnings []string
+			var calls atomic.Int32
+			model := admissionModel("anthropic", func(r *http.Request) (*http.Response, error) {
+				calls.Add(1)
+				data, _ := io.ReadAll(r.Body)
+				if err := json.Unmarshal(data, &got); err != nil {
+					return nil, err
+				}
+				body := admissionSuccess["anthropic"]
+				if stream {
+					body = admissionSSE("anthropic")
+				}
+				return &http.Response{StatusCode: 200, Header: make(http.Header), Body: io.NopCloser(strings.NewReader(body)), Request: r}, nil
+			}, func(f string, a ...any) { warnings = append(warnings, fmt.Sprintf(f, a...)) })
+			if _, err := callAdmissionModel(context.Background(), model, request, stream); err != nil || calls.Load() != 1 {
+				t.Fatal(err, calls.Load())
+			}
+			long := map[string]any{"type": "ephemeral", "ttl": "1h"}
+			if !reflect.DeepEqual(got["tools"].([]any)[1].(map[string]any)["cache_control"], long) || !reflect.DeepEqual(got["system"].([]any)[1].(map[string]any)["cache_control"], long) {
+				t.Fatal("long TTL mapped to wrong prefix")
+			}
+			messages := got["messages"].([]any)
+			if !reflect.DeepEqual(messages[1].(map[string]any)["content"].([]any)[1].(map[string]any)["cache_control"], map[string]any{"type": "ephemeral"}) {
+				t.Fatal("default TTL changed")
+			}
+			if !reflect.DeepEqual(messages[2].(map[string]any)["content"].([]any)[1].(map[string]any)["cache_control"], map[string]any{"type": "ephemeral", "ttl": "5m"}) {
+				t.Fatal("short TTL result mismatch")
+			}
+			if len(warnings) != 4 || !reflect.DeepEqual(request, before) {
+				t.Fatal("diagnostics/source mutation")
+			}
+		})
+	}
+}
+
+func TestAnthropicRequiredTTLConflictsUseWireOrder(t *testing.T) {
+	for _, stream := range []bool{false, true} {
+		for _, kind := range []string{"tools", "hierarchy", "merged", "blocks"} {
+			for _, reverse := range []bool{false, true} {
+				t.Run(fmt.Sprintf("%v/%s/%v", stream, kind, reverse), func(t *testing.T) {
+					request := toolCacheRequest()
+					var directives []llm.CacheDirective
+					switch kind {
+					case "tools":
+						directives = []llm.CacheDirective{toolDirective(0, llm.CacheRequired, ""), toolDirective(5, llm.CacheRequired, llm.CacheTTL1Hour)}
+					case "hierarchy":
+						directives = []llm.CacheDirective{toolDirective(0, llm.CacheRequired, ""), ttlDirective(messageDirective(0, llm.CacheRequired), llm.CacheTTL1Hour)}
+					case "merged":
+						request.Messages[3], request.Messages[4] = request.Messages[4], request.Messages[3]
+						directives = []llm.CacheDirective{messageDirective(3, llm.CacheRequired), ttlDirective(messageDirective(4, llm.CacheRequired), llm.CacheTTL1Hour)}
+					case "blocks":
+						directives = []llm.CacheDirective{blockDirective(2, 0, llm.CacheRequired), ttlDirective(blockDirective(2, 1, llm.CacheRequired), llm.CacheTTL1Hour)}
+					}
+					if reverse {
+						directives[0], directives[1] = directives[1], directives[0]
+					}
+					bindToolCache(t, &request, directives)
+					var calls atomic.Int32
+					model := admissionModel("anthropic", func(*http.Request) (*http.Response, error) { calls.Add(1); return nil, fmt.Errorf("must not send") }, func(string, ...any) { t.Error("rejected plan produced partial diagnostics") })
+					_, err := callAdmissionModel(context.Background(), model, request, stream)
+					assertCacheViewError(t, err, "ttl_order_conflict", 1)
+					if calls.Load() != 0 {
+						t.Fatal("TTL conflict reached network")
+					}
+				})
+			}
+		}
+	}
+}
+
+func TestAnthropicBestEffortTTLConflictDoesNotConsumeCapacity(t *testing.T) {
+	for _, stream := range []bool{false, true} {
+		t.Run(fmt.Sprint(stream), func(t *testing.T) {
+			request := toolCacheRequest()
+			bindToolCache(t, &request, []llm.CacheDirective{toolDirective(0, llm.CacheBestEffort, ""), toolDirective(4, llm.CacheRequired, llm.CacheTTL1Hour), toolDirective(1, llm.CacheBestEffort, llm.CacheTTL1Hour), toolDirective(2, llm.CacheBestEffort, llm.CacheTTL1Hour), toolDirective(5, llm.CacheBestEffort, ""), toolDirective(3, llm.CacheBestEffort, llm.CacheTTL1Hour)})
+			var got []int
+			var warnings []string
+			model := admissionModel("anthropic", func(r *http.Request) (*http.Response, error) {
+				data, _ := io.ReadAll(r.Body)
+				var payload map[string]any
+				if err := json.Unmarshal(data, &payload); err != nil {
+					return nil, err
+				}
+				for i, t := range payload["tools"].([]any) {
+					if t.(map[string]any)["cache_control"] != nil {
+						got = append(got, i)
+					}
+				}
+				return &http.Response{StatusCode: 401, Header: make(http.Header), Body: io.NopCloser(strings.NewReader(`{"error":{"message":"fixture"}}`)), Request: r}, nil
+			}, func(f string, a ...any) { warnings = append(warnings, fmt.Sprintf(f, a...)) })
+			_, _ = callAdmissionModel(context.Background(), model, request, stream)
+			if !reflect.DeepEqual(got, []int{1, 2, 4, 5}) {
+				t.Fatalf("TTL selection/capacity=%v", got)
+			}
+			if len(warnings) != 6 || !strings.Contains(warnings[0], "ttl_order_conflict") || !strings.Contains(warnings[5], "breakpoint_limit") {
+				t.Fatal("decision reasons", warnings)
+			}
+		})
+	}
+}
+
+func TestAnthropicCollapsedSystemLongTTL(t *testing.T) {
+	request := llm.InvokeRequest{Messages: []llm.Message{{Role: llm.RoleSystem, Content: llm.TextContent("one")}, {Role: llm.RoleSystem, Content: llm.TextContent("two")}, {Role: llm.RoleUser, Content: llm.TextContent("hello")}}}
+	bindToolCache(t, &request, []llm.CacheDirective{messageDirective(2, llm.CacheRequired), ttlDirective(blockDirective(1, 0, llm.CacheRequired), llm.CacheTTL1Hour)})
+	var calls atomic.Int32
+	model := admissionModel("anthropic", func(r *http.Request) (*http.Response, error) {
+		calls.Add(1)
+		data, _ := io.ReadAll(r.Body)
+		var payload map[string]any
+		if err := json.Unmarshal(data, &payload); err != nil {
+			return nil, err
+		}
+		want := []any{map[string]any{"type": "text", "text": "one\n\ntwo", "cache_control": map[string]any{"type": "ephemeral", "ttl": "1h"}}}
+		if !reflect.DeepEqual(payload["system"], want) {
+			t.Error("collapsed long TTL changed boundary")
+		}
+		return &http.Response{StatusCode: 401, Header: make(http.Header), Body: io.NopCloser(strings.NewReader(`{"error":{"message":"fixture"}}`)), Request: r}, nil
+	}, func(string, ...any) {})
+	_, _ = model.Invoke(context.Background(), request)
+	if calls.Load() != 1 {
+		t.Fatal("valid collapsed TTL not sent")
+	}
+}
+
+type ttlOrderModel struct {
+	cacheDecisionModel
+	hook func(llm.InvokeRequest, []llm.CacheTarget) []int
+}
+
+func (m *ttlOrderModel) PromptCacheTTLOrder(request llm.InvokeRequest, targets []llm.CacheTarget) []int {
+	return m.hook(request, targets)
+}
+
+func TestCacheTTLOrderHookOwnershipAndFailures(t *testing.T) {
+	request, view, plan := cacheDecisionFixture(t)
+	plan.Directives[2].TTL = llm.CacheTTL1Hour
+	before, _ := llm.CloneInvokeRequest(request)
+	model := &ttlOrderModel{cacheDecisionModel: cacheDecisionModel{caps: llm.PromptCacheCapabilities{ExplicitMessageBoundary: true, MaxBreakpoints: 4, SupportedTTLs: []llm.CacheTTL{llm.CacheTTL1Hour}}}}
+	positions := []int{2, 3, 1}
+	model.hook = func(copy llm.InvokeRequest, targets []llm.CacheTarget) []int {
+		copy.Messages[0].Content.Text = "private-change"
+		targets[0].MessageIndex = 99
+		return positions
+	}
+	result, err := view.Decide(request, plan, model)
+	if err != nil {
+		t.Fatal(err)
+	}
+	positions[0] = -1
+	if !reflect.DeepEqual(request, before) || len(result.Plan.Directives) != 3 || result.Plan.Directives[0].Target.MessageIndex != 0 {
+		t.Fatal("hook aliases escaped")
+	}
+	for _, bad := range []struct {
+		positions []int
+		reason    string
+		index     int
+	}{{[]int{1}, "invalid_capabilities", -1}, {[]int{-1, -1, -1}, "unmappable_target", 0}, {[]int{0, 1, 0}, "duplicate_boundary", 2}} {
+		model.hook = func(llm.InvokeRequest, []llm.CacheTarget) []int { return bad.positions }
+		plan.Directives[0].Policy = llm.CacheRequired
+		result, err := view.Decide(request, plan, model)
+		if result != nil || err == nil {
+			t.Fatal("bad order returned partial plan")
+		}
+		assertCacheViewError(t, err, bad.reason, bad.index)
+	}
+}
+
+func TestCacheTTLBestEffortKeepsInputPriority(t *testing.T) {
+	request, view, plan := cacheDecisionFixture(t)
+	for i := range plan.Directives {
+		plan.Directives[i].Policy = llm.CacheBestEffort
+	}
+	plan.Directives[1].TTL = llm.CacheTTL1Hour
+	model := &ttlOrderModel{cacheDecisionModel: cacheDecisionModel{caps: llm.PromptCacheCapabilities{ExplicitMessageBoundary: true, MaxBreakpoints: 2, SupportedTTLs: []llm.CacheTTL{llm.CacheTTL1Hour}}}}
+	model.hook = func(llm.InvokeRequest, []llm.CacheTarget) []int { return []int{0, 1, 2} }
+	result, err := view.Decide(request, plan, model)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := []llm.CacheDirectiveDecision{{DirectiveIndex: 0, Accepted: true, Reason: "accepted"}, {DirectiveIndex: 1, Reason: "ttl_order_conflict"}, {DirectiveIndex: 2, Accepted: true, Reason: "accepted"}}
+	if !reflect.DeepEqual(result.Directives, want) || !reflect.DeepEqual(result.Plan.Directives, []llm.CacheDirective{plan.Directives[0], plan.Directives[2]}) {
+		t.Fatalf("optional priority/capacity mismatch: %+v", result)
+	}
+}


### PR DESCRIPTION
## Scope

Related to #89; the multi-phase issue remains open.

Support Anthropic explicit 1h cache controls and mixed TTLs in actual tools → system → messages wire order. Reuse existing serializer source locations, admission, and Required-first capacity selection. Required conflicts reject before I/O; best-effort selection preserves input priority and does not consume capacity for conflicts. Never rewrite TTLs or reorder prompt content. Validate selected destinations again before writing any markers.

The optional TTL-order capability hook receives owned input. Existing providers without this constraint are unchanged. Nil/empty and all-skipped plans retain legacy behavior. Previous unsupported-1h fixtures now use genuinely unmappable document sources; nil/empty wire golden bytes are unchanged.

## Evidence

- Local focused mixed-TTL tests ×100 pass; preliminary full/vet/LLM+Agent+Compaction race pass.
- Final09c5f3c44cb2ffc8fa23f04798ebe8a9f79119dc author full/vet/LLM+Agent+Compaction race and focused/beta100 pass. Independent SDK exact-head APPROVE with full/vet/build/LLM+Agent race/focused100; wire-order, Required reservation, capacity, builder guard and repeated-admission mutations all detected.
- Independent Goode compatibility APPROVE: full/vet/5pkg race on identicald0d77b5 production, final09 beta race10/strict actual-source build repeated. Author paired Goode d8cfaf6 full/vet/seven-package race/strict actual09 build also pass.
- HTTP fixtures cover buffered/streamed mappings, opposite directive/wire order, merged results, collapsed system, Required conflicts with zero I/O, optional capacity, hook ownership/failure reasons, and builder rejection before mutation.
- Official rule: https://platform.claude.com/docs/en/build-with-claude/prompt-caching

## Non-goals

No host plan generator, dynamic concrete-model snapshot, production concurrency, second serializer, hash gate, session-format change, or raw-content diagnostics. No live-provider acceptance/cache-hit or performance claim.

Existing builder-only benchmark medians (3 samples): legacy1182ns/984B/14alloc, tool1525ns/1168B/20alloc, message1520ns/1232B/21alloc, block2780ns/3024B/27alloc. These are existing5m fixtures excluding admission/eligibility/JSON/network, not1h performance or an end-to-end improvement claim.
