### PR TITLE
fix(tools): never replay handlers based on execution errors

### DIFF
--- a/agent_docs/tools-and-sandbox.md
+++ b/agent_docs/tools-and-sandbox.md
@@ -4,6 +4,15 @@ This document explains the tool subsystem and how it interacts with the agent lo
 provider-facing schemas, metadata propagation, and sandbox safety gates.
 
 ## Tool Core Model
+
+`Tool.Execute` invokes an arbitrary Handler at most once. Error strings do not
+prove that an effect did not happen and never authorize automatic replay.
+`Func` and the sandbox typed adapter use `DecodeTypedToolArgs`: valid inputs
+are unchanged; plain unknown-field decode failures may receive schema repair
+and a fresh decode before business execution. Custom JSON/Text decoders are
+never reentered; their own adapter is responsible for aliases. Business handlers
+are never retried, and the original execution error/result is preserved.
+
 - `Tool` is the runtime unit: name, description, schema, handler, visibility (`Hidden`), and retention (`EphemeralKeep`) (`sdk/tools/tool.go:15`)
 - `Definition()` converts internal tools to strict provider tool definitions (`sdk/tools/tool.go:31`)
 - `Execute()` is the single execution path used by the agent (`sdk/tools/tool.go:40`)
@@ -22,9 +31,9 @@ provider-facing schemas, metadata propagation, and sandbox safety gates.
    - Loose-object repair is now schema-aware: repaired payloads are accepted only when their shape/types remain compatible with the tool schema.
    - References: `sdk/tools/args_normalize.go:64`, `sdk/tools/tool.go:398`
 
-3. **Strict decode and second-chance schema repair**
-   - `Tool.Execute` retries when decode fails due to unknown/misaligned keys.
-   - Schema-key repair now recurses through nested objects, strips unknown fields on retry, and applies tool-specific alias mappings for ambiguous keys (for example `line` -> `offset` only for read-style tools).
+3. **Typed decoding and schema repair before execution**
+   - `DecodeTypedToolArgs` can repair unknown keys after a plain strict decode fails, before the business handler runs. `Tool.Execute` never retries a Handler; custom JSON/Text decoders are never reentered.
+   - Schema-key repair recurses through nested objects, strips unknown fields, and applies existing tool-specific alias mappings (for example `line` -> `offset` only for read-style tools).
    - References: `sdk/tools/tool.go:58`, `sdk/tools/tool.go:67`, `sdk/tools/tool.go:96`, `sdk/tools/tool.go:105`, `sdk/tools/tool.go:363`
 
 4. **Empty-output fallback**

--- a/sdk/agent/tool_handler_once_test.go
+++ b/sdk/agent/tool_handler_once_test.go
@@ -1,0 +1,60 @@
+package agent
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"github.com/timwhitez/agent-sdk-golang/sdk/llm"
+	"github.com/timwhitez/agent-sdk-golang/sdk/tools"
+)
+
+type onceEffectModel struct{ calls int }
+
+func (*onceEffectModel) Provider() string { return "fixture" }
+func (*onceEffectModel) Model() string    { return "fixture" }
+func (m *onceEffectModel) Invoke(context.Context, llm.InvokeRequest) (*llm.Completion, error) {
+	m.calls++
+	if m.calls == 1 {
+		return &llm.Completion{ToolCalls: []llm.ToolCall{{ID: "effect", Function: llm.FunctionCall{Name: "effect", Arguments: `{"value":"ok","extra":true}`}}}}, nil
+	}
+	return &llm.Completion{Content: llm.TextContent("done")}, nil
+}
+func TestHandlerUnknownFieldErrorClosesOnceAfterEffect(t *testing.T) {
+	effects := 0
+	tool := tools.Tool{Name: "effect", Schema: map[string]any{"type": "object", "additionalProperties": false, "properties": map[string]any{"value": map[string]any{"type": "string"}}}, Handler: func(context.Context, json.RawMessage, *tools.Container) (llm.Content, error) {
+		effects++
+		return llm.TextContent("effect happened"), errors.New("remote unknown field")
+	}}
+	a, err := New(Config{LLM: &onceEffectModel{}, Tools: []tools.Tool{tool}, Warningf: func(string, ...any) {}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	results := 0
+	var states []toolCallState
+	a.toolBlockStateObserved = func(block *toolBlockState) { states = append(states, block.calls...) }
+	for ev := range a.QueryStream(context.Background(), llm.TextContent("run")) {
+		if result, ok := ev.(ToolResultEvent); ok {
+			results++
+			if !result.IsError {
+				t.Fatal("execution error lost")
+			}
+		}
+	}
+	historyResults := 0
+	for _, m := range a.Messages() {
+		if m.Role == llm.RoleTool {
+			historyResults++
+			if !m.IsError || m.Content.PlainText() != "effect happened" {
+				t.Fatal("history error lost")
+			}
+		}
+	}
+	if effects != 1 || results != 1 || historyResults != 1 {
+		t.Fatal("effect or closure duplicated", effects, results, historyResults)
+	}
+	if len(states) != 1 || states[0].executionKnowledge != toolExecutionOutcomeObserved || states[0].terminalCount != 1 {
+		t.Fatal("wrong execution knowledge", states)
+	}
+}

--- a/sdk/tools/args_normalize.go
+++ b/sdk/tools/args_normalize.go
@@ -33,8 +33,10 @@ func DecodeTypedToolArgs[Args any](ctx context.Context, name string, schema map[
 		return args, err
 	}
 	meta := ToolResultMetadataSnapshot(ctx)
-	if original, ok := ctx.Value(originalToolArgsKey{}).(string); ok {
-		meta = ensureArgsRaw(meta, original)
+	if ctx != nil {
+		if original, ok := ctx.Value(originalToolArgsKey{}).(string); ok {
+			meta = ensureArgsRaw(meta, original)
+		}
 	}
 	if repaired, repairedMeta, ok := repairToolArgsBySchema(name, schema, raw, meta); ok {
 		if repairedArgs, repairedErr := decode(repaired); repairedErr == nil {

--- a/sdk/tools/args_normalize.go
+++ b/sdk/tools/args_normalize.go
@@ -1,11 +1,78 @@
 package tools
 
 import (
+	"bytes"
+	"context"
+	"encoding"
 	"encoding/json"
 	"errors"
 	"io"
+	"reflect"
 	"strings"
 )
+
+// Original spelling is needed only if a later typed decode repairs arguments.
+// Keeping it in context avoids publishing args_raw metadata on untouched calls.
+type originalToolArgsKey struct{}
+
+// DecodeTypedToolArgs preserves an already valid input. After an unknown-field
+// decode error, plain argument types may receive one schema-key repair and fresh
+// decode before business execution. Types with custom JSON/Text decoders are
+// never decoded twice: their accepted keys and effects cannot be inferred from
+// the schema. This helper never invokes a business handler.
+func DecodeTypedToolArgs[Args any](ctx context.Context, name string, schema map[string]any, raw json.RawMessage) (Args, error) {
+	decode := func(raw json.RawMessage) (Args, error) {
+		var args Args
+		dec := json.NewDecoder(bytes.NewReader(raw))
+		dec.DisallowUnknownFields()
+		err := dec.Decode(&args)
+		return args, err
+	}
+	args, err := decode(raw)
+	if err == nil || !strings.Contains(err.Error(), "unknown field") || hasCustomArgumentDecoder(reflect.TypeOf((*Args)(nil)).Elem(), make(map[reflect.Type]bool)) {
+		return args, err
+	}
+	meta := ToolResultMetadataSnapshot(ctx)
+	if original, ok := ctx.Value(originalToolArgsKey{}).(string); ok {
+		meta = ensureArgsRaw(meta, original)
+	}
+	if repaired, repairedMeta, ok := repairToolArgsBySchema(name, schema, raw, meta); ok {
+		if repairedArgs, repairedErr := decode(repaired); repairedErr == nil {
+			UpsertToolResultMetadata(ctx, repairedMeta)
+			return repairedArgs, nil
+		}
+	}
+	return args, err
+}
+
+func hasCustomArgumentDecoder(typ reflect.Type, seen map[reflect.Type]bool) bool {
+	if seen[typ] {
+		return false
+	}
+	seen[typ] = true
+	decoder := reflect.TypeOf((*json.Unmarshaler)(nil)).Elem()
+	textDecoder := reflect.TypeOf((*encoding.TextUnmarshaler)(nil)).Elem()
+	if typ.Implements(decoder) || reflect.PointerTo(typ).Implements(decoder) || typ.Implements(textDecoder) || reflect.PointerTo(typ).Implements(textDecoder) {
+		return true
+	}
+	switch typ.Kind() {
+	case reflect.Pointer, reflect.Slice, reflect.Array:
+		return hasCustomArgumentDecoder(typ.Elem(), seen)
+	case reflect.Map:
+		return hasCustomArgumentDecoder(typ.Key(), seen) || hasCustomArgumentDecoder(typ.Elem(), seen)
+	case reflect.Struct:
+		for i := 0; i < typ.NumField(); i++ {
+			field := typ.Field(i)
+			if (field.PkgPath != "" && !field.Anonymous) || strings.Split(field.Tag.Get("json"), ",")[0] == "-" {
+				continue
+			}
+			if hasCustomArgumentDecoder(field.Type, seen) {
+				return true
+			}
+		}
+	}
+	return false
+}
 
 // ToolArgsNormalization captures normalized tool arguments and metadata.
 type ToolArgsNormalization struct {

--- a/sdk/tools/handler_once_test.go
+++ b/sdk/tools/handler_once_test.go
@@ -1,0 +1,156 @@
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/timwhitez/agent-sdk-golang/sdk/llm"
+)
+
+func TestHandlerEffectMustNotReplayOnUnknownField(t *testing.T) {
+	effects := 0
+	tool := Tool{Name: "custom", Schema: map[string]any{"type": "object", "properties": map[string]any{"value": map[string]any{"type": "string"}}, "additionalProperties": false}, Handler: func(_ context.Context, raw json.RawMessage, _ *Container) (llm.Content, error) {
+		effects++
+		var args map[string]any
+		_ = json.Unmarshal(raw, &args)
+		if _, unknown := args["extra"]; unknown {
+			return llm.TextContent("effect committed"), errors.New("downstream response: unknown field extra")
+		}
+		return llm.TextContent("second effect committed"), nil
+	}}
+	out, err := tool.Execute(context.Background(), `{"value":"ok","extra":true}`, NewContainer())
+	if effects != 1 {
+		t.Fatalf("handler side effects replayed: effects=%d error=%v output=%s", effects, err, out.PlainText())
+	}
+	if err == nil || out.PlainText() != "effect committed" {
+		t.Fatal("first execution outcome was replaced", err)
+	}
+}
+
+var decodeCalls int
+var decodedRaw string
+
+type flexibleNested struct {
+	Value string `json:"value"`
+}
+
+func (v *flexibleNested) UnmarshalJSON(raw []byte) error {
+	var input map[string]string
+	if err := json.Unmarshal(raw, &input); err != nil {
+		return err
+	}
+	v.Value = input["flattened_alias"]
+	return nil
+}
+func TestTypedNestedCustomDecoderPreservesWiderInput(t *testing.T) {
+	type args struct {
+		Nested flexibleNested `json:"nested"`
+	}
+	tool := Func[args]("fixture", "fixture", func(_ context.Context, a args, _ *Container) (any, error) { return a.Nested.Value, nil })
+	out, err := tool.Execute(context.Background(), `{"nested":{"flattened_alias":"preserved"}}`, NewContainer())
+	if err != nil || out.PlainText() != "preserved" {
+		t.Fatal("custom nested input stripped", out.PlainText(), err)
+	}
+}
+
+type textDecoded string
+
+func (v *textDecoded) UnmarshalText(raw []byte) error { *v = textDecoded(raw); return nil }
+
+type failingTextDecoded string
+
+func (*failingTextDecoded) UnmarshalText([]byte) error {
+	decodeCalls++
+	return errors.New("text decoder effect then unknown field")
+}
+func TestTypedTextDecoderErrorIsNotRetried(t *testing.T) {
+	type args struct {
+		Value failingTextDecoded `json:"value"`
+	}
+	decodeCalls = 0
+	business := 0
+	tool := Func[args]("fixture", "fixture", func(context.Context, args, *Container) (any, error) { business++; return "wrong", nil })
+	_, err := tool.Execute(context.Background(), `{"value":"ok","extra":true}`, NewContainer())
+	if decodeCalls != 1 || business != 0 || err == nil || err.Error() != "text decoder effect then unknown field" {
+		t.Fatal("text decoder repeated", decodeCalls, business, err)
+	}
+}
+func TestTypedPreparationSkipsCustomDecoderGraphs(t *testing.T) {
+	type recursive struct {
+		Next   *recursive
+		Custom map[textDecoded][]flexibleNested
+	}
+	raw := json.RawMessage(`{ "unknown" : "retain" }`)
+	schema := map[string]any{"type": "object", "properties": map[string]any{"value": map[string]any{"type": "string"}}}
+	if !hasCustomArgumentDecoder(reflect.TypeOf(recursive{}), make(map[reflect.Type]bool)) {
+		t.Fatal("nested decoder graph not detected")
+	}
+	if got, err := DecodeTypedToolArgs[map[textDecoded]string](context.Background(), "fixture", schema, raw); err != nil || got["unknown"] != "retain" {
+		t.Fatal("text decoder graph normalized", got, err)
+	}
+}
+
+func TestTypedValidCaseInsensitiveArgsAvoidRepair(t *testing.T) {
+	type args struct {
+		Value string `json:"value"`
+	}
+	ctx := WithToolResultMetadata(context.Background())
+	tool := Func[args]("fixture", "fixture", func(_ context.Context, a args, _ *Container) (any, error) { return a.Value, nil })
+	out, err := tool.Execute(ctx, `{ "VALUE" : "ok" }`, NewContainer())
+	if err != nil || out.PlainText() != "ok" || argsRepaired(ToolResultMetadataSnapshot(ctx)) {
+		t.Fatal("valid arguments changed", err, ToolResultMetadataSnapshot(ctx))
+	}
+}
+
+func TestTypedRepairPreservesOriginalSpellingMetadata(t *testing.T) {
+	type args struct {
+		Value string `json:"value"`
+	}
+	tool := Func[args]("fixture", "fixture", func(_ context.Context, a args, _ *Container) (any, error) { return a.Value, nil })
+	for _, raw := range []string{" \n {\"value\":\"ok\",\"extra\":true}\t ", " \n {\"value\":\"ok\"}\t "} {
+		ctx := WithToolResultMetadata(context.Background())
+		if _, err := tool.Execute(ctx, raw, NewContainer()); err != nil {
+			t.Fatal(err)
+		}
+		meta := ToolResultMetadataSnapshot(ctx)
+		if strings.Contains(raw, "extra") {
+			if meta["args_raw"] != raw {
+				t.Fatal("original spelling lost", meta)
+			}
+		} else if _, ok := meta["args_raw"]; ok {
+			t.Fatal("untouched raw newly exposed", meta)
+		}
+	}
+}
+
+type onceDecodedArgs struct {
+	Value string `json:"value"`
+}
+
+func (a *onceDecodedArgs) UnmarshalJSON(raw []byte) error {
+	decodeCalls++
+	decodedRaw = string(raw)
+	return errors.New("decoder effect then unknown field")
+}
+
+func TestTypedDecoderRunsOnceBeforeBusiness(t *testing.T) {
+	for _, raw := range []string{`{ "value" : "ok" }`, `{"value":"ok","extra":true}`} {
+		decodeCalls, decodedRaw = 0, ""
+		business := 0
+		tool := Func[onceDecodedArgs]("custom", "fixture", func(context.Context, onceDecodedArgs, *Container) (any, error) { business++; return "wrong", nil })
+		_, err := tool.Execute(context.Background(), raw, NewContainer())
+		if decodeCalls != 1 || business != 0 || err == nil || err.Error() != "decoder effect then unknown field" {
+			t.Fatal("decoder replayed or lost error", decodeCalls, business, err)
+		}
+		if raw[1] == ' ' && decodedRaw != raw {
+			t.Fatal("valid raw bytes changed", decodedRaw)
+		}
+		if decodedRaw != raw {
+			t.Fatal("custom decoder input changed", decodedRaw)
+		}
+	}
+}

--- a/sdk/tools/handler_once_test.go
+++ b/sdk/tools/handler_once_test.go
@@ -127,6 +127,42 @@ func TestTypedRepairPreservesOriginalSpellingMetadata(t *testing.T) {
 	}
 }
 
+func TestNestedExecuteRepairOwnsItsOriginalArgs(t *testing.T) {
+	type args struct {
+		Value string `json:"value"`
+	}
+	child := Func[args]("child", "fixture", func(_ context.Context, a args, _ *Container) (any, error) { return a.Value, nil })
+	childRaw := `{"value":"child","extra":true}`
+	var childMeta map[string]any
+	parent := Tool{Name: "parent", Handler: func(ctx context.Context, _ json.RawMessage, deps *Container) (llm.Content, error) {
+		ctx = WithToolResultMetadata(ctx)
+		out, err := child.Execute(ctx, childRaw, deps)
+		childMeta = ToolResultMetadataSnapshot(ctx)
+		return out, err
+	}}
+	if _, err := parent.Execute(WithToolResultMetadata(context.Background()), `  {"parent":"private"}  `, NewContainer()); err != nil {
+		t.Fatal(err)
+	}
+	if childMeta["args_raw"] != childRaw {
+		t.Fatal("child inherited parent raw", childMeta)
+	}
+}
+
+func TestTypedDecodeNilContextDoesNotPanic(t *testing.T) {
+	type args struct {
+		Value string `json:"value"`
+	}
+	tool := Func[args]("fixture", "fixture", func(ctx context.Context, a args, _ *Container) (any, error) {
+		if ctx != nil {
+			t.Fatal("nil context changed")
+		}
+		return a.Value, nil
+	})
+	if out, err := tool.Execute(nil, `{"value":"ok","extra":true}`, NewContainer()); err != nil || out.PlainText() != "ok" {
+		t.Fatal(out, err)
+	}
+}
+
 type onceDecodedArgs struct {
 	Value string `json:"value"`
 }

--- a/sdk/tools/sandbox/sandbox_helpers.go
+++ b/sdk/tools/sandbox/sandbox_helpers.go
@@ -1,7 +1,6 @@
 package sandbox
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -315,10 +314,8 @@ func toolWithArgs[Args any](name, description string, fn func(ctx context.Contex
 		Description: description,
 		Schema:      schema,
 		Handler: func(ctx context.Context, raw json.RawMessage, deps *tools.Container) (llm.Content, error) {
-			var a Args
-			dec := json.NewDecoder(bytes.NewReader(raw))
-			dec.DisallowUnknownFields()
-			if err := dec.Decode(&a); err != nil {
+			a, err := tools.DecodeTypedToolArgs[Args](ctx, name, schema, raw)
+			if err != nil {
 				msg := formatErrorDiagnosticFromErr("tool arguments are invalid", err, "Fix tool arguments and retry.")
 				return llm.TextContent(msg), err
 			}

--- a/sdk/tools/tool.go
+++ b/sdk/tools/tool.go
@@ -1,7 +1,6 @@
 package tools
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -61,25 +60,15 @@ func (t Tool) Execute(ctx context.Context, argsJSON string, deps *Container) (ll
 		return llm.TextContent(formatToolErrorDiagnostic("Invalid tool arguments", parseErr, toolDiagnosticInvalidArgsAction)), parseErr
 	}
 
-	call := func(raw json.RawMessage, meta map[string]any) (llm.Content, error, map[string]any) {
-		content, err := t.Handler(ctx, raw, deps)
-		if err == nil {
-			return content, nil, meta
-		}
-		// Second-chance: some models/proxies emit slightly-wrong keys (e.g. "content content")
-		// that fail strict decoding. Try to normalize keys to the schema and retry.
-		if looksLikeUnknownFieldErr(err) {
-			meta = ensureArgsRaw(meta, argsJSON)
-			if repaired, meta2, ok := repairToolArgsBySchema(t.Name, t.Schema, raw, meta); ok {
-				if content2, err2 := t.Handler(ctx, repaired, deps); err2 == nil {
-					return content2, nil, meta2
-				}
-			}
-		}
-		return content, err, meta
+	if argsRepaired(norm.Meta) {
+		UpsertToolResultMetadata(ctx, norm.Meta)
 	}
-
-	content, err, meta := call(norm.Normalized, norm.Meta)
+	// A handler error cannot prove that no side effect happened. Never replay
+	// execution based on its error text; typed adapters prepare before decoding.
+	if argsJSON != string(norm.Normalized) {
+		ctx = context.WithValue(ctx, originalToolArgsKey{}, argsJSON)
+	}
+	content, err := t.Handler(ctx, norm.Normalized, deps)
 	if err != nil && content.IsEmpty() {
 		content = llm.TextContent(formatToolErrorDiagnostic("Tool execution failed", err, toolDiagnosticDefaultAction))
 	}
@@ -87,19 +76,7 @@ func (t Tool) Execute(ctx context.Context, argsJSON string, deps *Container) (ll
 		content = llm.TextContent("Warning: tool returned no output.")
 		UpsertToolResultMetadata(ctx, map[string]any{"tool_warning": "handler returned empty content"})
 	}
-	if argsRepaired(meta) {
-		UpsertToolResultMetadata(ctx, meta)
-	}
 	return content, err
-}
-
-func looksLikeUnknownFieldErr(err error) bool {
-	if err == nil {
-		return false
-	}
-	// json.Decoder with DisallowUnknownFields() returns errors like:
-	//   json: unknown field "foo"
-	return strings.Contains(err.Error(), "unknown field")
 }
 
 func formatToolErrorDiagnostic(summary string, err error, action string) string {
@@ -772,6 +749,8 @@ func jsonValueType(value any) string {
 
 // Func creates a tool from an Args struct and a handler.
 // Args should be a struct type with json tags.
+// Plain unknown-field decode errors may receive schema key repair before business
+// execution. Custom decoders and business handlers are never retried.
 func Func[Args any](name, description string, fn func(ctx context.Context, args Args, deps *Container) (any, error)) Tool {
 	schema := SchemaFor[Args]()
 	return Tool{
@@ -780,10 +759,8 @@ func Func[Args any](name, description string, fn func(ctx context.Context, args 
 		EphemeralKeep: 0,
 		Schema:        schema,
 		Handler: func(ctx context.Context, raw json.RawMessage, deps *Container) (llm.Content, error) {
-			var a Args
-			dec := json.NewDecoder(bytes.NewReader(raw))
-			dec.DisallowUnknownFields()
-			if err := dec.Decode(&a); err != nil {
+			a, err := DecodeTypedToolArgs[Args](ctx, name, schema, raw)
+			if err != nil {
 				return llm.TextContent(formatToolErrorDiagnostic("Invalid tool arguments", err, toolDiagnosticInvalidArgsAction)), err
 			}
 			res, err := fn(ctx, a, deps)

--- a/sdk/tools/tool.go
+++ b/sdk/tools/tool.go
@@ -65,7 +65,7 @@ func (t Tool) Execute(ctx context.Context, argsJSON string, deps *Container) (ll
 	}
 	// A handler error cannot prove that no side effect happened. Never replay
 	// execution based on its error text; typed adapters prepare before decoding.
-	if argsJSON != string(norm.Normalized) {
+	if ctx != nil {
 		ctx = context.WithValue(ctx, originalToolArgsKey{}, argsJSON)
 	}
 	content, err := t.Handler(ctx, norm.Normalized, deps)


### PR DESCRIPTION
## Scope

Related to #139 and #84/#85. Unknown-field-like error text never proves a Handler has not already caused effects: remove the shared Execute post-error Handler retry. Keep one invocation, first content/error, existing empty-result diagnostics and terminal closure. Issue #139 remains open until paired merged-main verification.

Reuse schema repair inside `DecodeTypedToolArgs`, before business execution: preserve a first successful strict decode; only plain types with no reachable custom JSON/Text decoder may receive a fresh schema-repaired decode after a builtin unknown-field decoding failure. Custom decoders run once and retain wider accepted input. This is not an error capability that permits reentering an arbitrary wrapper/Handler.

SDK Func/sandbox adapters use the helper. Valid case-insensitive input acquires no repair metadata. Existing repaired args_raw spelling is retained via invocation-local context; nested Execute shadows its own source and nil-context behavior remains compatible. Goode subtask typed adapter has a separate tested companion pending; Batch/custom flattened decoding must not be globally schema-cleaned.

## Verification

Final candidate `87ef6097f4d366df88ffe4abf40a66bb8fd99005` on SDK main `5fdd53b`. Author full/vet/build, tools/Agent/Compaction race and focused race100 passed (`/tmp/sdk139-final5-*.log`). Independent current-main direct Handler race20 reproduced effects=2 and masked error; real Agent baseline regression also failed effects=2 while closure remained1 (`/tmp/sdk139-agent-baseline-red.log`). Fixed tests require one effect, first content/error, one event/history terminal and truthful outcome_observed.

Coverage includes typed alias/repair metadata, already-valid uppercase keys, nested/wide/custom JSON/Text decoder input, recursive type graph, decoder error without business entry, whitespace raw provenance, nested invocation metadata ownership and nil context. Root review found and author fixed the initial nested metadata inheritance bug. Final independent exact-head Review APPROVE: full/vet/related race (with explicit cache hits), separate uncached tools/Agent/Compaction race, focused race20 and four successful mutations (outer retry, custom decode replay, nested raw inheritance, valid raw disclosure), restored clean. Root additionally passed focused race20/vet. Logs `/tmp/review-sdk139-final-*.log`, `/tmp/review-sdk139-restored-*.log`, `/tmp/sdk139-root-*.log`. Actual Goode companion PR225 full validation and independent Review remain merge prerequisites.

Goode companion PR225 exact `bdb679335bdddf137c2b525e8876fa6928f8f845` has now passed author and independent full/vet/six-package race/strict actual-SDK build, with independent exact-head APPROVE and effective batch/typed/partial-result regression checks. Merge order: this SDK PR, then Goode225; no SDK pin workflow.

This deliberately removes unsafe automatic replay for arbitrary/custom handlers; malformed input with custom decoders no longer gets external automatic repair. No Provider payload/Prompt/persistence protocol, scheduler/concurrency, Session/Artifact integrity, or new diagnostics payload change. No live-provider or performance claim.
