### PR TITLE
feat(openai): bind owned frame configuration and static extras

### DIFF
--- a/agent_docs/providers.md
+++ b/agent_docs/providers.md
@@ -13,8 +13,13 @@ stream normalization, and response metadata behavior.
   promotion cannot strip a host wrapper. No reflection-based unwrapping occurs.
   Anthropic currently provides an owned copy of scalar/pointer/Beta/retry-map
   configuration. HTTPClient and Warningf remain runtime handles; configure input
-  before binding, never mutate it concurrently. OpenAI clients and current Goode
-  wrappers have not adopted this contract. Compaction/whole-Run publication and
+  before binding, never mutate it concurrently. OpenAI Chat/Responses also bind
+  their configuration, including nested Extra/ExtraBody through the existing
+  clone walker. The strict binding variant rejects custom JSON/text marshalers
+  (except copied RawMessage), hidden mutable state and excessive traversal;
+  failure does not return a partial binding or emit source contents. Goode's
+  Switchable/Retry/Debug chain adopts the contract when its leaf supports it.
+  Compaction/whole-Run publication and
   full host identity remain separate work; no new Manifest or content hash.
 - `InvokeRequest.CachePlan` is experimental in-memory intent, owned by
   `CloneInvokeRequest` and the private execution frame, and excluded from JSON.

--- a/sdk/llm/clone.go
+++ b/sdk/llm/clone.go
@@ -1,6 +1,8 @@
 package llm
 
 import (
+	"encoding"
+	"encoding/json"
 	"fmt"
 	"reflect"
 )
@@ -85,10 +87,29 @@ func cloneBool(value *bool) *bool {
 }
 
 func cloneJSONMap(value map[string]any) (map[string]any, error) {
+	return cloneJSONMapMode(value, false)
+}
+
+// CloneStaticJSONMap owns nested configuration without executing custom JSON
+// or text marshalers. Such methods can observe hidden/global state, so a copy
+// alone cannot establish a stable configuration. Existing request cloning keeps
+// its compatibility behavior; this stricter variant is for model bindings.
+// RawMessage is copied as bytes. Traversal is limited to 100000 visited values
+// and 128 nesting levels, with container size checked before allocation.
+func CloneStaticJSONMap(value map[string]any) (map[string]any, error) {
+	return cloneJSONMapMode(value, true)
+}
+
+func cloneJSONMapMode(value map[string]any, static bool) (map[string]any, error) {
 	if value == nil {
 		return nil, nil
 	}
-	cloned, err := cloneJSONValue(reflect.ValueOf(value), 0)
+	var budget *int
+	if static {
+		remaining := 100000
+		budget = &remaining
+	}
+	cloned, err := cloneJSONValueMode(reflect.ValueOf(value), 0, budget)
 	if err != nil {
 		return nil, err
 	}
@@ -99,19 +120,44 @@ func cloneJSONMap(value map[string]any) (map[string]any, error) {
 	return out, nil
 }
 
-func cloneJSONValue(value reflect.Value, depth int) (reflect.Value, error) {
+func cloneJSONValueMode(value reflect.Value, depth int, budget *int) (reflect.Value, error) {
 	if !value.IsValid() {
 		return value, nil
 	}
 	if depth > 128 {
 		return reflect.Value{}, fmt.Errorf("JSON value nesting exceeds 128 levels")
 	}
+	if budget != nil {
+		*budget--
+		if *budget < 0 {
+			return reflect.Value{}, fmt.Errorf("static JSON configuration exceeds node budget")
+		}
+		// RawMessage has deterministic byte serialization; other custom methods
+		// may read external state even when their receiver contains only scalars.
+		rawType := reflect.TypeOf(json.RawMessage(nil))
+		typ := value.Type()
+		if typ != rawType && typ != reflect.PointerTo(rawType) {
+			jsonType := reflect.TypeOf((*json.Marshaler)(nil)).Elem()
+			textType := reflect.TypeOf((*encoding.TextMarshaler)(nil)).Elem()
+			if typ.Implements(jsonType) || typ.Implements(textType) || reflect.PointerTo(typ).Implements(jsonType) || reflect.PointerTo(typ).Implements(textType) {
+				return reflect.Value{}, fmt.Errorf("custom serialization cannot be statically bound")
+			}
+		}
+		// Reject large containers before allocating their copy, not only while
+		// descending into their elements.
+		switch value.Kind() {
+		case reflect.Map, reflect.Slice, reflect.Array:
+			if value.Len() > *budget {
+				return reflect.Value{}, fmt.Errorf("static JSON configuration exceeds node budget")
+			}
+		}
+	}
 	switch value.Kind() {
 	case reflect.Interface:
 		if value.IsNil() {
 			return reflect.Zero(value.Type()), nil
 		}
-		item, err := cloneJSONValue(value.Elem(), depth+1)
+		item, err := cloneJSONValueMode(value.Elem(), depth+1, budget)
 		if err != nil {
 			return reflect.Value{}, err
 		}
@@ -122,7 +168,7 @@ func cloneJSONValue(value reflect.Value, depth int) (reflect.Value, error) {
 		if value.IsNil() {
 			return reflect.Zero(value.Type()), nil
 		}
-		item, err := cloneJSONValue(value.Elem(), depth+1)
+		item, err := cloneJSONValueMode(value.Elem(), depth+1, budget)
 		if err != nil {
 			return reflect.Value{}, err
 		}
@@ -136,11 +182,11 @@ func cloneJSONValue(value reflect.Value, depth int) (reflect.Value, error) {
 		out := reflect.MakeMapWithSize(value.Type(), value.Len())
 		iter := value.MapRange()
 		for iter.Next() {
-			key, err := cloneJSONValue(iter.Key(), depth+1)
+			key, err := cloneJSONValueMode(iter.Key(), depth+1, budget)
 			if err != nil {
 				return reflect.Value{}, err
 			}
-			item, err := cloneJSONValue(iter.Value(), depth+1)
+			item, err := cloneJSONValueMode(iter.Value(), depth+1, budget)
 			if err != nil {
 				return reflect.Value{}, err
 			}
@@ -153,7 +199,7 @@ func cloneJSONValue(value reflect.Value, depth int) (reflect.Value, error) {
 		}
 		out := reflect.MakeSlice(value.Type(), value.Len(), value.Len())
 		for i := 0; i < value.Len(); i++ {
-			item, err := cloneJSONValue(value.Index(i), depth+1)
+			item, err := cloneJSONValueMode(value.Index(i), depth+1, budget)
 			if err != nil {
 				return reflect.Value{}, err
 			}
@@ -163,7 +209,7 @@ func cloneJSONValue(value reflect.Value, depth int) (reflect.Value, error) {
 	case reflect.Array:
 		out := reflect.New(value.Type()).Elem()
 		for i := 0; i < value.Len(); i++ {
-			item, err := cloneJSONValue(value.Index(i), depth+1)
+			item, err := cloneJSONValueMode(value.Index(i), depth+1, budget)
 			if err != nil {
 				return reflect.Value{}, err
 			}
@@ -181,7 +227,7 @@ func cloneJSONValue(value reflect.Value, depth int) (reflect.Value, error) {
 				}
 				continue
 			}
-			item, err := cloneJSONValue(value.Field(i), depth+1)
+			item, err := cloneJSONValueMode(value.Field(i), depth+1, budget)
 			if err != nil {
 				return reflect.Value{}, err
 			}

--- a/sdk/llm/clone_static_test.go
+++ b/sdk/llm/clone_static_test.go
@@ -1,0 +1,63 @@
+package llm
+
+import (
+	"encoding/json"
+	"reflect"
+	"testing"
+)
+
+type dynamicJSON int
+
+func (dynamicJSON) MarshalJSON() ([]byte, error) { panic("must not execute serializer during binding") }
+
+type dynamicPointer struct{ Value int }
+
+func (*dynamicPointer) MarshalJSON() ([]byte, error) { panic("must not execute pointer serializer") }
+
+type dynamicKey string
+
+func (dynamicKey) MarshalText() ([]byte, error) { panic("must not execute map key serializer") }
+
+type privateMutable struct{ values []int }
+
+func TestCloneStaticJSONMapOwnsValuesWithoutRoundtrip(t *testing.T) {
+	value := int64(9007199254740993)
+	raw := json.RawMessage(`{"safe":true}`)
+	source := map[string]any{"integer": value, "pointer": &value, "raw": raw, "slice": []map[string]int{{"x": 1}}, "empty": []string{}, "nil": []string(nil), "number": json.Number("9007199254740993")}
+	owned, err := CloneStaticJSONMap(source)
+	if err != nil || !reflect.DeepEqual(source, owned) {
+		t.Fatal("value/type changed", err)
+	}
+	value = 1
+	raw[0] = '['
+	source["slice"].([]map[string]int)[0]["x"] = 9
+	if *owned["pointer"].(*int64) != 9007199254740993 || owned["raw"].(json.RawMessage)[0] != '{' || owned["slice"].([]map[string]int)[0]["x"] != 1 {
+		t.Fatal("clone aliases mutable input")
+	}
+	for _, source := range []map[string]any{nil, {}} {
+		owned, err := CloneStaticJSONMap(source)
+		if err != nil || !reflect.DeepEqual(source, owned) {
+			t.Fatal("nil/empty shape changed")
+		}
+	}
+}
+
+func TestCloneStaticJSONMapRejectsDynamicAndUnboundedGraphs(t *testing.T) {
+	cycle := map[string]any{}
+	cycle["self"] = cycle
+	branch := map[string]any{"leaf": 1}
+	for i := 0; i < 20; i++ {
+		branch = map[string]any{"a": branch, "b": branch}
+	}
+	for _, value := range []any{dynamicJSON(1), dynamicPointer{Value: 1}, &dynamicPointer{Value: 1}, map[dynamicKey]int{"x": 1}, privateMutable{values: []int{1}}, make(chan int), func() {}, cycle, branch, make([]int, 100001)} {
+		if owned, err := CloneStaticJSONMap(map[string]any{"fixture": value}); err == nil || owned != nil {
+			t.Fatalf("unsafe configuration accepted: %T", value)
+		}
+	}
+	// Existing request cloning retains its old type-preserving behavior. The
+	// stricter binding policy must not silently rewrite that public contract.
+	legacy := map[string]any{"value": dynamicJSON(1), "pointer": dynamicPointer{Value: 2}}
+	if cloned, err := cloneJSONMap(legacy); err != nil || !reflect.DeepEqual(cloned, legacy) {
+		t.Fatal("legacy cloning policy changed", err)
+	}
+}

--- a/sdk/llm/openai/model_binding.go
+++ b/sdk/llm/openai/model_binding.go
@@ -1,0 +1,85 @@
+package openai
+
+import (
+	"context"
+	"errors"
+
+	"github.com/timwhitez/agent-sdk-golang/sdk/llm"
+)
+
+// BindFrameModel captures owned client configuration, not HTTP transport or
+// diagnostic closure state. Configure the input before binding, never during it.
+func (c *ChatClient) BindFrameModel(ctx context.Context) (llm.ChatModel, bool, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, false, err
+	}
+	if c == nil {
+		return nil, false, nil
+	}
+	bound := *c
+	var err error
+	bound.Extra, bound.ExtraBody, err = bindExtraMaps(c.Extra, c.ExtraBody)
+	if err != nil {
+		return nil, false, err
+	}
+	bound.Temperature = bindingValue(c.Temperature)
+	bound.TopP = bindingValue(c.TopP)
+	bound.Seed = bindingValue(c.Seed)
+	bound.MaxCompletionTokens = bindingValue(c.MaxCompletionTokens)
+	bound.RetryableStatusCodes = bindingCodes(c.RetryableStatusCodes)
+	return &bound, true, nil
+}
+
+// BindFrameModel preserves compatibility flags and provider label while owning
+// mutable parameters and extras. Custom marshalers cannot provide static intent.
+func (c *ResponsesClient) BindFrameModel(ctx context.Context) (llm.ChatModel, bool, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, false, err
+	}
+	if c == nil {
+		return nil, false, nil
+	}
+	bound := *c
+	var err error
+	bound.Extra, bound.ExtraBody, err = bindExtraMaps(c.Extra, c.ExtraBody)
+	if err != nil {
+		return nil, false, err
+	}
+	bound.Temperature = bindingValue(c.Temperature)
+	bound.TopP = bindingValue(c.TopP)
+	bound.Seed = bindingValue(c.Seed)
+	bound.MaxOutputTokens = bindingValue(c.MaxOutputTokens)
+	bound.RetryableStatusCodes = bindingCodes(c.RetryableStatusCodes)
+	return &bound, true, nil
+}
+
+func bindExtraMaps(extra, body map[string]any) (map[string]any, map[string]any, error) {
+	owned, err := llm.CloneStaticJSONMap(extra)
+	if err != nil {
+		return nil, nil, errors.New("OpenAI frame configuration extras cannot be bound")
+	}
+	ownedBody, err := llm.CloneStaticJSONMap(body)
+	if err != nil {
+		return nil, nil, errors.New("OpenAI frame configuration extras cannot be bound")
+	}
+	return owned, ownedBody, nil
+}
+
+func bindingValue[T any](value *T) *T {
+	if value == nil {
+		return nil
+	}
+	copy := *value
+	return &copy
+}
+
+func bindingCodes(codes map[int]struct{}) map[int]struct{} {
+	if codes == nil {
+		return nil
+	}
+	copy := make(map[int]struct{}, len(codes))
+	for code := range codes {
+		copy[code] = struct{}{}
+	}
+	return copy
+}

--- a/sdk/llm/openai/model_binding_test.go
+++ b/sdk/llm/openai/model_binding_test.go
@@ -1,0 +1,193 @@
+package openai
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/timwhitez/agent-sdk-golang/sdk/llm"
+)
+
+type bindingWireTransport func(*http.Request) (*http.Response, error)
+
+func (f bindingWireTransport) RoundTrip(r *http.Request) (*http.Response, error) { return f(r) }
+
+type bindingDynamicValue int
+
+func (bindingDynamicValue) MarshalJSON() ([]byte, error) { panic("untrusted marshaler executed") }
+
+func TestOpenAIFrameBindingOwnsConfigurationAndWire(t *testing.T) {
+	for _, responses := range []bool{false, true} {
+		for _, stream := range []bool{false, true} {
+			name := "chat"
+			if responses {
+				name = "responses"
+			}
+			if stream {
+				name += "/stream"
+			}
+			t.Run(name, func(t *testing.T) {
+				temperature, topP, seed, maxTokens := 0.2, 0.7, 13, 123
+				extra := map[string]any{"fixture": map[string]any{"list": []string{"old"}, "large": int64(9007199254740993)}}
+				body := map[string]any{"nested": map[string]any{"old": true}, "raw": json.RawMessage(`{"x":1}`)}
+				codes := map[int]struct{}{500: {}}
+				var payloads, endpoints, keys []string
+				httpClient := &http.Client{Transport: bindingWireTransport(func(r *http.Request) (*http.Response, error) {
+					data, _ := io.ReadAll(r.Body)
+					payloads = append(payloads, string(data))
+					endpoints = append(endpoints, r.URL.String())
+					keys = append(keys, r.Header.Get("Authorization"))
+					return &http.Response{StatusCode: 401, Header: make(http.Header), Body: io.NopCloser(strings.NewReader(`{"error":{"message":"fixture"}}`)), Request: r}, nil
+				})}
+				chat := &ChatClient{HTTPClient: httpClient, BaseURL: "https://fixture.invalid", APIKey: "fixture-key", ProviderLabel: "fixture-label", ModelName: "old", Extra: extra, ExtraBody: body, Temperature: &temperature, TopP: &topP, Seed: &seed, MaxCompletionTokens: &maxTokens, RetryableStatusCodes: codes, MaxRetries: 1, UseLegacyMaxTokens: true, ParallelToolCalls: true, ServiceTier: "auto", ReasoningEffort: "low"}
+				response := &ResponsesClient{HTTPClient: httpClient, BaseURL: "https://fixture.invalid", APIKey: "fixture-key", ProviderLabel: "fixture-label", ModelName: "old", Extra: extra, ExtraBody: body, Temperature: &temperature, TopP: &topP, Seed: &seed, MaxOutputTokens: &maxTokens, RetryableStatusCodes: codes, MaxRetries: 1, ForceStringInput: true, ServiceTier: "auto", ReasoningEffort: "low"}
+				var source llm.ChatModel = chat
+				if responses {
+					source = response
+				}
+				invoke := func(model llm.ChatModel) {
+					request := llm.InvokeRequest{Messages: []llm.Message{llm.NewUserMessage("fixture")}}
+					if stream {
+						ch, err := model.(llm.StreamingChatModel).InvokeStream(context.Background(), request)
+						if err == nil {
+							for range ch {
+							}
+						}
+					} else {
+						_, _ = model.Invoke(context.Background(), request)
+					}
+				}
+				invoke(source)
+				bound, known, err := llm.BindFrameModel(context.Background(), source)
+				if err != nil || !known || !reflect.DeepEqual(source, bound) {
+					t.Fatal("binding values changed", known, err)
+				}
+				temperature, topP, seed, maxTokens = 0.8, 0.9, 99, 999
+				extra["fixture"].(map[string]any)["list"].([]string)[0] = "new"
+				body["nested"].(map[string]any)["old"] = false
+				body["raw"].(json.RawMessage)[5] = '2'
+				delete(codes, 500)
+				chat.ModelName, response.ModelName = "new", "new"
+				chat.APIKey, response.APIKey = "new-key", "new-key"
+				chat.BaseURL, response.BaseURL = "https://new.invalid", "https://new.invalid"
+				invoke(bound)
+				if len(payloads) != 2 || payloads[0] != payloads[1] || endpoints[0] != endpoints[1] || keys[0] != keys[1] {
+					t.Fatal("bound wire changed after source mutation")
+				}
+				if !strings.Contains(payloads[1], `9007199254740993`) || bound.Model() != "old" || bound.Provider() != "fixture-label" {
+					t.Fatal("configuration identity/precision changed")
+				}
+				if responses {
+					c := bound.(*ResponsesClient)
+					if c.HTTPClient != httpClient || len(c.RetryableStatusCodes) != 1 || *c.MaxOutputTokens != 123 {
+						t.Fatal("response configuration alias")
+					}
+				} else {
+					c := bound.(*ChatClient)
+					if c.HTTPClient != httpClient || len(c.RetryableStatusCodes) != 1 || *c.MaxCompletionTokens != 123 {
+						t.Fatal("chat configuration alias")
+					}
+				}
+			})
+		}
+	}
+}
+
+func TestOpenAIFrameBindingNilEmptyAndFailure(t *testing.T) {
+	for _, empty := range []bool{false, true} {
+		var extra map[string]any
+		var codes map[int]struct{}
+		if empty {
+			extra = map[string]any{}
+			codes = map[int]struct{}{}
+		}
+		for _, model := range []llm.ChatModel{&ChatClient{Extra: extra, ExtraBody: extra, RetryableStatusCodes: codes}, &ResponsesClient{Extra: extra, ExtraBody: extra, RetryableStatusCodes: codes}} {
+			bound, known, err := llm.BindFrameModel(context.Background(), model)
+			if err != nil || !known || !reflect.DeepEqual(model, bound) {
+				t.Fatal("nil/empty changed", known, err)
+			}
+		}
+	}
+	for _, value := range []any{make(chan int), bindingDynamicValue(1)} {
+		for _, inBody := range []bool{false, true} {
+			extra := map[string]any{"PRIVATE_SECRET_KEY": value}
+			chat, responses := &ChatClient{}, &ResponsesClient{}
+			if inBody {
+				chat.ExtraBody, responses.ExtraBody = extra, extra
+			} else {
+				chat.Extra, responses.Extra = extra, extra
+			}
+			for _, model := range []llm.ChatModel{chat, responses} {
+				bound, known, err := llm.BindFrameModel(context.Background(), model)
+				if err == nil || known || bound != nil || strings.Contains(err.Error(), "PRIVATE") {
+					t.Fatal("unsafe extras not rejected privately", known, err)
+				}
+			}
+		}
+	}
+}
+
+func TestOpenAIFrameBindingKeepsCompatibilityDowngrade(t *testing.T) {
+	for _, responses := range []bool{false, true} {
+		for _, stream := range []bool{false, true} {
+			t.Run(fmt.Sprintf("responses=%v/stream=%v", responses, stream), func(t *testing.T) {
+				var payloads, warnings []string
+				httpClient := &http.Client{Transport: bindingWireTransport(func(r *http.Request) (*http.Response, error) {
+					data, _ := io.ReadAll(r.Body)
+					payloads = append(payloads, string(data))
+					status, body := 401, "fixture final rejection"
+					if len(payloads)%2 == 1 {
+						status, body = 400, "unknown field reasoning_effort extra_body; unsupported thinking; MissingParameter input.content"
+					}
+					return &http.Response{StatusCode: status, Header: make(http.Header), Body: io.NopCloser(strings.NewReader(body)), Request: r}, nil
+				})}
+				var source llm.ChatModel = &ChatClient{HTTPClient: httpClient, BaseURL: "https://fixture.invalid", ModelName: "fixture", MaxRetries: 2, ReasoningEffort: "low", Extra: map[string]any{"thinking": true}, ExtraBody: map[string]any{"enable_thinking": true}}
+				if responses {
+					source = &ResponsesClient{HTTPClient: httpClient, BaseURL: "https://fixture.invalid", ModelName: "fixture", MaxRetries: 2, ReasoningEffort: "low", Extra: map[string]any{"thinking": true}, ExtraBody: map[string]any{"enable_thinking": true}}
+				}
+				ctx := llm.WithWarningSink(context.Background(), func(f string, args ...any) { warnings = append(warnings, fmt.Sprintf(f, args...)) })
+				invoke := func(model llm.ChatModel) {
+					request := llm.InvokeRequest{Messages: []llm.Message{{Role: llm.RoleUser, Content: llm.Content{Blocks: []llm.ContentBlock{{Type: "text", Text: "fixture"}}}}}}
+					if stream {
+						ch, err := model.(llm.StreamingChatModel).InvokeStream(ctx, request)
+						if err == nil {
+							for range ch {
+							}
+						}
+					} else {
+						_, _ = model.Invoke(ctx, request)
+					}
+				}
+				invoke(source)
+				originalWarnings := append([]string(nil), warnings...)
+				warnings = nil
+				bound, known, err := llm.BindFrameModel(ctx, source)
+				if err != nil || !known {
+					t.Fatal(known, err)
+				}
+				invoke(bound)
+				if len(payloads) != 4 || payloads[0] == payloads[1] || payloads[0] != payloads[2] || payloads[1] != payloads[3] || !reflect.DeepEqual(warnings, originalWarnings) {
+					t.Fatal("binding changed compatibility retry wire/diagnostics")
+				}
+				if !reflect.DeepEqual(source, bound) {
+					t.Fatal("downgrade mutated bound configuration")
+				}
+			})
+		}
+	}
+}
+
+func BenchmarkOpenAIFrameBinding(b *testing.B) {
+	client := &ChatClient{ModelName: "fixture", Extra: map[string]any{"nested": map[string]any{"enabled": true, "values": []string{"a", "b"}}}}
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		if _, known, err := llm.BindFrameModel(context.Background(), client); err != nil || !known {
+			b.Fatal(known, err)
+		}
+	}
+}


### PR DESCRIPTION
## Scope

Related to #83. Extend the existing FrameModelBinder to OpenAI Chat and Responses; retain the existing invocation/serializer/compatibility downgrade paths. Own all four option pointers, nested Extra/ExtraBody and retry-code maps. HTTPClient and Warningf remain runtime handles, not copied transports or closure state; configure sources before binding.

Expose CloneStaticJSONMap through the existing clone walker, leaving ordinary request cloning unchanged. Static mode preserves types, large integer precision, nil/empty and copied RawMessage bytes. It rejects custom JSON/text serialization (value, pointer and map-key method sets), hidden mutable state, unsupported values, depth beyond128 and traversal beyond100000 nodes, checking container sizes before allocation. Binding failure returns a fixed content-free error and no partial model. No JSON roundtrip or second serializer.

## Evidence

Final51fd0742a0bec163f88b379e579956768c25c8c3 author full/vet/build/Agent+Compaction+LLM race/focused100 pass. Independent SDK Review APPROVE: full/vet/build/relatedrace/focusedrace20 pass, five mutations (dynamic serialization, node bound, pointer/map ownership, compatibility flag) detected and restored. Both clients × buffered/stream real wire/source-mutation and400→401 compatibility trajectories preserve values and warning behavior. Paired Goode #218 adds actual wrapper-chain coverage rather than retaining obsolete unknown-client expectations; paired final review/gates pending.

Binding-only benchmark (three samples, Chat configuration with one nested map and two strings): median2002ns/1080B/16alloc. Excludes Agent Frame construction, serialization, HTTP/model time; not an end-to-end speedup claim. Node/depth limits are not byte budgets or a promise to accept all JSON-serializable Go types.

Goode #218 exact6f3d2d1 has been independently approved with full/vet/eight-package race/bindingrace100/strict actual SDK51fd074 build; root-author paired gates also pass. It updates former OpenAI-unknown fixtures while retaining unknown plugin coverage and adding real buffered/stream wrapper-chain HTTP evidence. SDK #138 is merged first, then this companion; no pin-only update.

No Prompt wording, Provider payload schema, cache policy, session format, production concurrency, new event sequence, whole-Run freeze or remote/cache-hit claim. Custom dynamic serialization now explicitly rejects at binding rather than falsely claiming immutable intent.
