### PR TITLE
feat(agent): bind explicit model configuration once per frame

### DIFF
--- a/agent_docs/architecture.md
+++ b/agent_docs/architecture.md
@@ -27,9 +27,11 @@ Key implementation: [agent.go](../sdk/agent/agent.go),
 [execution_frame.go](../sdk/agent/execution_frame.go),
 [tool_block_state.go](../sdk/agent/tool_block_state.go).
 
-- A Frame owns a cloned logical request and resolver definitions. Model/handler
-  references are handles, not immutable closure state or a dynamic wrapper's
-  concrete model snapshot. Provider serialization may transform the outgoing copy.
+- A Frame owns a cloned logical request and resolver definitions. It calls an
+  explicit `llm.FrameModelBinder` once before invocation; all SDK retries reuse
+  that configuration binding. Unknown/unsupported wrappers retain legacy handles.
+  Handler closure state and transport handles are not frozen. Provider
+  serialization may still transform the outgoing copy.
 - Partial continuation calls are not accepted Tool Blocks. Finalized calls use
   the finalizing Frame's dispatch context; their content can have multiple sources.
 - Provider Call IDs may repeat across blocks. The sequential block authority uses

--- a/agent_docs/providers.md
+++ b/agent_docs/providers.md
@@ -4,6 +4,18 @@ This document explains provider implementations, compatibility fallbacks,
 stream normalization, and response metadata behavior.
 
 ## Shared LLM Contracts
+- `FrameModelBinder` is an optional configuration-binding contract, not an
+  endpoint/model acceptance guarantee. The query driver captures it once per
+  logical Frame and preserves SDK retry/attempt numbering. Errors fail before
+  invocation with fixed diagnostics; unsupported/false results stay legacy.
+  A binding must retain streaming support and its outer concrete wrapper type;
+  different wrapper types are treated as unknown so embedded-client method
+  promotion cannot strip a host wrapper. No reflection-based unwrapping occurs.
+  Anthropic currently provides an owned copy of scalar/pointer/Beta/retry-map
+  configuration. HTTPClient and Warningf remain runtime handles; configure input
+  before binding, never mutate it concurrently. OpenAI clients and current Goode
+  wrappers have not adopted this contract. Compaction/whole-Run publication and
+  full host identity remain separate work; no new Manifest or content hash.
 - `InvokeRequest.CachePlan` is experimental in-memory intent, owned by
   `CloneInvokeRequest` and the private execution frame, and excluded from JSON.
   Bind nonempty plans with `CacheTargetView.Bind`. Built-in buffered/streaming

--- a/sdk/agent/agent.go
+++ b/sdk/agent/agent.go
@@ -803,6 +803,15 @@ func (a *Agent) queryStreamWithSteering(ctx context.Context, input llm.Content, 
 			} else if !frame.validBindings() {
 				frameFailure = "execution frame tool bindings inconsistent"
 			}
+			if frameFailure == "" {
+				bound, known, bindErr := llm.BindFrameModel(ctx, frame.model)
+				if bindErr != nil {
+					// A plugin error may contain configuration or credentials.
+					frameFailure = "execution frame model binding unavailable"
+				} else {
+					frame.model, frame.modelBound = bound, known
+				}
+			}
 			if frameFailure != "" {
 				a.warnf("warning: %s", frameFailure)
 				if cont.hasPending() {
@@ -919,7 +928,7 @@ func (a *Agent) queryStreamWithSteering(ctx context.Context, input llm.Content, 
 				if ctx.Err() != nil {
 					origin = EventOriginSDKDriver
 				}
-				emitErr(a.errEvent(err), origin, correlation)
+				emitErr(errEventForModel(err, frame.model), origin, correlation)
 				return
 			}
 			streamIdleRecoveries = 0
@@ -970,7 +979,7 @@ func (a *Agent) queryStreamWithSteering(ctx context.Context, input llm.Content, 
 					a.mu.Unlock()
 				}
 				emitErr(ErrorEvent{
-					Provider: a.llm.Provider(),
+					Provider: frame.model.Provider(),
 					Kind:     "invalid_tool_call_block",
 					Message:  fmt.Sprintf("provider returned duplicate tool_call_id values at positions %d and %d; no tools were executed", first+1, second+1),
 				}, EventOriginSDKDriver, correlation)
@@ -4981,9 +4990,17 @@ func classifyGenericErrorKind(err error) string {
 }
 
 func (a *Agent) errEvent(err error) ErrorEvent {
+	var model llm.ChatModel
+	if a != nil {
+		model = a.llm
+	}
+	return errEventForModel(err, model)
+}
+
+func errEventForModel(err error, model llm.ChatModel) ErrorEvent {
 	prov := ""
-	if a != nil && a.llm != nil {
-		prov = strings.TrimSpace(a.llm.Provider())
+	if model != nil {
+		prov = strings.TrimSpace(model.Provider())
 	}
 	if err == nil {
 		return ErrorEvent{Provider: prov, Message: "<nil>", Kind: "unknown"}

--- a/sdk/agent/agent.go
+++ b/sdk/agent/agent.go
@@ -797,6 +797,7 @@ func (a *Agent) queryStreamWithSteering(ctx context.Context, input llm.Content, 
 			}
 			frame, frameErr := newExecutionFrame(fmt.Sprintf("%s/frame/%d", out.queryID, iter+1), a.llm, request, a.toolMap, a.toolMapNormalized)
 			frameFailure := ""
+			frameFailureHint := "rebuild the Agent with consistent, cloneable tool definitions"
 			if frameErr != nil {
 				// Clone errors may contain schema data. Keep diagnostics structural.
 				frameFailure = "execution frame snapshot unavailable"
@@ -804,12 +805,13 @@ func (a *Agent) queryStreamWithSteering(ctx context.Context, input llm.Content, 
 				frameFailure = "execution frame tool bindings inconsistent"
 			}
 			if frameFailure == "" {
-				bound, known, bindErr := llm.BindFrameModel(ctx, frame.model)
+				bound, _, bindErr := llm.BindFrameModel(ctx, frame.model)
 				if bindErr != nil {
 					// A plugin error may contain configuration or credentials.
 					frameFailure = "execution frame model binding unavailable"
+					frameFailureHint = "check the model's FrameModelBinder implementation"
 				} else {
-					frame.model, frame.modelBound = bound, known
+					frame.model = bound
 				}
 			}
 			if frameFailure != "" {
@@ -825,7 +827,7 @@ func (a *Agent) queryStreamWithSteering(ctx context.Context, input llm.Content, 
 				return
 			}
 			if frameFailure != "" {
-				emitSDKErr(ErrorEvent{Kind: "invalid_request", Message: frameFailure + "; rebuild the Agent with consistent, cloneable tool definitions"})
+				emitSDKErr(ErrorEvent{Kind: "invalid_request", Message: frameFailure + "; " + frameFailureHint})
 				return
 			}
 			invocation := &frameInvocation{frameID: frame.id}

--- a/sdk/agent/execution_frame.go
+++ b/sdk/agent/execution_frame.go
@@ -17,7 +17,6 @@ import (
 type executionFrame struct {
 	id         string
 	model      llm.ChatModel
-	modelBound bool
 	request    llm.InvokeRequest
 	exact      map[string]tools.Tool
 	normalized map[string]tools.Tool

--- a/sdk/agent/execution_frame.go
+++ b/sdk/agent/execution_frame.go
@@ -10,12 +10,14 @@ import (
 // executionFrame owns one logical request, not the final provider payload.
 // For continued tool calls it is the finalizing request's dispatch snapshot;
 // the merged arguments may originate from multiple earlier requests.
-// Model/Handler values retain runtime handles, not immutable closure state or
-// a dynamic model wrapper's concrete target. Only the opaque id is correlated
+// Handlers retain runtime handles, not immutable closure state. The driver
+// captures a model configuration only through explicit FrameModelBinder support;
+// unbound wrappers retain legacy behavior. Only the opaque id is correlated
 // in event metadata; request/model/resolver content is not emitted here.
 type executionFrame struct {
 	id         string
 	model      llm.ChatModel
+	modelBound bool
 	request    llm.InvokeRequest
 	exact      map[string]tools.Tool
 	normalized map[string]tools.Tool

--- a/sdk/agent/frame_model_binding_test.go
+++ b/sdk/agent/frame_model_binding_test.go
@@ -1,0 +1,259 @@
+package agent
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/timwhitez/agent-sdk-golang/sdk/llm"
+	"github.com/timwhitez/agent-sdk-golang/sdk/llm/anthropic"
+	"github.com/timwhitez/agent-sdk-golang/sdk/tools"
+)
+
+type frameBindingSource struct {
+	current  llm.ChatModel
+	bind     func(context.Context) (llm.ChatModel, bool, error)
+	bindings int
+	label    string
+}
+
+func (m *frameBindingSource) Provider() string {
+	if m.label != "" {
+		return m.label
+	}
+	return "outer"
+}
+func (*frameBindingSource) Model() string { return "outer" }
+func (m *frameBindingSource) Invoke(ctx context.Context, request llm.InvokeRequest) (*llm.Completion, error) {
+	return m.current.Invoke(ctx, request)
+}
+func (m *frameBindingSource) BindFrameModel(ctx context.Context) (llm.ChatModel, bool, error) {
+	m.bindings++
+	return m.bind(ctx)
+}
+
+func TestFrameModelBindingRetryAndNextFrame(t *testing.T) {
+	for _, known := range []bool{false, true} {
+		var calls []string
+		source := &frameBindingSource{}
+		newModel := &frameScriptModel{invoke: func(llm.InvokeRequest) (*llm.Completion, error) {
+			calls = append(calls, "new")
+			return &llm.Completion{Content: llm.TextContent("done")}, nil
+		}}
+		oldModel := &frameScriptModel{invoke: func(llm.InvokeRequest) (*llm.Completion, error) {
+			calls = append(calls, "old")
+			if len(calls) == 1 {
+				source.current = newModel
+				return nil, &llm.ProviderError{StatusCode: 500, Message: "fixture"}
+			}
+			return &llm.Completion{ToolCalls: []llm.ToolCall{{ID: "work", Function: llm.FunctionCall{Name: "work", Arguments: `{}`}}}}, nil
+		}}
+		source.current = oldModel
+		source.bind = func(context.Context) (llm.ChatModel, bool, error) {
+			return &frameBindingSource{current: source.current}, known, nil
+		}
+		handlers := 0
+		ag, err := New(Config{LLM: source, QueryIDGenerator: func() string { return "binding" }, InvokeRetryMaxAttempts: 2, InvokeRetryBackoff: time.Millisecond, Warningf: func(string, ...any) {}, Tools: []tools.Tool{tools.Func[struct{}]("work", "fixture", func(context.Context, struct{}, *tools.Container) (any, error) { handlers++; return "ok", nil })}})
+		if err != nil {
+			t.Fatal(err)
+		}
+		var final EventEnvelope
+		for e := range ag.QueryStreamEnveloped(context.Background(), llm.TextContent("run")) {
+			if _, ok := e.Event.(ToolCallEvent); ok && (e.FrameID != "binding/frame/1" || e.InvokeAttempt != 2) {
+				t.Error("binding altered retry correlation", e.FrameID, e.InvokeAttempt)
+			}
+			if _, ok := e.Event.(FinalResponseEvent); ok {
+				final = e
+			}
+		}
+		want, bindings, toolCalls, frame := []string{"old", "new"}, 1, 0, "binding/frame/1"
+		if known {
+			want, bindings, toolCalls, frame = []string{"old", "old", "new"}, 2, 1, "binding/frame/2"
+		}
+		if !reflect.DeepEqual(calls, want) || source.bindings != bindings || handlers != toolCalls || final.FrameID != frame {
+			t.Fatalf("known=%v calls=%v bindings=%d handlers=%d final=%s", known, calls, source.bindings, handlers, final.FrameID)
+		}
+	}
+}
+
+func TestFrameBindingFailureCleansUnacceptedContinuation(t *testing.T) {
+	for _, canceled := range []bool{false, true} {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		invocations := 0
+		partial := &frameScriptModel{invoke: func(llm.InvokeRequest) (*llm.Completion, error) {
+			invocations++
+			return &llm.Completion{StopReason: "max_tokens", ToolCalls: []llm.ToolCall{{ID: "unfinished", Function: llm.FunctionCall{Name: "work", Arguments: `{"x":`}}}}, nil
+		}}
+		source := &frameBindingSource{current: partial}
+		source.bind = func(context.Context) (llm.ChatModel, bool, error) {
+			if source.bindings == 1 {
+				return &frameBindingSource{current: partial}, true, nil
+			}
+			if canceled {
+				cancel()
+			}
+			return nil, false, errors.New("PRIVATE_BINDING_SECRET")
+		}
+		ag, err := New(Config{LLM: source, Warningf: func(format string, args ...any) {
+			if strings.Contains(fmt.Sprintf(format, args...), "PRIVATE_") {
+				t.Error("raw binding error logged")
+			}
+		}})
+		if err != nil {
+			t.Fatal(err)
+		}
+		errorsSeen := 0
+		for e := range ag.QueryStreamEnveloped(ctx, llm.TextContent("run")) {
+			if failure, ok := e.Event.(ErrorEvent); ok {
+				errorsSeen++
+				kind := "invalid_request"
+				if canceled {
+					kind = "canceled"
+				}
+				if failure.Kind != kind || strings.Contains(failure.Message, "PRIVATE_") || e.InvokeAttempt != 0 || e.Origin != EventOriginSDKDriver {
+					t.Fatal("wrong binding failure outcome", failure, e.InvokeAttempt, e.Origin)
+				}
+			}
+			if _, ok := e.Event.(ToolResultEvent); ok {
+				t.Error("unaccepted fragment got result")
+			}
+		}
+		if invocations != 1 || source.bindings != 2 || errorsSeen != 1 {
+			t.Fatal(invocations, source.bindings, errorsSeen)
+		}
+		for _, m := range ag.Messages() {
+			if len(m.ToolCalls) != 0 || m.Role == llm.RoleTool {
+				t.Fatal("unaccepted continuation survived")
+			}
+		}
+	}
+}
+
+func TestFrameBindingTerminalErrorUsesBoundProvider(t *testing.T) {
+	target := &frameScriptModel{invoke: func(llm.InvokeRequest) (*llm.Completion, error) { return nil, errors.New("fixture rejection") }}
+	source := &frameBindingSource{current: target, bind: func(context.Context) (llm.ChatModel, bool, error) {
+		return &frameBindingSource{current: target, label: "fixture"}, true, nil
+	}}
+	ag, err := New(Config{LLM: source, InvokeRetryMaxAttempts: 1, Warningf: func(string, ...any) {}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	errorsSeen := 0
+	for event := range ag.QueryStream(context.Background(), llm.TextContent("run")) {
+		if e, ok := event.(ErrorEvent); ok {
+			errorsSeen++
+			if e.Provider != "fixture" {
+				t.Fatalf("error provider=%q, used outer instead of bound model", e.Provider)
+			}
+		}
+	}
+	if errorsSeen != 1 {
+		t.Fatalf("terminal errors=%d", errorsSeen)
+	}
+}
+
+type embeddedFrameClient struct {
+	*anthropic.Client
+	calls int
+}
+
+func (*embeddedFrameClient) Provider() string { return "wrapper" }
+func (*embeddedFrameClient) Model() string    { return "wrapper" }
+func (m *embeddedFrameClient) InvokeStream(context.Context, llm.InvokeRequest) (<-chan llm.StreamEvent, error) {
+	m.calls++
+	out := make(chan llm.StreamEvent, 2)
+	out <- llm.StreamTextDeltaEvent{Delta: "wrapper guard"}
+	out <- llm.StreamDoneEvent{}
+	close(out)
+	return out, nil
+}
+
+type frameBindingTransport func(*http.Request) (*http.Response, error)
+
+func (f frameBindingTransport) RoundTrip(r *http.Request) (*http.Response, error) { return f(r) }
+
+func TestPromotedFrameBinderCannotBypassWrapper(t *testing.T) {
+	for _, nilClient := range []bool{false, true} {
+		httpCalls := 0
+		wrapper := &embeddedFrameClient{}
+		if !nilClient {
+			wrapper.Client = &anthropic.Client{ModelName: "fixture", MaxRetries: 1, HTTPClient: &http.Client{Transport: frameBindingTransport(func(r *http.Request) (*http.Response, error) {
+				httpCalls++
+				return &http.Response{StatusCode: 401, Header: make(http.Header), Body: io.NopCloser(strings.NewReader(`{"error":{"message":"unexpected"}}`)), Request: r}, nil
+			})}}
+		}
+		ag, err := New(Config{LLM: wrapper, InvokeRetryMaxAttempts: 1, Warningf: func(string, ...any) {}})
+		if err != nil {
+			t.Fatal(err)
+		}
+		out, err := ag.Query(context.Background(), "run")
+		if err != nil || out != "wrapper guard" || wrapper.calls != 1 || httpCalls != 0 {
+			t.Fatalf("promoted binder bypassed wrapper: %q %v calls=%d http=%d", out, err, wrapper.calls, httpCalls)
+		}
+	}
+}
+
+func TestAnthropicFrameBindingOwnsActualRetryWire(t *testing.T) {
+	temperature := 0.2
+	client := &anthropic.Client{BaseURL: "https://fixture.invalid", ModelName: "old", Temperature: &temperature, Beta: []string{"old-beta"}, MaxRetries: 1}
+	var bodies, betas []string
+	client.HTTPClient = &http.Client{Transport: frameBindingTransport(func(r *http.Request) (*http.Response, error) {
+		body, _ := io.ReadAll(r.Body)
+		bodies = append(bodies, string(body))
+		betas = append(betas, r.Header.Get("anthropic-beta"))
+		status := 200
+		payload := ""
+		switch len(bodies) {
+		case 1:
+			// Binding is complete before this callback. Source changes must not
+			// alter this frame's retry, but must be visible to the next frame.
+			client.ModelName, client.Beta[0], temperature = "new", "new-beta", 0.9
+			status, payload = 500, `{"error":{"message":"fixture"}}`
+		case 2:
+			payload = "data: {\"type\":\"message_start\",\"message\":{\"id\":\"m1\",\"usage\":{\"input_tokens\":7}}}\n\n" +
+				"data: {\"type\":\"content_block_start\",\"index\":0,\"content_block\":{\"type\":\"tool_use\",\"id\":\"work\",\"name\":\"work\",\"input\":{}}}\n\n" +
+				"data: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"partial_json\":\"{}\"}}\n\n" +
+				"data: {\"type\":\"message_delta\",\"delta\":{\"stop_reason\":\"tool_use\"},\"usage\":{\"output_tokens\":1}}\n\ndata: {\"type\":\"message_stop\"}\n\n"
+		default:
+			payload = "data: {\"type\":\"message_start\",\"message\":{\"id\":\"m2\",\"usage\":{\"input_tokens\":7}}}\n\n" +
+				"data: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"text\":\"done\"}}\n\n" +
+				"data: {\"type\":\"message_delta\",\"delta\":{\"stop_reason\":\"end_turn\"},\"usage\":{\"output_tokens\":1}}\n\ndata: {\"type\":\"message_stop\"}\n\n"
+		}
+		return &http.Response{StatusCode: status, Header: make(http.Header), Body: io.NopCloser(strings.NewReader(payload)), Request: r}, nil
+	})}
+	handlers := 0
+	ag, err := New(Config{LLM: client, InvokeRetryMaxAttempts: 2, InvokeRetryBackoff: time.Millisecond, Warningf: func(string, ...any) {}, Tools: []tools.Tool{tools.Func[struct{}]("work", "fixture", func(context.Context, struct{}, *tools.Container) (any, error) { handlers++; return "ok", nil })}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	out, err := ag.Query(ctx, "run")
+	if err != nil || out != "done" || len(bodies) != 3 || handlers != 1 {
+		t.Fatalf("wire run: %q %v requests=%d tools=%d", out, err, len(bodies), handlers)
+	}
+	if bodies[0] != bodies[1] || betas[0] != betas[1] || !strings.Contains(betas[2], "new-beta") {
+		t.Fatal("same-frame retry wire changed")
+	}
+	for i, body := range bodies {
+		var payload map[string]any
+		if err := json.Unmarshal([]byte(body), &payload); err != nil {
+			t.Fatal(err)
+		}
+		model, temp := "old", 0.2
+		if i == 2 {
+			model, temp = "new", 0.9
+		}
+		if payload["model"] != model || payload["temperature"] != temp {
+			t.Fatalf("request %d did not use bound configuration: %v %v", i, payload["model"], payload["temperature"])
+		}
+	}
+}

--- a/sdk/llm/anthropic/model_binding.go
+++ b/sdk/llm/anthropic/model_binding.go
@@ -1,0 +1,45 @@
+package anthropic
+
+import (
+	"context"
+
+	"github.com/timwhitez/agent-sdk-golang/sdk/llm"
+)
+
+// BindFrameModel owns this client's semantic configuration. HTTPClient and
+// Warningf remain runtime handles, not cloned transports or closure state.
+// Configure the source before use; this is not synchronization for concurrent
+// writes to the source's exported fields.
+func (c *Client) BindFrameModel(ctx context.Context) (llm.ChatModel, bool, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, false, err
+	}
+	if c == nil {
+		// A nil embedded client may promote this method on an otherwise valid
+		// outer model. There is no client configuration to bind in that case.
+		return nil, false, nil
+	}
+	bound := *c
+	bound.Temperature = copyBindingValue(c.Temperature)
+	bound.TopP = copyBindingValue(c.TopP)
+	bound.Seed = copyBindingValue(c.Seed)
+	bound.ThinkingBudgetTokens = copyBindingValue(c.ThinkingBudgetTokens)
+	if c.Beta != nil {
+		bound.Beta = append([]string{}, c.Beta...)
+	}
+	if c.RetryableStatusCodes != nil {
+		bound.RetryableStatusCodes = make(map[int]struct{}, len(c.RetryableStatusCodes))
+		for code := range c.RetryableStatusCodes {
+			bound.RetryableStatusCodes[code] = struct{}{}
+		}
+	}
+	return &bound, true, nil
+}
+
+func copyBindingValue[T any](value *T) *T {
+	if value == nil {
+		return nil
+	}
+	copy := *value
+	return &copy
+}

--- a/sdk/llm/anthropic/model_binding_test.go
+++ b/sdk/llm/anthropic/model_binding_test.go
@@ -1,0 +1,93 @@
+package anthropic
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/timwhitez/agent-sdk-golang/sdk/llm"
+)
+
+func TestFrameBindingOwnsClientConfiguration(t *testing.T) {
+	temperature, topP, seed, budget := 0.2, 0.7, 7, 1500
+	client := &Client{ModelName: "old", APIKey: "fixture", Temperature: &temperature, TopP: &topP, Seed: &seed, ThinkingBudgetTokens: &budget, Beta: []string{"old-beta"}, RetryableStatusCodes: map[int]struct{}{500: {}}}
+	model, known, err := llm.BindFrameModel(context.Background(), client)
+	if err != nil || !known {
+		t.Fatal(known, err)
+	}
+	bound := model.(*Client)
+	if !reflect.DeepEqual(client, bound) {
+		t.Fatal("binding changed configuration values")
+	}
+	client.ModelName, client.APIKey = "new", "new-fixture"
+	temperature, topP, seed, budget = 0.8, 0.9, 8, 3000
+	client.Beta[0] = "new-beta"
+	delete(client.RetryableStatusCodes, 500)
+	if bound.ModelName != "old" || bound.APIKey != "fixture" || *bound.Temperature != 0.2 || *bound.TopP != 0.7 || *bound.Seed != 7 || *bound.ThinkingBudgetTokens != 1500 || bound.Beta[0] != "old-beta" || len(bound.RetryableStatusCodes) != 1 {
+		t.Fatal("binding retained mutable source configuration")
+	}
+	for _, empty := range []bool{false, true} {
+		c := &Client{}
+		if empty {
+			c.Beta = []string{}
+			c.RetryableStatusCodes = map[int]struct{}{}
+		}
+		m, _, err := c.BindFrameModel(context.Background())
+		if err != nil || !reflect.DeepEqual(c, m) {
+			t.Fatal("nil/empty changed", err)
+		}
+	}
+}
+
+func TestFrameBindingPreservesBufferedAndStreamWire(t *testing.T) {
+	for _, stream := range []bool{false, true} {
+		var requests, headers []string
+		httpClient := &http.Client{Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+			body, _ := io.ReadAll(r.Body)
+			requests = append(requests, string(body))
+			headers = append(headers, r.Header.Get("anthropic-beta"))
+			return httpResponse(401, `{"error":{"message":"fixture"}}`, r), nil
+		})}
+		temperature := 0.2
+		client := &Client{HTTPClient: httpClient, BaseURL: "https://fixture.invalid", ModelName: "old", Temperature: &temperature, Beta: []string{"old-beta"}, MaxRetries: 1}
+		invoke := func(model llm.ChatModel) {
+			request := llm.InvokeRequest{Messages: []llm.Message{llm.NewUserMessage("fixture")}}
+			if stream {
+				ch, err := model.(llm.StreamingChatModel).InvokeStream(context.Background(), request)
+				if err == nil {
+					for range ch {
+					}
+				}
+			} else {
+				_, _ = model.Invoke(context.Background(), request)
+			}
+		}
+		invoke(client)
+		bound, known, err := llm.BindFrameModel(context.Background(), client)
+		if err != nil || !known {
+			t.Fatal(err)
+		}
+		client.ModelName, client.Beta[0], temperature = "new", "new-beta", 0.9
+		invoke(bound)
+		if len(requests) != 2 || requests[0] != requests[1] || headers[0] != headers[1] || !strings.Contains(requests[1], `"model":"old"`) || !strings.Contains(requests[1], `"temperature":0.2`) {
+			t.Fatal("bound wire changed with source", requests, headers)
+		}
+		if bound.(*Client).HTTPClient != httpClient {
+			t.Fatal("transport handle unexpectedly copied")
+		}
+	}
+}
+
+func BenchmarkFrameModelBinding(b *testing.B) {
+	temperature := 0.2
+	client := &Client{ModelName: "fixture", Temperature: &temperature, Beta: []string{"a", "b"}, RetryableStatusCodes: map[int]struct{}{500: {}, 502: {}}}
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		if _, known, err := llm.BindFrameModel(context.Background(), client); err != nil || !known {
+			b.Fatal(known, err)
+		}
+	}
+}

--- a/sdk/llm/model_binding.go
+++ b/sdk/llm/model_binding.go
@@ -1,0 +1,72 @@
+package llm
+
+import (
+	"context"
+	"errors"
+	"reflect"
+)
+
+// FrameModelBinder optionally captures a callable model configuration for one
+// logical frame, including its SDK retries. A successful binding must preserve
+// invocation/streaming behavior and own mutable semantic configuration and
+// capability inputs. Transport and diagnostic handles may remain shared; this
+// is not a claim about a remote endpoint or mutable state inside those handles.
+//
+// Implementations must be bounded, respect context, and not invoke the model or
+// mutate host state. Return bound=false when the complete configured chain
+// cannot provide this guarantee; the driver then retains legacy dispatch.
+type FrameModelBinder interface {
+	BindFrameModel(context.Context) (model ChatModel, bound bool, err error)
+}
+
+// BindFrameModel calls the explicit capability once, without inspecting model
+// names or unwrapping arbitrary models. The bool distinguishes known binding
+// from legacy/unknown. Callers must not concurrently mutate input configuration.
+// A different concrete wrapper type is treated as unknown: an embedded client's
+// promoted method must not accidentally strip the outer wrapper's behavior.
+func BindFrameModel(ctx context.Context, model ChatModel) (ChatModel, bool, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, false, err
+	}
+	if nilFrameModel(model) {
+		return nil, false, errors.New("nil frame model")
+	}
+	binder, ok := model.(FrameModelBinder)
+	if !ok {
+		return model, false, nil
+	}
+	bound, known, err := binder.BindFrameModel(ctx)
+	if canceled := ctx.Err(); canceled != nil {
+		return nil, false, canceled
+	}
+	if err != nil {
+		return nil, false, err
+	}
+	if !known {
+		return model, false, nil
+	}
+	if nilFrameModel(bound) {
+		return nil, false, errors.New("nil frame model binding")
+	}
+	_, before := model.(StreamingChatModel)
+	_, after := bound.(StreamingChatModel)
+	if before != after {
+		return nil, false, errors.New("frame binding changed streaming support")
+	}
+	if reflect.TypeOf(model) != reflect.TypeOf(bound) {
+		return model, false, nil
+	}
+	return bound, true, nil
+}
+
+func nilFrameModel(model ChatModel) bool {
+	v := reflect.ValueOf(model)
+	if !v.IsValid() {
+		return true
+	}
+	switch v.Kind() {
+	case reflect.Pointer, reflect.Map, reflect.Slice, reflect.Func, reflect.Chan, reflect.Interface:
+		return v.IsNil()
+	}
+	return false
+}

--- a/sdk/llm/model_binding_test.go
+++ b/sdk/llm/model_binding_test.go
@@ -40,6 +40,11 @@ func TestBindFrameModelCapabilityAndFailureBoundaries(t *testing.T) {
 	}
 	target := &bindingModel{}
 	var nilTarget *bindingModel
+	for _, missing := range []ChatModel{nil, nilTarget} {
+		if _, _, err := BindFrameModel(context.Background(), missing); err == nil {
+			t.Fatal("nil source model accepted")
+		}
+	}
 	sentinel := errors.New("private binding failure")
 	for _, tc := range []struct {
 		name    string

--- a/sdk/llm/model_binding_test.go
+++ b/sdk/llm/model_binding_test.go
@@ -1,0 +1,94 @@
+package llm
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+type bindingModel struct {
+	bind func(context.Context) (ChatModel, bool, error)
+}
+
+func (*bindingModel) Provider() string { panic("binding must not inspect names") }
+func (*bindingModel) Model() string    { panic("binding must not inspect names") }
+func (*bindingModel) Invoke(context.Context, InvokeRequest) (*Completion, error) {
+	panic("binding must not invoke")
+}
+func (m *bindingModel) BindFrameModel(ctx context.Context) (ChatModel, bool, error) {
+	return m.bind(ctx)
+}
+
+type bindingStreamModel struct{ *bindingModel }
+
+func (*bindingStreamModel) InvokeStream(context.Context, InvokeRequest) (<-chan StreamEvent, error) {
+	panic("must not stream")
+}
+
+type unboundModel struct{}
+
+func (unboundModel) Provider() string { panic("must not inspect") }
+func (unboundModel) Model() string    { panic("must not inspect") }
+func (unboundModel) Invoke(context.Context, InvokeRequest) (*Completion, error) {
+	panic("must not invoke")
+}
+
+func TestBindFrameModelCapabilityAndFailureBoundaries(t *testing.T) {
+	legacy := unboundModel{}
+	if model, known, err := BindFrameModel(context.Background(), legacy); err != nil || known || model != legacy {
+		t.Fatal(model, known, err)
+	}
+	target := &bindingModel{}
+	var nilTarget *bindingModel
+	sentinel := errors.New("private binding failure")
+	for _, tc := range []struct {
+		name    string
+		model   ChatModel
+		known   bool
+		err     error
+		wantErr bool
+	}{
+		{"bound", target, true, nil, false},
+		{"unknown_ignores_candidate", target, false, nil, false},
+		{"error_even_if_unknown", target, false, sentinel, true},
+		{"nil", nil, true, nil, true},
+		{"typed_nil", nilTarget, true, nil, true},
+		{"stream_upgrade", &bindingStreamModel{target}, true, nil, true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			calls := 0
+			source := &bindingModel{bind: func(context.Context) (ChatModel, bool, error) { calls++; return tc.model, tc.known, tc.err }}
+			got, known, err := BindFrameModel(context.Background(), source)
+			if calls != 1 || (err != nil) != tc.wantErr {
+				t.Fatal(calls, known, err)
+			}
+			if err != nil {
+				if got != nil || known {
+					t.Fatal("partial binding returned")
+				}
+				return
+			}
+			want := ChatModel(source)
+			if tc.known {
+				want = target
+			}
+			if got != want || known != tc.known {
+				t.Fatal("unknown/success ownership changed")
+			}
+		})
+	}
+	source := &bindingStreamModel{&bindingModel{bind: func(context.Context) (ChatModel, bool, error) { return target, true, nil }}}
+	if _, _, err := BindFrameModel(context.Background(), source); err == nil {
+		t.Fatal("stream downgrade accepted")
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	source.bindingModel.bind = func(context.Context) (ChatModel, bool, error) { cancel(); return nil, true, sentinel }
+	if _, _, err := BindFrameModel(ctx, source); !errors.Is(err, context.Canceled) {
+		t.Fatal("cancellation lost precedence", err)
+	}
+	source.bindingModel.bind = func(context.Context) (ChatModel, bool, error) {
+		t.Error("canceled entry called binder")
+		return nil, false, nil
+	}
+	_, _, _ = BindFrameModel(ctx, source)
+}


### PR DESCRIPTION
## Scope

Related to #83; full lineage, other leaf clients, Goode adoption and whole-Run publication remain open.

Add optional FrameModelBinder and a shared binding helper, used once at actual query Frame materialization after request/resolver validation. SDK retries use the returned model; false/unsupported results retain the original handle as unknown. Binding does not count as InvokeAttempt. Failures reuse pending-continuation cleanup and fixed SDK-origin diagnostics, with cancellation taking precedence. Terminal provider/invalid-block metadata uses the actual frame model.

First supported leaf: Anthropic Client owns its scalar configuration, four parameter pointers, Beta and retry-code map. Nil/empty shape is preserved. HTTPClient and Warningf are shared runtime handles, not frozen transport/closure state; callers must not mutate input config concurrently. OpenAI clients and current Goode wrappers are still unsupported.

Successful bindings preserve streaming support. A changed outer concrete type becomes unknown, preventing a promoted embedded-client binder from stripping an outer wrapper's policy. This is a structural retention check, not reflective unwrapping or name-based inference; implementations remain responsible for their declared configuration contract.

## Evidence

- Real Agent → Anthropic HTTP fixture: source model/temperature/Beta change after first send; same-frame SDK retry remains byte-identical old configuration, next Frame sees new configuration. Other fixtures cover buffered/stream wire, ownership/nil/empty, unsupported [old,new] legacy, known [old,old,new], embedded-policy retention, typed nils/stream shape, cancellation, source-negative binding errors and unaccepted continuation cleanup.
- Final8ed2d5d77ce9dba86473d88a1c76d6b9e4235f24 author full/vet/build/Agent+Compaction+LLM race and focusedrace20 pass; earlier f3 focused100 passes. Two independent final APPROVE verdicts: SDK f3 full/vet/build/race/focused100 plus six mutations, finaldelta package/vet/build/race20; Goode f3 full/vet/five-package race/actual SDKbuild and wrapper/old-new/warning/cancel probesrace10, finaldelta failure-boundary race10/strictactualSDKbuild. Finaldelta removes unused state and improves fixed binding-error hint, not binding/dispatch algorithms. All mutations restored.
- Binding-only benchmark (three samples, one temperature pointer/two beta strings/two retry codes): median1723ns,392B,5alloc. Excludes Frame/request cloning, serialization, network and model time; no end-to-end performance or remote/cache acceptance claim.

## Non-goals

No new event sequence, Manifest, content hash, session format, production concurrency, cache policy rewrite or transport deep-copy. No forced full snapshot of unknown plugins, and no claim that the whole Goode Run is frozen. Goode #182/#124/#125 characterization is reused rather than repeated as a new foundation.
